### PR TITLE
Add trailing semicolon, avoiding EOL error

### DIFF
--- a/git/gitconfig.aliases.symlink
+++ b/git/gitconfig.aliases.symlink
@@ -50,7 +50,7 @@
     migrate = "!f(){ CURRENT=$(git symbolic-ref --short HEAD); git checkout -b $1 && git branch --force $CURRENT ${3-$CURRENT@{u}} && git rebase --onto ${2-master} $CURRENT; }; f"
     open = "!f(){ URL=$(git config remote.origin.url); open ${URL%.git}; }; f"
     pr = "!f(){ URL=$(git config remote.origin.url); open ${URL%.git}/compare/$(git rev-parse --abbrev-ref HEAD); }; f"
-    publish = "!f() { git push origin $1 && git push drafts :$1 && git browse }; f"
+    publish = "!f() { git push origin $1 && git push drafts :$1 && git browse; }; f"
     rba = rebase --abort
     rbc = "!f(){ git add -A && git rebase --continue; }; f"
     re = "!f(){ git fetch origin && git rebase origin/${1-master}; }; f"


### PR DESCRIPTION
Omitting the trailing semicolon results in the following error (at least for me):
```
f() { git push origin $1 && git push drafts :$1 && git browse }; f: -c: line 1: syntax error: unexpected end of file
```
Adding a semicolon after `git browse` fixes this. I guess this is Mac/Linux compatible (in case Mac doesn't require this, which I dunno).

Cheers!