### PR TITLE
Prevent duplicate PR reviews from concurrent runs

### DIFF
--- a/bin/run-pr-reviews.sh
+++ b/bin/run-pr-reviews.sh
@@ -40,6 +40,7 @@ DRY_RUN=false
 AUTO_MODE=false
 ORG="PostHog"
 TEAMS=()
+REVIEW_FILE_PATH_SCRIPT="${HOME}/.claude/skills/review-code/scripts/review-file-path.sh"
 
 usage() {
   cat <<EOF
@@ -182,6 +183,29 @@ is_reviewed() {
   local pr_url="$1"
   echo "$SESSION" | jq -e --arg url "$pr_url" \
     '.reviewed | map(if type == "object" then .url else . end) | index($url) != null' > /dev/null 2>&1
+}
+
+# Check if a review file already exists for a PR
+# Uses the review-code skill's path resolution script
+review_exists() {
+  local pr_number="$1"
+  local pr_repo="$2"
+
+  if [[ ! -x "$REVIEW_FILE_PATH_SCRIPT" ]]; then
+    # Script not available, fall back to not skipping
+    return 1
+  fi
+
+  local org repo
+  org="${pr_repo%/*}"
+  repo="${pr_repo#*/}"
+
+  local review_info
+  review_info=$("$REVIEW_FILE_PATH_SCRIPT" --org "$org" --repo "$repo" "pr-${pr_number}" 2>/dev/null) || return 1
+
+  local file_exists
+  file_exists=$(echo "$review_info" | jq -r '.file_exists')
+  [[ "$file_exists" == "true" ]]
 }
 
 # Get PR list - either from stdin or auto-discover
@@ -403,6 +427,14 @@ main() {
     # Check if already reviewed today
     if is_reviewed "$pr_url"; then
       log_warn "Skipping PR #${pr_number} - already reviewed today"
+      mark_skipped "$pr_url"
+      ((skipped++)) || true
+      continue
+    fi
+
+    # Check if review file already exists (handles concurrent runs)
+    if review_exists "$pr_number" "$pr_repo"; then
+      log_warn "Skipping PR #${pr_number} - review already exists"
       mark_skipped "$pr_url"
       ((skipped++)) || true
       continue

--- a/bin/run-pr-reviews.sh
+++ b/bin/run-pr-reviews.sh
@@ -432,7 +432,8 @@ main() {
       continue
     fi
 
-    # Check if review file already exists (handles concurrent runs)
+    # Best-effort dedup for concurrent runs — not a lock, but catches the
+    # common case where a prior run already completed a review.
     if review_exists "$pr_number" "$pr_repo"; then
       log_warn "Skipping PR #${pr_number} - review already exists"
       mark_skipped "$pr_url"


### PR DESCRIPTION
## Summary

- Add a `review_exists()` check that uses the review-code skill's path resolution script to detect if a review file already exists for a PR
- Skip PRs that already have review files, preventing duplicate reviews when multiple concurrent `run-pr-reviews.sh` invocations pick up the same PRs

## Test plan

- [ ] Run `run-pr-reviews.sh` and verify it skips PRs that already have review files
- [ ] Run two concurrent instances and confirm duplicate reviews are reduced (best-effort — a narrow TOCTOU race window remains)
- [ ] Verify graceful fallback when the path resolution script is missing