### PR TITLE
Add --team flag and --draft mode to PR review scripts

### DIFF
--- a/bin/review-all-prs.sh
+++ b/bin/review-all-prs.sh
@@ -77,6 +77,10 @@ while [[ $# -gt 0 ]]; do
       shift
       ;;
     --team)
+      if [[ -z "${2:-}" || "${2:-}" == --* ]]; then
+        echo "--team requires a team name" >&2
+        exit 1
+      fi
       TEAMS+=("$2")
       shift 2
       ;;
@@ -160,7 +164,7 @@ for search_query in "${SEARCH_QUERIES[@]}"; do
     exit 1
   }
   ALL_RESULTS=$(echo "$ALL_RESULTS" "$RESULT" | jq -s '
-    .[0] + [.[1].data.search.edges[].node | select(. != null)]
+    .[0] + [.[1].data.search.edges[]?.node | select(. != null)]
   ')
 done
 

--- a/bin/review-all-prs.sh
+++ b/bin/review-all-prs.sh
@@ -11,6 +11,7 @@
 #   --org ORG       GitHub organization (default: PostHog)
 #   --limit N       Maximum number of PRs to return (default: 50)
 #   --json          Output raw JSON (default: formatted table)
+#   --team TEAM     Also find PRs requested from this team (repeatable)
 #   --include-reviewed  Include PRs you've already reviewed
 #   -h, --help      Show this help message
 #
@@ -34,6 +35,7 @@ ORG="PostHog"
 LIMIT=50
 JSON_OUTPUT=false
 INCLUDE_REVIEWED=false
+TEAMS=()
 
 usage() {
   cat <<EOF
@@ -45,6 +47,7 @@ Options:
   --org ORG           GitHub organization (default: PostHog)
   --limit N           Maximum number of PRs to return (default: 50)
   --json              Output raw JSON (default: formatted table)
+  --team TEAM         Also find PRs requested from this team (repeatable)
   --include-reviewed  Include PRs you've already reviewed
   -h, --help          Show this help message
 
@@ -53,6 +56,7 @@ Examples:
   $(basename "$0") --org myorg        # Find PRs in myorg
   $(basename "$0") --json             # Output as JSON for scripting
   $(basename "$0") --limit 10         # Limit to 10 PRs
+  $(basename "$0") --team my-team     # Include team review requests
 EOF
   exit 0
 }
@@ -71,6 +75,10 @@ while [[ $# -gt 0 ]]; do
     --json)
       JSON_OUTPUT=true
       shift
+      ;;
+    --team)
+      TEAMS+=("$2")
+      shift 2
       ;;
     --include-reviewed)
       INCLUDE_REVIEWED=true
@@ -127,27 +135,44 @@ query($searchQuery: String!, $limit: Int!) {
 }
 '
 
-SEARCH_QUERY="is:pr is:open review-requested:@me org:${ORG}"
-
-# Execute GraphQL query
-RESULT=$(gh api graphql \
-  -f query="$QUERY" \
-  -F searchQuery="$SEARCH_QUERY" \
-  -F limit="$LIMIT" \
-  2>&1) || {
-  echo "GraphQL query failed: $RESULT" >&2
-  exit 1
+# Run a search query and return the raw GraphQL result
+run_search() {
+  local search_query="$1"
+  gh api graphql \
+    -f query="$QUERY" \
+    -F searchQuery="$search_query" \
+    -F limit="$LIMIT" \
+    2>&1
 }
+
+# GitHub search combines multiple qualifiers with AND, so we need separate
+# queries for personal and team review requests and then merge the results.
+SEARCH_QUERIES=("is:pr is:open review-requested:@me org:${ORG}")
+for team in "${TEAMS[@]}"; do
+  SEARCH_QUERIES+=("is:pr is:open team-review-requested:${ORG}/${team} org:${ORG}")
+done
+
+# Execute all queries and merge results
+ALL_RESULTS="[]"
+for search_query in "${SEARCH_QUERIES[@]}"; do
+  RESULT=$(run_search "$search_query") || {
+    echo "GraphQL query failed: $RESULT" >&2
+    exit 1
+  }
+  ALL_RESULTS=$(echo "$ALL_RESULTS" "$RESULT" | jq -s '
+    .[0] + [.[1].data.search.edges[].node | select(. != null)]
+  ')
+done
+
+# Deduplicate by PR URL
+ALL_RESULTS=$(echo "$ALL_RESULTS" | jq 'unique_by(.url)')
 
 # Process results with jq
 # - Extract PR data
 # - Check if user has already reviewed
 # - Filter based on --include-reviewed flag
-PROCESSED=$(echo "$RESULT" | jq --arg user "$GITHUB_USER" --argjson include_reviewed "$INCLUDE_REVIEWED" '
-  .data.search.edges
-  | map(.node)
-  | map(select(. != null))
-  | map({
+PROCESSED=$(echo "$ALL_RESULTS" | jq --arg user "$GITHUB_USER" --argjson include_reviewed "$INCLUDE_REVIEWED" '
+  map({
       number: .number,
       title: .title,
       url: .url,

--- a/bin/run-pr-reviews.sh
+++ b/bin/run-pr-reviews.sh
@@ -110,6 +110,10 @@ while [[ $# -gt 0 ]]; do
       shift 2
       ;;
     --team)
+      if [[ -z "${2:-}" || "${2:-}" == --* ]]; then
+        log_error "--team requires a team name"
+        exit 1
+      fi
       TEAMS+=("$2")
       shift 2
       ;;

--- a/macos/LaunchAgents/com.haacked.review-all-prs.plist
+++ b/macos/LaunchAgents/com.haacked.review-all-prs.plist
@@ -25,7 +25,7 @@ log_dir="$HOME/.local/state/review-all-prs"
 mkdir -p "$log_dir"
 
 # Run the review script with logging
-exec "$HOME/.dotfiles/bin/run-pr-reviews.sh" --auto --max-prs 5 \
+exec "$HOME/.dotfiles/bin/run-pr-reviews.sh" --auto --max-prs 5 --team team-flags-platform \
     >> "$log_dir/launchd.log" 2>&1
 ]]></string>
     </array>


### PR DESCRIPTION
## Summary

- Add a repeatable `--team` flag to `review-all-prs.sh` and `run-pr-reviews.sh` to discover PRs where a GitHub team is requested as reviewer (e.g. `--team team-flags-platform`)
- Since GitHub search combines qualifiers with AND, each team runs a separate GraphQL query and results are merged and deduplicated
- Switch `/review-code` invocation to use `--draft` so overnight reviews don't count as submitted reviews
- Configure the LaunchAgent plist to include `--team team-flags-platform` by default

## Test plan

- [x] `bin/review-all-prs.sh --json --team team-flags-platform --limit 5` returns PRs from both personal and team review requests
- [ ] `bin/review-all-prs.sh --json --limit 5` still works without `--team` (backwards compatible)
- [ ] `bin/run-pr-reviews.sh --dry-run --auto --team team-flags-platform` shows team flag forwarded