### PR TITLE
Add /note command for technical discovery notes

### DIFF
--- a/ai/agents/note-taker.md
+++ b/ai/agents/note-taker.md
@@ -31,10 +31,25 @@ Structure your documentation to capture:
 
 ### 3. **Documentation Creation**
 Create structured notes following this approach:
-- **File Location**: `~/dev/ai/notes/{org}/{repo}/{feature-or-area}.md`
-- **Naming Convention**: Use kebab-case (e.g., `cohort-uploads.md`, `oauth-flow.md`)
-- **Directory Structure**: Create as needed (e.g., `~/dev/ai/notes/posthog/posthog/cohorts/`)
-- **Update Strategy**: Enhance existing notes rather than creating duplicates
+
+**ALWAYS** use the helper script to find existing notes or get the path for new ones:
+
+```bash
+~/.dotfiles/ai/bin/note-find-or-create.sh {slug}
+```
+
+This returns tab-separated output:
+- `found\t/path/to/existing/note.md` - Note already exists
+- `new\t/path/to/new/note.md` - Note doesn't exist; use this path
+
+**Never construct paths manually.** The script handles:
+- Deriving org/repo from the current git repository
+- PostHog repos: `~/dev/haacked/notes/PostHog/repositories/{repo}/{slug}.md`
+- Other repos: `~/dev/ai/notes/{org}/{repo}/{slug}.md`
+- Validating the slug format (kebab-case required)
+
+**Naming Convention**: Use kebab-case (e.g., `cohort-uploads`, `oauth-flow`)
+**Update Strategy**: Enhance existing notes rather than creating duplicates
 
 ### 4. **Quality Validation**
 Ensure your documentation:
@@ -147,7 +162,11 @@ Focus on capturing the knowledge that was hard-won through exploration, debuggin
 
 ## Boundary: Note-Taker vs Support
 
-This agent creates **technical discovery notes** in `~/dev/ai/notes/{org}/{repo}/`. These are:
+This agent creates **technical discovery notes** using the `note-find-or-create.sh` script. Notes are stored at:
+- PostHog repos: `~/dev/haacked/notes/PostHog/repositories/{repo}/`
+- Other repos: `~/dev/ai/notes/{org}/{repo}/`
+
+These are:
 - Reusable technical knowledge for future development
 - System behavior documentation
 - Knowledge that persists indefinitely

--- a/ai/bin/note-find-or-create.sh
+++ b/ai/bin/note-find-or-create.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+# Find an existing note or return the path where it would be created.
+# Derives org/repo from the current git repository.
+#
+# Usage: note-find-or-create.sh <slug>
+# Example: note-find-or-create.sh cohort-uploads
+#
+# Output format (tab-separated):
+#   <status>\t<path>
+# Where status is:
+#   found    - Note exists at the returned path
+#   new      - Note doesn't exist; path is where it would be created
+
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+    echo "Usage: note-find-or-create.sh <slug>" >&2
+    echo "  slug: kebab-case name for the note (e.g., cohort-uploads, oauth-flow)" >&2
+    exit 1
+fi
+
+slug="$1"
+
+# Validate slug is kebab-case (lowercase letters, numbers, hyphens)
+if ! [[ "$slug" =~ ^[a-z0-9]+(-[a-z0-9]+)*$ ]]; then
+    echo "Error: slug must be kebab-case (e.g., cohort-uploads, oauth-flow)" >&2
+    exit 1
+fi
+
+# Get org/repo from git remote
+if ! git rev-parse --git-dir > /dev/null 2>&1; then
+    echo "Error: not in a git repository" >&2
+    exit 1
+fi
+
+remote_url=$(git remote get-url origin 2>/dev/null || echo "")
+if [[ -z "$remote_url" ]]; then
+    echo "Error: no origin remote found" >&2
+    exit 1
+fi
+
+# Parse org/repo from various git URL formats:
+# - git@github.com:org/repo.git
+# - https://github.com/org/repo.git
+# - https://github.com/org/repo
+if [[ "$remote_url" =~ github\.com[:/]([^/]+)/([^/.]+)(\.git)?$ ]]; then
+    org="${BASH_REMATCH[1]}"
+    repo="${BASH_REMATCH[2]}"
+else
+    echo "Error: could not parse org/repo from remote URL: $remote_url" >&2
+    exit 1
+fi
+
+# Use different notes location for PostHog repos
+org_lower=$(echo "$org" | tr '[:upper:]' '[:lower:]')
+if [[ "$org_lower" == "posthog" ]]; then
+    notes_base="$HOME/dev/haacked/notes/PostHog/repositories"
+    note_path="${notes_base}/${repo}/${slug}.md"
+else
+    notes_base="$HOME/dev/ai/notes"
+    note_path="${notes_base}/${org}/${repo}/${slug}.md"
+fi
+
+if [[ -f "$note_path" ]]; then
+    echo -e "found\t${note_path}"
+else
+    echo -e "new\t${note_path}"
+fi

--- a/ai/commands/note.md
+++ b/ai/commands/note.md
@@ -56,12 +56,12 @@ else
 fi
 ```
 
-**If creating a new note**, use this template:
+**If creating a new note**, use this template (insert today's date in YYYY-MM-DD format):
 
 ```markdown
 # {Title} Technical Discovery
 
