### PR TITLE
Add script to convert a repo to blobless

### DIFF
--- a/bin/convert-to-blobless.sh
+++ b/bin/convert-to-blobless.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+show_help() {
+    cat <<EOF
+Usage: $0 [--dry-run] <path-to-repo>
+
+Convert an existing git clone into a blobless clone by:
+  - Backing up the repo directory
+  - Re-cloning using --filter=blob:none
+  - Importing all local branches from the backup
+
+Options:
+  --dry-run   Show what actions would be taken, but do nothing.
+
+Example:
+  $0 ~/dev/posthog/posthog
+  $0 --dry-run ~/dev/posthog/posthog
+EOF
+}
+
+# --------------------------
+# Argument parsing
+# --------------------------
+DRY_RUN=false
+REPO_DIR=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --dry-run)
+            DRY_RUN=true
+            shift
+            ;;
+        -h|--help)
+            show_help
+            exit 0
+            ;;
+        *)
+            if [[ -z "$REPO_DIR" ]]; then
+                REPO_DIR="$1"
+            else
+                echo "ERROR: Unexpected argument: $1" >&2
+                echo >&2
+                show_help >&2
+                exit 1
+            fi
+            shift
+            ;;
+    esac
+done
+
+if [[ -z "$REPO_DIR" ]]; then
+    echo "ERROR: Missing required <path-to-repo> argument." >&2
+    echo >&2
+    show_help >&2
+    exit 1
+fi
+
+# Normalize to absolute path
+REPO_DIR="$(cd "$(dirname "$REPO_DIR")" && pwd)/$(basename "$REPO_DIR")"
+
+# Simple dry-run helper
+run() {
+    if $DRY_RUN; then
+        echo "[dry-run] $*"
+    else
+        eval "$@"
+    fi
+}
+
+echo "=== Converting repo at: ${REPO_DIR} ==="
+$DRY_RUN && echo "(dry-run mode enabled)"
+
+# Validate existence
+if [[ ! -d "$REPO_DIR/.git" ]]; then
+    echo "ERROR: '$REPO_DIR' is not a git repository." >&2
+    exit 1
+fi
+
+cd "$REPO_DIR"
+
+# Check working tree cleanliness
+if [[ -n "$(git status --porcelain)" ]]; then
+    echo "ERROR: Working tree is not clean. Commit/stash changes first." >&2
+    exit 1
+fi
+
+# Capture local branches
+echo "Collecting local branches..."
+mapfile -t LOCAL_BRANCHES < <(git for-each-ref refs/heads --format='%(refname:short)')
+
+echo "Found ${#LOCAL_BRANCHES[@]} local branches:"
+for b in "${LOCAL_BRANCHES[@]}"; do
+    echo "  - $b"
+done
+
+# Prepare backup path
+BACKUP_PARENT="$(dirname "$REPO_DIR")"
+BACKUP_NAME="$(basename "$REPO_DIR")-backup-$(date +%Y%m%d-%H%M%S)"
+BACKUP_DIR="$BACKUP_PARENT/$BACKUP_NAME"
+
+echo "Backup repo will be moved to: $BACKUP_DIR"
+
+# --------------------------
+# Main actions
+# --------------------------
+
+echo
+echo "=== Step 1: Move existing repo to backup ==="
+run mv "$REPO_DIR" "$BACKUP_DIR"
+
+echo
+echo "=== Step 2: Clone new blobless repo ==="
+run git clone --filter=blob:none https://github.com/PostHog/posthog.git "$REPO_DIR"
+
+echo
+echo "=== Step 3: Configure partial clone settings ==="
+run git -C "$REPO_DIR" config remote.origin.promisor true
+run git -C "$REPO_DIR" config remote.origin.partialclonefilter blob:none
+
+echo
+echo "=== Step 4: Add backup as remote 'old' ==="
+run git -C "$REPO_DIR" remote add old "$BACKUP_DIR"
+run git -C "$REPO_DIR" fetch old
+
+echo
+echo "=== Step 5: Recreate local branches ==="
+for b in "${LOCAL_BRANCHES[@]}"; do
+    echo "  - Recreating branch '$b'"
+
+    # Does it exist in backup?
+    if ! git -C "$REPO_DIR" show-ref --verify --quiet "refs/remotes/old/$b"; then
+        echo "    (skipping: not found in backup)"
+        continue
+    fi
+
+    run git -C "$REPO_DIR" branch "$b" "old/$b"
+done
+
+echo
+echo "=== Conversion complete ==="
+echo "New blobless clone: $REPO_DIR"
+echo "Backup saved at:    $BACKUP_DIR"
+
+if $DRY_RUN; then
+    echo
+    echo "Dry run complete — no changes were made."
+fi


### PR DESCRIPTION
This changes the clone from a normal one to one with `git clone --filter=blob:none https://github.com/{org}{repo}` by backing up your existing clone, recloning it, then copying your branches over. Your clone must be clean to work (no working changes).

This can save a lot of local disk space for repos with a lot of blobs that have changed over time.

Note that even with this filter, git still downloads blobs to the working directory when checking out a branch, etc. But it doesn't download all versions of the blob, only the latest needed to hydrate a working directory.