### PR TITLE
Refined aliases command's grep pattern

### DIFF
--- a/git/.gitconfig.aliases
+++ b/git/.gitconfig.aliases
@@ -6,13 +6,13 @@
 #    path = ~/.gitconfig.aliases
 #
 # If you don't have any existing includes, you can add this via the following command
-# 
+#
 #   git config --global include.path ~/.gitconfig.aliases
 #
 
 [alias]
     abort = rebase --abort
-    aliases = "!git config -l | grep alias | cut -c 7-"
+    aliases = "!git config -l | grep ^alias\\. | cut -c 7-"
     amend = commit -a --amend
     # Deletes all branches merged specified branch (or master if no branch is specified)
     bclean = "!f() { git branch --merged ${1-master} | grep -v " ${1-master}$" | xargs git branch -d; }; f"


### PR DESCRIPTION
As written, the 'aliases' alias includes settings that aren't necessarily aliases, like `include.path=~/.gitconfig.aliases`. This revision changes the pattern to only match settings that start with "alias.".