### PR TITLE
Bin tree me use switch

### DIFF
--- a/bin/README-tree-me.md
+++ b/bin/README-tree-me.md
@@ -20,14 +20,14 @@ source <(tree-me shellenv)
 
 This enables:
 
-- **Auto-CD**: Automatically changes to the worktree directory after `create`, `checkout`, or `pr` commands
+- **Auto-CD**: Automatically changes to the worktree directory after `create`, `switch`, or `pr` commands
 - **Tab Completion**: Tab complete commands and branch names
 
 ### Usage
 
 ```bash
 tree-me create feature-branch         # Create new branch (auto-cd enabled)
-tree-me co feature-branch             # Checkout existing branch (alias for checkout)
+tree-me sw feature-branch             # switch existing branch (alias for switch)
 tree-me pr 123                        # Checkout GitHub PR (auto-cd enabled)
 tree-me ls                            # List all worktrees (alias for list)
 tree-me rm feature-branch             # Remove worktree (tab completion for branches)
@@ -50,11 +50,11 @@ tree-me create feature-branch develop      # Creates from develop
 - **Automatically cds into the worktree** (when using `source <(tree-me shellenv)`)
 - Lets **git handle all validation and errors**
 
-### Checkout an existing branch
+### Switch to an existing branch
 
 ```bash
-tree-me checkout feature-branch     # Full command
-tree-me co feature-branch           # Shorter alias
+tree-me switch feature-branch     # Full command
+tree-me sw feature-branch           # Shorter alias
 ```
 
 Checks out an existing local or remote branch in a new worktree.
@@ -148,8 +148,8 @@ This tool is just a thin wrapper. Git does the real work:
 # Create a new feature branch
 tree-me create haacked/new-feature
 
-# Checkout existing branch
-tree-me co main
+# Switch to existing branch
+tree-me sw main
 
 # Branch from develop instead of main
 tree-me create haacked/fix-bug develop

--- a/bin/tree-me
+++ b/bin/tree-me
@@ -6,7 +6,7 @@
 #   source <(tree-me shellenv)
 #
 # This enables:
-# - Automatic cd to worktree after checkout/create/pr commands
+# - Automatic cd to worktree after switch/create/pr commands
 # - Tab completion for commands and branch names
 
 set -e
@@ -42,7 +42,7 @@ Git-like worktree management with organized directory structure.
 Automatically integrates with Graphite (gt) when available.
 
 Commands:
-  checkout, co <branch>         Checkout existing branch in new worktree
+  switch, sw <branch>           Switch to an existing branch in new worktree
   create <branch> [base]        Create new branch in worktree (default: main/master)
   pr <number|url>               Checkout GitHub PR in worktree (uses gh)
   list, ls                      List all worktrees
@@ -51,7 +51,7 @@ Commands:
   shellenv                      Output shell function for auto-cd (source this)
 
 Examples:
-  tree-me checkout feature-branch
+  tree-me switch feature-branch
   tree-me create my-feature
   tree-me create my-feature develop
   tree-me pr 123
@@ -129,7 +129,7 @@ if [ -n "$BASH_VERSION" ]; then
         COMPREPLY=()
         cur="${COMP_WORDS[COMP_CWORD]}"
         prev="${COMP_WORDS[COMP_CWORD-1]}"
-        commands="checkout co create pr list ls remove rm prune help shellenv"
+        commands="switch sw create pr list ls remove rm prune help shellenv"
 
         # Complete commands if first argument
         if [ $COMP_CWORD -eq 1 ]; then
@@ -137,9 +137,9 @@ if [ -n "$BASH_VERSION" ]; then
             return 0
         fi
 
-        # Complete branch names for checkout/remove/rm
+        # Complete branch names for switch/remove/rm
         case "$prev" in
-            checkout|co|remove|rm)
+            switch|sw|remove|rm)
                 local branches
                 branches=$(git worktree list 2>/dev/null | sed -n 's/.*\[\([^]]*\)\].*/\1/p' | tail -n +2)
                 COMPREPLY=( $(compgen -W "$branches" -- "$cur") )
@@ -155,8 +155,8 @@ if [ -n "$ZSH_VERSION" ]; then
     _tree_me_complete_zsh() {
         local -a commands branches
         commands=(
-            'checkout:Checkout existing branch in new worktree'
-            'co:Checkout existing branch in new worktree'
+            'switch:Switch to an existing branch in new worktree'
+            'sw:Switch to an existing branch in new worktree'
             'create:Create new branch in worktree'
             'pr:Checkout GitHub PR in worktree'
             'list:List all worktrees'
@@ -172,7 +172,7 @@ if [ -n "$ZSH_VERSION" ]; then
             _describe 'command' commands
         elif (( CURRENT == 3 )); then
             case "$words[2]" in
-                checkout|co|remove|rm)
+                switch|sw|remove|rm)
                     branches=(${(f)"$(git worktree list 2>/dev/null | sed -n 's/.*\[\([^]]*\)\].*/\1/p' | tail -n +1)"})
                     _describe 'branch' branches
                     ;;
@@ -184,8 +184,8 @@ fi
 EOF
         ;;
 
-    checkout|co)
-        branch="${1:?Branch name required. Usage: tree-me checkout <branch>}"
+    switch|sw)
+        branch="${1:?Branch name required. Usage: tree-me switch <branch>}"
         path="$WORKTREE_ROOT/$repo/$branch"
 
         # Check if worktree already exists

--- a/bin/tree-me
+++ b/bin/tree-me
@@ -139,7 +139,7 @@ if [ -n "$BASH_VERSION" ]; then
 
         # Complete branch names for switch/remove/rm
         case "$prev" in
-            switch|sw|remove|rm)
+            co|checkout|switch|sw|remove|rm)
                 local branches
                 branches=$(git worktree list 2>/dev/null | sed -n 's/.*\[\([^]]*\)\].*/\1/p' | tail -n +2)
                 COMPREPLY=( $(compgen -W "$branches" -- "$cur") )
@@ -172,7 +172,7 @@ if [ -n "$ZSH_VERSION" ]; then
             _describe 'command' commands
         elif (( CURRENT == 3 )); then
             case "$words[2]" in
-                switch|sw|remove|rm)
+                checkout|co|switch|sw|remove|rm)
                     branches=(${(f)"$(git worktree list 2>/dev/null | sed -n 's/.*\[\([^]]*\)\].*/\1/p' | tail -n +1)"})
                     _describe 'branch' branches
                     ;;
@@ -184,7 +184,7 @@ fi
 EOF
         ;;
 
-    switch|sw)
+    checkout|co|switch|sw)
         branch="${1:?Branch name required. Usage: tree-me switch <branch>}"
         path="$WORKTREE_ROOT/$repo/$branch"
 

--- a/bin/tree-me
+++ b/bin/tree-me
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Minimal git worktree helper - leverages git's native capabilities
 # Usage: tree-me <command> [options]
 #


### PR DESCRIPTION
I have switched to using `git switch` instead of `git checkout`. The `tree-me` checkout sub command seems to fit better with the `git switch` sub command. 

Also, I had to change the shebang to work on my machine (nixos which has a minimal `/bin`). My shebang should work on any *nix including macos.

No hard feeling if you prefer `checkout`. The strongest argument I have for switch is that it's what all the kids are doing these days. I teach git often and, in my opinion, it's so much easier to explain `switch` and `restore` over `checkout`.