-**Discovery Date**: {YYYY-MM-DD}
+**Discovery Date**: {today's date in YYYY-MM-DD format}
 **Context**: {Brief description of what problem led to this exploration}
 
 ## Summary
@@ -144,7 +144,7 @@ This command ensures:
 |-----------------|-------------------|
 | Technical discoveries for future dev | Customer tickets (Zendesk, GitHub) |
 | System behavior documentation | Weekly support log summaries |
-| Knowledge persisting indefinitely | Time-bounded support work |
+| Knowledge that persists indefinitely | Time-bounded support work |
 | Cross-cutting insights | Customer-specific investigation |
 
 If you discover something during support that should be permanent technical docs, use `/note` to capture it separately.

--- a/ai/commands/note.md
+++ b/ai/commands/note.md
@@ -1,0 +1,150 @@
+# Technical Discovery Note
+
+Capture complex technical discoveries into structured, reusable notes.
+
+## Arguments (parsed from user input)
+
+- **slug**: kebab-case name for the note (required)
+
+Example invocations:
+
+- `/note cohort-uploads`
+- `/note oauth-flow`
+- `/note feature-flags-evaluation`
+
+## Your Task
+
+### Step 1: Parse and Validate Arguments
+
+Extract from user input:
+
+- `slug` = kebab-case note name (e.g., `cohort-uploads`, `oauth-flow`)
+
+If missing, ask the user what to name the note. Suggest a slug based on recent conversation context.
+
+### Step 2: Find or Create Note Path (Deterministic)
+
+**ALWAYS** use the helper script to find existing notes or get the path for new ones:
+
+```bash
+~/.dotfiles/ai/bin/note-find-or-create.sh {slug}
+```
+
+This returns tab-separated output:
+
+- `found\t/path/to/existing/note.md` - Note already exists
+- `new\t/path/to/new/note.md` - Note doesn't exist; use this path
+
+**Never construct paths manually.** The script handles:
+
+- Deriving org/repo from the current git repository
+- Building the path `~/dev/ai/notes/{org}/{repo}/{slug}.md`
+- Validating the slug format
+
+### Step 3: Create or Update Note
+
+```bash
+result=$(~/.dotfiles/ai/bin/note-find-or-create.sh {slug})
+status=$(echo "$result" | cut -f1)
+note_path=$(echo "$result" | cut -f2)
+
+if [[ "$status" == "found" ]]; then
+    echo "Found existing note at: $note_path"
+else
+    echo "Creating new note at: $note_path"
+    mkdir -p "$(dirname "$note_path")"
+fi
+```
+
+**If creating a new note**, use this template:
+
+```markdown
+# {Title} Technical Discovery
+
+**Discovery Date**: {YYYY-MM-DD}
+**Context**: {Brief description of what problem led to this exploration}
+
+## Summary
+
+{2-3 sentence overview of what was discovered and why it matters}
+
+## Problem Context
+
+- **Original Issue**: {What you were trying to solve}
+- **Why This Was Complex**: {What made this non-obvious}
+
+## System Overview
+
+{High-level architecture and data flow}
+
+## Key Components
+
+### {Component Name}
+
+- **Location**: {File path}
+- **Responsibility**: {What this component does}
+- **Gotchas**: {Non-obvious behaviors}
+
+## Code Examples
+
+```{language}
+// Context: {When/why you'd use this}
+```
+
+## Common Pitfalls
+
+1. **{Issue}**: {Description}
+   - **Symptom**: {How this manifests}
+   - **Solution**: {How to handle}
+
+## Related Resources
+
+- {Links to files, PRs, issues, documentation}
+```
+
+**If updating an existing note**, read the current content and add new discoveries while preserving existing knowledge.
+
+### Step 4: Confirm and Gather Context
+
+Tell the user:
+
+1. Where the note is being stored (full path)
+2. Whether this is a new note or updating an existing one
+3. Ask them to describe what they discovered (if not already clear from conversation)
+
+Then create or update the note based on:
+
+- The current conversation context
+- Any code explored during this session
+- Debugging insights or system behaviors discovered
+
+## Quality Standards
+
+Your notes should:
+
+- **Eliminate re-discovery**: Provide enough detail that the same exploration isn't needed again
+- **Enable quick context**: Allow someone to understand the system in minutes, not hours
+- **Support implementation**: Include practical examples and configuration details
+- **Reference authority**: Link to specific files, commits, or PRs
+
+## Determinism Guarantees
+
+This command ensures:
+
+1. **Consistent location**: Script derives org/repo from git automatically
+   - PostHog repos: `~/dev/haacked/notes/PostHog/repositories/{repo}/{slug}.md`
+   - Other repos: `~/dev/ai/notes/{org}/{repo}/{slug}.md`
+2. **Consistent naming**: Kebab-case slugs enforced by script
+3. **No manual path construction**: Script handles all path building
+4. **Validation**: Script validates slug format and git context
+
+## Boundary: /note vs /support
+
+| Use `/note` for | Use `/support` for |
+|-----------------|-------------------|
+| Technical discoveries for future dev | Customer tickets (Zendesk, GitHub) |
+| System behavior documentation | Weekly support log summaries |
+| Knowledge persisting indefinitely | Time-bounded support work |
+| Cross-cutting insights | Customer-specific investigation |
+
+If you discover something during support that should be permanent technical docs, use `/note` to capture it separately.


### PR DESCRIPTION
Creates a user-invocable command to capture complex technical discoveries with deterministic path calculation. PostHog repos use ~/dev/haacked/notes/PostHog/repositories/{repo}/, others use ~/dev/ai/notes/{org}/{repo}/.