### PR TITLE
Add archive step to sprint planning skill

### DIFF
--- a/ai/skills/sprint-planning/SKILL.md
+++ b/ai/skills/sprint-planning/SKILL.md
@@ -45,6 +45,13 @@ Sprints are two weeks. Support hero shifts are one week. Each sprint has two sup
 
 Format as `MM/DD - MM/DD` in the output.
 
+## Arguments
+
+- `/sprint-planning archive` — Skip the full sprint planning workflow and jump directly to archiving old Done items from the project board. When this argument is present:
+  1. Run Step 1 (Detect Sprint Context) to get `sprint_start`
+  2. Jump directly to Step 12 (Archive Previous Sprint's Done Items)
+  3. Exit after archiving
+
 ## Your Task
 
 Follow these steps in order. Gather as much data automatically as possible before asking the user anything.
@@ -308,6 +315,30 @@ gh issue comment <current_number> --repo PostHog/posthog --body "$(cat <<'EOF'
 <the markdown>
 EOF
 )"
+```
+
+### Step 12: Archive Previous Sprint's Done Items
+
+After posting the comment (or if the user declines to post), offer to clean up the project board by archiving Done items from previous sprints.
+
+1. Run the helper script to find archivable items:
+
+```bash
+~/.claude/skills/sprint-planning/scripts/archive-done-items.sh <sprint_start>
+```
+
+2. If the result is an empty array, skip silently — no prompt needed.
+
+3. Otherwise, present the list and ask for confirmation:
+
+> I found {N} items in the Done column that were completed before this sprint ({sprint_start}). Would you like me to archive them to keep the board clean?
+>
+> {list of items with titles and closed dates}
+
+4. If the user confirms, archive each item:
+
+```bash
+gh project item-archive 170 --owner PostHog --id <item-id>
 ```
 
 ## Formatting Rules

--- a/ai/skills/sprint-planning/scripts/archive-done-items.sh
+++ b/ai/skills/sprint-planning/scripts/archive-done-items.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+# List project board items in the "Done" column that were closed or merged
+# before the current sprint started. These are candidates for archiving to
+# keep the board tidy between sprints.
+#
+# Usage: archive-done-items.sh <sprint_start_date>
+#
+# Arguments:
+#   sprint_start_date - Current sprint's start date (YYYY-MM-DD). Items
+#                       closed/merged before this date are included.
+#
+# Output: JSON array of qualifying items with fields:
+#   id, title, number, type, closed_date
+#
+# Returns an empty array [] if no items qualify.
+
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+  echo "Usage: $0 <sprint_start_date>" >&2
+  exit 1
+fi
+
+sprint_start="$1"
+
+if ! [[ "$sprint_start" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
+  echo "Error: sprint_start_date must be YYYY-MM-DD, got: $sprint_start" >&2
+  exit 1
+fi
+
+# Fetch all Done items from the project board as JSON.
+done_items=$(gh project item-list 170 \
+  --owner PostHog \
+  --format json \
+  --limit 200 \
+  | jq '[.items[] | select(.status == "Done")]')
+
+item_count=$(echo "$done_items" | jq 'length')
+
+if [[ "$item_count" -eq 0 ]]; then
+  echo "[]"
+  exit 0
+fi
+
+results="[]"
+
+for i in $(seq 0 $((item_count - 1))); do
+  item=$(echo "$done_items" | jq ".[$i]")
+
+  # Draft items have no content — skip them.
+  content_url=$(echo "$item" | jq -r '.content.url // empty')
+  if [[ -z "$content_url" ]]; then
+    continue
+  fi
+
+  item_id=$(echo "$item" | jq -r '.id')
+  title=$(echo "$item" | jq -r '.title')
+  content_type=$(echo "$item" | jq -r '.content.type')
+  content_number=$(echo "$item" | jq -r '.content.number')
+  repo=$(echo "$item" | jq -r '.content.repository')
+
+  # Determine the closed/merged date via the GitHub API.
+  closed_date=""
+  if [[ "$content_type" == "PullRequest" ]]; then
+    pr_data=$(gh api "repos/${repo}/pulls/${content_number}" --jq '{merged_at, closed_at}' 2>/dev/null) || pr_data=""
+    if [[ -n "$pr_data" ]]; then
+      closed_date=$(echo "$pr_data" | jq -r '.merged_at // .closed_at // empty')
+    fi
+  elif [[ "$content_type" == "Issue" ]]; then
+    closed_date=$(gh api "repos/${repo}/issues/${content_number}" --jq '.closed_at // empty' 2>/dev/null) || closed_date=""
+  fi
+
+  if [[ -z "$closed_date" ]]; then
+    continue
+  fi
+
+  # Compare only the date portion (YYYY-MM-DD) against the sprint start.
+  closed_day="${closed_date:0:10}"
+  if [[ "$closed_day" < "$sprint_start" ]]; then
+    results=$(echo "$results" | jq \
+      --arg id "$item_id" \
+      --arg title "$title" \
+      --arg number "$content_number" \
+      --arg type "$content_type" \
+      --arg closed_date "$closed_day" \
+      '. + [{"id": $id, "title": $title, "number": ($number | tonumber), "type": $type, "closed_date": $closed_date}]')
+  fi
+done
+
+echo "$results" | jq '.'

--- a/ai/skills/sprint-planning/scripts/archive-done-items.sh
+++ b/ai/skills/sprint-planning/scripts/archive-done-items.sh
@@ -42,7 +42,8 @@ if [[ "$item_count" -eq 0 ]]; then
   exit 0
 fi
 
-results="[]"
+results_file=$(mktemp)
+trap 'rm -f "$results_file"' EXIT
 
 for i in $(seq 0 $((item_count - 1))); do
   item=$(echo "$done_items" | jq ".[$i]")
@@ -53,11 +54,9 @@ for i in $(seq 0 $((item_count - 1))); do
     continue
   fi
 
-  item_id=$(echo "$item" | jq -r '.id')
-  title=$(echo "$item" | jq -r '.title')
-  content_type=$(echo "$item" | jq -r '.content.type')
-  content_number=$(echo "$item" | jq -r '.content.number')
-  repo=$(echo "$item" | jq -r '.content.repository')
+  IFS=$'\t' read -r item_id title content_type content_number repo < <(
+    echo "$item" | jq -r '[.id, .title, .content.type, .content.number, .content.repository] | @tsv'
+  )
 
   # Determine the closed/merged date via the GitHub API.
   closed_date=""
@@ -77,14 +76,18 @@ for i in $(seq 0 $((item_count - 1))); do
   # Compare only the date portion (YYYY-MM-DD) against the sprint start.
   closed_day="${closed_date:0:10}"
   if [[ "$closed_day" < "$sprint_start" ]]; then
-    results=$(echo "$results" | jq \
+    jq -n \
       --arg id "$item_id" \
       --arg title "$title" \
       --arg number "$content_number" \
       --arg type "$content_type" \
       --arg closed_date "$closed_day" \
-      '. + [{"id": $id, "title": $title, "number": ($number | tonumber), "type": $type, "closed_date": $closed_date}]')
+      '{"id": $id, "title": $title, "number": ($number | tonumber), "type": $type, "closed_date": $closed_date}' >> "$results_file"
   fi
 done
 
-echo "$results" | jq '.'
+if [[ -s "$results_file" ]]; then
+  jq -s '.' "$results_file"
+else
+  echo "[]"
+fi

--- a/ai/skills/sprint-planning/scripts/archive-done-items.sh
+++ b/ai/skills/sprint-planning/scripts/archive-done-items.sh
@@ -35,59 +35,65 @@ done_items=$(gh project item-list 170 \
   --limit 200 \
   | jq '[.items[] | select(.status == "Done")]')
 
-item_count=$(echo "$done_items" | jq 'length')
+# Extract non-draft items (those with a content URL) into a compact working set.
+work_items=$(echo "$done_items" | jq '[
+  .[] | select(.content.url != null and .content.url != "") |
+  {
+    id: .id,
+    title: .title,
+    type: .content.type,
+    number: (.content.number | tonumber),
+    repo: .content.repository
+  }
+]')
+
+item_count=$(echo "$work_items" | jq 'length')
 
 if [[ "$item_count" -eq 0 ]]; then
   echo "[]"
   exit 0
 fi
 
-results_file=$(mktemp)
-trap 'rm -f "$results_file"' EXIT
+# Build a single GraphQL query to fetch closed/merged dates for all items,
+# replacing N sequential REST API calls with one batched request.
+query=$(echo "$work_items" | jq -r '
+  [to_entries[] |
+    .key as $idx |
+    .value as $item |
+    ($item.repo | split("/")) as $parts |
+    "item_\($idx): repository(owner: \"\($parts[0])\", name: \"\($parts[1])\") { " +
+    if $item.type == "PullRequest" then
+      "pullRequest(number: \($item.number)) { mergedAt closedAt }"
+    else
+      "issue(number: \($item.number)) { closedAt }"
+    end + " }"
+  ] | "query { " + join(" ") + " }"
+')
 
-for i in $(seq 0 $((item_count - 1))); do
-  item=$(echo "$done_items" | jq ".[$i]")
+response=$(gh api graphql -f query="$query" 2>/dev/null) || response=""
 
-  # Draft items have no content — skip them.
-  content_url=$(echo "$item" | jq -r '.content.url // empty')
-  if [[ -z "$content_url" ]]; then
-    continue
-  fi
-
-  IFS=$'\t' read -r item_id title content_type content_number repo < <(
-    echo "$item" | jq -r '[.id, .title, .content.type, .content.number, .content.repository] | @tsv'
-  )
-
-  # Determine the closed/merged date via the GitHub API.
-  closed_date=""
-  if [[ "$content_type" == "PullRequest" ]]; then
-    pr_data=$(gh api "repos/${repo}/pulls/${content_number}" --jq '{merged_at, closed_at}' 2>/dev/null) || pr_data=""
-    if [[ -n "$pr_data" ]]; then
-      closed_date=$(echo "$pr_data" | jq -r '.merged_at // .closed_at // empty')
-    fi
-  elif [[ "$content_type" == "Issue" ]]; then
-    closed_date=$(gh api "repos/${repo}/issues/${content_number}" --jq '.closed_at // empty' 2>/dev/null) || closed_date=""
-  fi
-
-  if [[ -z "$closed_date" ]]; then
-    continue
-  fi
-
-  # Compare only the date portion (YYYY-MM-DD) against the sprint start.
-  closed_day="${closed_date:0:10}"
-  if [[ "$closed_day" < "$sprint_start" ]]; then
-    jq -n \
-      --arg id "$item_id" \
-      --arg title "$title" \
-      --arg number "$content_number" \
-      --arg type "$content_type" \
-      --arg closed_date "$closed_day" \
-      '{"id": $id, "title": $title, "number": ($number | tonumber), "type": $type, "closed_date": $closed_date}' >> "$results_file"
-  fi
-done
-
-if [[ -s "$results_file" ]]; then
-  jq -s '.' "$results_file"
-else
+if [[ -z "$response" ]]; then
   echo "[]"
+  exit 0
 fi
+
+# Join the batched results with work items and filter to those closed before
+# the sprint start date.
+echo "$work_items" | jq --arg sprint "$sprint_start" --argjson resp "$response" '
+  [to_entries[] |
+    .key as $idx |
+    .value as $item |
+    $resp.data["item_\($idx)"] as $data |
+    (
+      if $item.type == "PullRequest" then
+        ($data.pullRequest.mergedAt // $data.pullRequest.closedAt // null)
+      else
+        ($data.issue.closedAt // null)
+      end
+    ) as $closed |
+    select($closed != null) |
+    ($closed | .[0:10]) as $day |
+    select($day < $sprint) |
+    {id: $item.id, title: $item.title, number: $item.number, type: $item.type, closed_date: $day}
+  ]
+'


### PR DESCRIPTION
## Summary

- Adds a new **Step 12** to the sprint planning skill that offers to archive Done items from the project board that were completed before the current sprint started
- Adds an `archive` argument (`/sprint-planning archive`) to skip the full workflow and jump directly to archiving
- New helper script `archive-done-items.sh` fetches Done items, looks up closed/merged dates via the GitHub API, and filters to items older than the current sprint

## Test plan

- [ ] Run `/sprint-planning archive` and verify it detects the sprint, fetches Done items, filters correctly, and archives after confirmation
- [ ] Run the full `/sprint-planning` flow and verify Step 12 appears after posting the comment
- [ ] Verify edge cases: no qualifying items results in no prompt; draft items without content are skipped