### PR TITLE
Add global gitignore for Claude Code worktrees

### DIFF
--- a/git/gitconfig.symlink
+++ b/git/gitconfig.symlink
@@ -50,6 +50,7 @@
 	
 [core]
 	editor = code --wait
+	excludesfile = ~/.gitignore.global
 	sshCommand = ssh -o IdentityAgent=/Users/haacked/Library/Containers/com.maxgoedjen.Secretive.SecretAgent/Data/socket.ssh
 [init]
 	defaultBranch = main

--- a/git/gitignore.global.symlink
+++ b/git/gitignore.global.symlink
@@ -1,0 +1,2 @@
+# Claude Code worktrees
+.claude/worktrees/


### PR DESCRIPTION
## Summary

- Add a global gitignore file (`git/gitignore.global.symlink`) that ignores `.claude/worktrees/` across all repositories
- Wire it up via `core.excludesfile` in `gitconfig.symlink`
- Uses the existing `.symlink` bootstrap convention, so `script/bootstrap` symlinks it to `~/.gitignore.global`

## Test plan

- [ ] Run `script/bootstrap` and verify `~/.gitignore.global` is symlinked
- [ ] Verify `git config --global core.excludesfile` returns `~/.gitignore.global`
- [ ] Confirm `.claude/worktrees/` is ignored in any repo