### PR TITLE
Add a VS settings file add R# like mappings to VS

### DIFF
--- a/vs/vs2015-resharper-style-settings.vssettings
+++ b/vs/vs2015-resharper-style-settings.vssettings
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<UserSettings>
+  <ApplicationIdentity version="14.0"/>
+  <ToolsOptions>
+    <ToolsOptionsCategory name="Environment" RegisteredName="Environment"/>
+    <ToolsOptionsCategory name="TextEditor" RegisteredName="TextEditor">
+      <ToolsOptionsSubCategory name="CSharp-Specific" RegisteredName="CSharp-Specific" PackageName="CSharpPackage">
+        <PropertyValue name="SortUsings_PlaceSystemFirst">1</PropertyValue>
+      </ToolsOptionsSubCategory>
+    </ToolsOptionsCategory>
+  </ToolsOptions>
+  <Category name="Environment_Group" RegisteredName="Environment_Group">
+    <Category name="Environment_KeyBindings" Category="{F09035F1-80D2-4312-8EC4-4D354A4BCB4C}" Package="{DA9FB551-C724-11d0-AE1F-00A0C90FFFC3}" RegisteredName="Environment_KeyBindings" PackageName="Visual Studio Environment Package">
+      <Version>14.0.0.0</Version>
+      <KeyboardShortcuts>
+        <ScopeDefinitions>
+          <Scope Name="Global" ID="{5EFC7975-14BC-11CF-9B2B-00AA00573819}"/>
+          <Scope Name="Text Editor" ID="{8B382828-6202-11D1-8870-0000F87579D2}"/>
+        </ScopeDefinitions>
+        <DefaultShortcuts>
+          <Shortcut Command="View.ViewCode" Scope="Global">F7</Shortcut>
+          <Shortcut Command="View.ViewDesigner" Scope="Global">Shift+F7</Shortcut>
+        </DefaultShortcuts>
+        <ShortcutsScheme/>
+        <UserShortcuts>
+          <RemoveShortcut Command="Edit.CharTranspose" Scope="Text Editor">Ctrl+T</RemoveShortcut>
+          <Shortcut Command="Edit.NavigateTo" Scope="Global">Ctrl+T</Shortcut>
+          <Shortcut Command="View.QuickActions" Scope="Text Editor">Alt+Enter</Shortcut>
+        </UserShortcuts>
+      </KeyboardShortcuts>
+    </Category>
+  </Category>
+</UserSettings>


### PR DESCRIPTION
Note that this is not a full set of my settings, just the ones I've
changed from the VS 2015 defaults. This includes:
1. `ALT` + `Enter` instead of `CTRL` + `.` for quick actions/smart tags.
2. `CTRL` + `T` instead of `CTRL` + `,` for Navigate TO.
3. Changed `Order Usings` to list `System.*` namespaces first before others.

Many thanks to @kuhlenh for her help with this.
