### PR TITLE
Use HTML rich text for Slack-compatible standup notes

### DIFF
--- a/ai/skills/standup/scripts/copy-html-to-clipboard.swift
+++ b/ai/skills/standup/scripts/copy-html-to-clipboard.swift
@@ -1,0 +1,33 @@
+#!/usr/bin/env swift
+// Copies HTML content from stdin to clipboard as rich text.
+// Usage: echo "<b>Hello</b>" | swift copy-html-to-clipboard.swift
+// Or: swift copy-html-to-clipboard.swift < file.html
+
+import AppKit
+import Foundation
+
+// Read HTML from stdin
+let htmlContent = FileHandle.standardInput.readDataToEndOfFile()
+guard let htmlString = String(data: htmlContent, encoding: .utf8), !htmlString.isEmpty else {
+    fputs("Error: No HTML content provided on stdin\n", stderr)
+    exit(1)
+}
+
+// Create plain text version by stripping HTML tags (basic approach)
+var plainText = htmlString
+    .replacingOccurrences(of: "<br>", with: "\n")
+    .replacingOccurrences(of: "<br/>", with: "\n")
+    .replacingOccurrences(of: "<br />", with: "\n")
+    .replacingOccurrences(of: "</li>", with: "\n")
+    .replacingOccurrences(of: "<li>", with: "• ")
+    .replacingOccurrences(of: "</ul>", with: "\n")
+    .replacingOccurrences(of: "<[^>]+>", with: "", options: .regularExpression)
+    .replacingOccurrences(of: "\n\n\n+", with: "\n\n", options: .regularExpression)
+    .trimmingCharacters(in: .whitespacesAndNewlines)
+
+let pasteboard = NSPasteboard.general
+pasteboard.clearContents()
+pasteboard.setString(htmlString, forType: .html)
+pasteboard.setString(plainText, forType: .string)
+
+print("Copied to clipboard as rich text")


### PR DESCRIPTION
## Summary

- Slack's mrkdwn link syntax (`<URL|text>`) only works via API, not when pasting
- Updated standup skill to generate HTML with `<ul><li>` lists and `<a>` links
- Added Swift helper script to copy HTML to clipboard as rich text
- Links are clickable and lists render properly when pasted into Slack
- Plain text version still saved to file for archival

## Test plan

- [x] Verified HTML with lists pastes correctly into Slack
- [x] Verified links are clickable after pasting
- [x] Tested Swift helper script works from command line