### PR TITLE
Add /sprint-planning goals command

### DIFF
--- a/ai/skills/sprint-planning/SKILL.md
+++ b/ai/skills/sprint-planning/SKILL.md
@@ -4,6 +4,7 @@ description: Write bi-weekly sprint planning updates for the Feature Flags Platf
 model: sonnet
 color: pink
 allowed-tools: Bash, Read, Grep, Glob
+argument-hint: [archive|goals]
 ---
 
 # Sprint Planning - Feature Flags Platform
@@ -51,6 +52,13 @@ Format as `MM/DD - MM/DD` in the output.
   1. Run Step 1 (Detect Sprint Context) to get `sprint_start`
   2. Jump directly to Step 12 (Archive Previous Sprint's Done Items)
   3. Exit after archiving
+
+- `/sprint-planning goals` — Show what the team is currently working on by fetching In Progress and Todo items from the project board, grouped by assignee. When this argument is present:
+  1. Run Step G1 (Fetch Team Members)
+  2. Run Step G2 (Determine Current User)
+  3. Run Step G3 (Fetch Board Goals)
+  4. Run Step G4 (Format and Display)
+  5. Exit after displaying
 
 ## Your Task
 
@@ -340,6 +348,74 @@ After posting the comment (or if the user declines to post), offer to clean up t
 ```bash
 gh project item-archive 170 --owner PostHog --id <item-id>
 ```
+
+## Goals Workflow
+
+These steps apply when the `goals` argument is provided. They run independently of the main sprint planning workflow.
+
+### Step G1: Fetch Team Members
+
+```bash
+gh api orgs/PostHog/teams/team-flags-platform/members --jq '.[].login'
+```
+
+If this fails, fall back to the hardcoded list in Team Configuration above.
+
+### Step G2: Determine Current User
+
+The current user is `haacked` (from git config). This user's section is highlighted in the output.
+
+### Step G3: Fetch Board Goals
+
+Run the helper script to fetch In Progress and Todo items with assignee data:
+
+```bash
+~/.claude/skills/sprint-planning/scripts/fetch-board-goals.sh
+```
+
+This returns a JSON array of items, each with `id`, `title`, `status`, `url`, `type`, `number`, and `assignees` fields.
+
+### Step G4: Format and Display
+
+Group the items by assignee and display using this format:
+
+```markdown
+## Team Goals - Feature Flags Platform
+
+[Project Board](https://github.com/orgs/PostHog/projects/170)
+
+**--> @haacked** (you)
+
+**In Progress:**
+- [Item title](url)
+
+**Todo:**
+- [Upcoming item](url)
+
+---
+
+@dmarticus
+
+**In Progress:**
+- [Their item](url)
+
+---
+
+### Unassigned
+- [Orphaned item](url) - In Progress
+- Draft board item title - Todo
+```
+
+**Display rules:**
+
+- Current user appears first with `**-->**` prefix and `(you)` suffix
+- Other team members in alphabetical order
+- Items with URLs use `[title](url)` links
+- DraftIssues (no URL) show plain text title
+- Unassigned items appear at bottom in a separate section
+- Items with multiple assignees appear under each assignee
+- Status subsections ("In Progress" and "Todo") only shown if items exist for that status
+- Only show team members who have at least one item assigned
 
 ## Formatting Rules
 

--- a/ai/skills/sprint-planning/SKILL.md
+++ b/ai/skills/sprint-planning/SKILL.md
@@ -53,12 +53,13 @@ Format as `MM/DD - MM/DD` in the output.
   2. Jump directly to Step 12 (Archive Previous Sprint's Done Items)
   3. Exit after archiving
 
-- `/sprint-planning goals` — Show what the team is currently working on by fetching In Progress and Todo items from the project board, grouped by assignee. When this argument is present:
+- `/sprint-planning goals` — Show what the team is currently working on by merging the current sprint plan with project board data, grouped by assignee. When this argument is present:
   1. Run Step G1 (Fetch Team Members)
   2. Run Step G2 (Determine Current User)
-  3. Run Step G3 (Fetch Board Goals)
-  4. Run Step G4 (Format and Display)
-  5. Exit after displaying
+  3. Run Step G3 (Fetch Current Sprint Plan)
+  4. Run Step G4 (Fetch Board Goals)
+  5. Run Step G5 (Merge and Display)
+  6. Exit after displaying
 
 ## Your Task
 
@@ -363,9 +364,31 @@ If this fails, fall back to the hardcoded list in Team Configuration above.
 
 ### Step G2: Determine Current User
 
-The current user is `haacked` (from git config). This user's section is highlighted in the output.
+```bash
+gh api user --jq .login
+```
 
-### Step G3: Fetch Board Goals
+This user's section is highlighted in the output. If the API call fails, fall back to the output of `git config user.email` and match against team member handles.
+
+### Step G3: Fetch Current Sprint Plan
+
+1. Detect the current sprint:
+
+```bash
+~/.claude/skills/sprint-planning/scripts/detect-sprint.sh
+```
+
+2. Fetch the team's comment from the current sprint issue:
+
+```bash
+~/.claude/skills/sprint-planning/scripts/fetch-previous-comment.sh <current_number>
+```
+
+3. If the result is "NOT_FOUND", skip this step (no sprint plan exists yet). The output will rely solely on board data from Step G4.
+
+4. If a comment is found, parse the **Plan** section to extract each team member's planned items. Each item may be plain text or a `[title](url)` link.
+
+### Step G4: Fetch Board Goals
 
 Run the helper script to fetch In Progress and Todo items with assignee data:
 
@@ -375,26 +398,43 @@ Run the helper script to fetch In Progress and Todo items with assignee data:
 
 This returns a JSON array of items, each with `id`, `title`, `status`, `url`, `type`, `number`, and `assignees` fields.
 
-### Step G4: Format and Display
+### Step G5: Merge and Display
 
-Group the items by assignee and display using this format:
+Merge the sprint plan (Step G3) with the project board (Step G4) into a single view per team member.
+
+**Merge strategy:**
+
+1. Start from the sprint plan items as the baseline for each person.
+2. For each board item, check if it matches a plan item by URL, issue/PR number, or keyword similarity in the title.
+3. Matched items: use the board item's status (In Progress / Todo) and URL, preserving the plan's item description.
+4. Unmatched plan items (not on the board): include as-is from the plan, without a status subheading.
+5. Unmatched board items (not in the plan): append under a **"New (not in sprint plan):"** subheading.
+6. If no sprint plan exists (Step G3 returned NOT_FOUND), display board items only, grouped by status as before.
+
+**Output format:**
 
 ```markdown
 ## Team Goals - Feature Flags Platform
 
 [Project Board](https://github.com/orgs/PostHog/projects/170)
 
-**--> @haacked** (you)
+**--> @currentuser** (you)
 
 **In Progress:**
-- [Item title](url)
+- [Item from plan that's in progress on board](url)
 
 **Todo:**
-- [Upcoming item](url)
+- [Item from plan that's todo on board](url)
+
+**Other planned:**
+- Item from plan not on board
+
+**New (not in sprint plan):**
+- [Board item not in plan](url) - In Progress
 
 ---
 
-@dmarticus
+@teammate
 
 **In Progress:**
 - [Their item](url)
@@ -414,8 +454,9 @@ Group the items by assignee and display using this format:
 - DraftIssues (no URL) show plain text title
 - Unassigned items appear at bottom in a separate section
 - Items with multiple assignees appear under each assignee
-- Status subsections ("In Progress" and "Todo") only shown if items exist for that status
+- Status subsections only shown if items exist for that status
 - Only show team members who have at least one item assigned
+- Side quests from the sprint plan appear under their own heading per person
 
 ## Formatting Rules
 

--- a/ai/skills/sprint-planning/scripts/fetch-board-goals.sh
+++ b/ai/skills/sprint-planning/scripts/fetch-board-goals.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+# Fetch In Progress and Todo items from the project board with assignee
+# information. Uses a single batched GraphQL query to resolve assignees
+# for all linkable items (Issues and PRs), keeping API calls to a minimum.
+#
+# Usage: fetch-board-goals.sh
+#
+# Output: JSON array of items with fields:
+#   id, title, status, url, type, number, assignees
+#
+# Draft items (no linked Issue/PR) have null url, type, number,
+# and an empty assignees array.
+#
+# Returns an empty array [] if no qualifying items exist.
+
+set -euo pipefail
+
+# Fetch all items and filter to active statuses.
+active_items=$(gh project item-list 170 \
+  --owner PostHog \
+  --format json \
+  --limit 200 \
+  | jq '[.items[] | select(.status == "In Progress" or .status == "Todo")]')
+
+item_count=$(echo "$active_items" | jq 'length')
+
+if [[ "$item_count" -eq 0 ]]; then
+  echo "[]"
+  exit 0
+fi
+
+# Separate linkable items (Issues/PRs with a content URL) from drafts.
+linkable=$(echo "$active_items" | jq '[
+  .[] | select(.content.url != null and .content.url != "") |
+  {
+    id: .id,
+    title: .title,
+    status: .status,
+    url: .content.url,
+    type: .content.type,
+    number: (.content.number | tonumber),
+    repo: .content.repository
+  }
+]')
+
+drafts=$(echo "$active_items" | jq '[
+  .[] | select(.content.url == null or .content.url == "") |
+  {
+    id: .id,
+    title: .title,
+    status: .status,
+    url: null,
+    type: null,
+    number: null,
+    assignees: []
+  }
+]')
+
+linkable_count=$(echo "$linkable" | jq 'length')
+
+if [[ "$linkable_count" -eq 0 ]]; then
+  echo "$drafts"
+  exit 0
+fi
+
+# Build a single GraphQL query to fetch assignees for all linkable items.
+query=$(echo "$linkable" | jq -r '
+  [to_entries[] |
+    .key as $idx |
+    .value as $item |
+    ($item.repo | split("/")) as $parts |
+    "item_\($idx): repository(owner: \"\($parts[0])\", name: \"\($parts[1])\") { " +
+    if $item.type == "PullRequest" then
+      "pullRequest(number: \($item.number)) { assignees(first: 10) { nodes { login } } }"
+    else
+      "issue(number: \($item.number)) { assignees(first: 10) { nodes { login } } }"
+    end + " }"
+  ] | "query { " + join(" ") + " }"
+')
+
+response=$(gh api graphql -f query="$query" 2>/dev/null) || response=""
+
+# Join assignee data with linkable items. If the GraphQL call failed,
+# fall back to empty assignees so the caller still gets usable output.
+if [[ -n "$response" ]]; then
+  enriched=$(echo "$linkable" | jq --argjson resp "$response" '
+    [to_entries[] |
+      .key as $idx |
+      .value as $item |
+      $resp.data["item_\($idx)"] as $data |
+      (
+        if $item.type == "PullRequest" then
+          ($data.pullRequest.assignees.nodes // [])
+        else
+          ($data.issue.assignees.nodes // [])
+        end
+      ) as $nodes |
+      {
+        id: $item.id,
+        title: $item.title,
+        status: $item.status,
+        url: $item.url,
+        type: $item.type,
+        number: $item.number,
+        assignees: [$nodes[].login]
+      }
+    ]
+  ')
+else
+  enriched=$(echo "$linkable" | jq '[.[] | . + {assignees: []} | del(.repo)]')
+fi
+
+# Merge linkable and draft items into a single array.
+echo "$enriched" | jq --argjson drafts "$drafts" '. + $drafts'


### PR DESCRIPTION
## Summary

- Add `fetch-board-goals.sh` script that fetches In Progress and Todo items from PostHog Project 170, resolves assignees via a single batched GraphQL query, and outputs enriched JSON
- Add `goals` subcommand to the sprint-planning skill that groups board items by assignee and highlights the current user's items
- Follows existing patterns from `archive-done-items.sh` (batched GraphQL, graceful error handling, draft item support)

## Test plan

- [ ] Run `/sprint-planning goals` and verify items are fetched and grouped by assignee
- [ ] Verify current user's section appears first with highlight
- [ ] Verify only 2 API calls are made (one REST for board items, one GraphQL for assignees)
- [ ] Test edge cases: empty board, unassigned items, draft items