### PR TITLE
Add Homebrew bin to review LaunchAgent PATH

### DIFF
--- a/macos/LaunchAgents/com.haacked.review-all-prs.plist
+++ b/macos/LaunchAgents/com.haacked.review-all-prs.plist
@@ -15,7 +15,7 @@
         <string>-lc</string>
         <string><![CDATA[
 # Ensure Claude CLI is on PATH
-export PATH="$HOME/.local/bin:$PATH"
+export PATH="$HOME/.local/bin:/opt/homebrew/bin:$PATH"
 
 # Set up Secretive SSH agent if available
 secretive_sock="$HOME/Library/Containers/com.maxgoedjen.Secretive.SecretAgent/Data/socket.ssh"


### PR DESCRIPTION
The LaunchAgent's minimal PATH was missing /opt/homebrew/bin, causing the `timeout` command (from coreutils) to not be found.