### PR TITLE
Make bclean worktree-aware

### DIFF
--- a/bin/git-bclean-local
+++ b/bin/git-bclean-local
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Delete branches merged into the specified branch (or default branch),
+# removing associated worktrees first.
+# Usage: git bclean-local [target-branch]
+
+set -e
+
+DEFAULT=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null \
+  | sed 's@^refs/remotes/origin/@@' || echo main)
+target="${1:-$DEFAULT}"
+
+# Build a map of branch -> worktree path from porcelain output
+declare -A worktree_for
+current_wt=""
+while IFS= read -r line; do
+    if [[ "$line" == worktree\ * ]]; then
+        current_wt="${line#worktree }"
+    elif [[ "$line" == branch\ refs/heads/* ]]; then
+        branch="${line#branch refs/heads/}"
+        worktree_for["$branch"]="$current_wt"
+    fi
+done < <(git worktree list --porcelain)
+
+# Get merged branches, excluding the target branch itself
+merged=$(git branch --merged "$target" --format='%(refname:short)' \
+  | grep -v "^${target}$" || true)
+
+if [ -z "$merged" ]; then
+    exit 0
+fi
+
+while IFS= read -r branch; do
+    [ -z "$branch" ] && continue
+
+    wt_path="${worktree_for[$branch]:-}"
+    if [ -n "$wt_path" ]; then
+        if git worktree remove "$wt_path" 2>/dev/null; then
+            echo "Removed worktree: $wt_path"
+        else
+            echo "Warning: worktree at $wt_path has uncommitted changes."
+            read -rp "Force remove worktree and delete branch '$branch'? [y/N] " answer
+            if [[ "$answer" =~ ^[Yy]$ ]]; then
+                git worktree remove --force "$wt_path"
+                echo "Force-removed worktree: $wt_path"
+            else
+                echo "Skipping $branch"
+                continue
+            fi
+        fi
+    fi
+
+    git branch -d "$branch" 2>/dev/null && echo "Deleted: $branch"
+done <<< "$merged"

--- a/bin/git-bclean-local
+++ b/bin/git-bclean-local
@@ -34,11 +34,12 @@ while IFS= read -r branch; do
 
     wt_path="${worktree_for[$branch]:-}"
     if [ -n "$wt_path" ]; then
-        if git worktree remove "$wt_path" 2>/dev/null; then
+        if err=$(git worktree remove "$wt_path" 2>&1); then
             echo "Removed worktree: $wt_path"
         else
-            echo "Warning: worktree at $wt_path has uncommitted changes."
-            read -rp "Force remove worktree and delete branch '$branch'? [y/N] " answer
+            echo "Warning: could not remove worktree at $wt_path"
+            echo "  Reason: $err"
+            read -rp "Force remove and delete branch '$branch'? [y/N] " answer
             if [[ "$answer" =~ ^[Yy]$ ]]; then
                 git worktree remove --force "$wt_path"
                 echo "Force-removed worktree: $wt_path"
@@ -49,5 +50,7 @@ while IFS= read -r branch; do
         fi
     fi
 
-    git branch -d "$branch" 2>/dev/null && echo "Deleted: $branch"
+    if git branch -d "$branch" 2>/dev/null; then
+        echo "Deleted: $branch"
+    fi
 done <<< "$merged"

--- a/git/gitconfig.aliases.symlink
+++ b/git/gitconfig.aliases.symlink
@@ -14,8 +14,8 @@
     abort = rebase --abort
     aliases = "!git config -l | grep ^alias\\. | cut -c 7-"
     amend = commit -a --amend
-    # Deletes all branches merged into the specified branch (or the default branch if no branch is specified)
-    bclean = "!gh poi; git bclean-local"
+    # Prune remote-merged branches (gh poi) then delete local merged branches and their worktrees
+    bclean = "!f() { gh poi; git bclean-local \"$@\"; }; f"
     # Switches to specified branch (or the dafult branch if no branch is specified), runs git up, then runs bclean.
     bdone = "!f() { DEFAULT=$(git default); git checkout ${1-$DEFAULT} && git up && git bclean; }; f"
     # Switches to specified branch, runs git up, then runs bclean-squash for squash-merged branches

--- a/git/gitconfig.aliases.symlink
+++ b/git/gitconfig.aliases.symlink
@@ -15,8 +15,7 @@
     aliases = "!git config -l | grep ^alias\\. | cut -c 7-"
     amend = commit -a --amend
     # Deletes all branches merged into the specified branch (or the default branch if no branch is specified)
-    bclean-local = "!f() { DEFAULT=$(git default); git branch --merged ${1-$DEFAULT} | grep -v " ${1-$DEFAULT}$" | xargs git branch -d; }; f"
-    bclean = "!gh poi && git bclean-local"
+    bclean = "!gh poi; git bclean-local"
     # Switches to specified branch (or the dafult branch if no branch is specified), runs git up, then runs bclean.
     bdone = "!f() { DEFAULT=$(git default); git checkout ${1-$DEFAULT} && git up && git bclean; }; f"
     # Switches to specified branch, runs git up, then runs bclean-squash for squash-merged branches


### PR DESCRIPTION
## Summary

- Extract `bclean-local` from a git alias into a standalone `bin/git-bclean-local` script that detects and removes worktrees associated with merged branches before deleting them
- Simplify the `bclean` alias to call `gh poi` followed by `git bclean-local`

## Motivation

The old `bclean-local` alias used `xargs git branch -d` which would fail on branches that had associated worktrees. The new script parses `git worktree list --porcelain` to build a branch-to-worktree map, removes worktrees first (prompting if there are uncommitted changes), then deletes the branch.

## Test plan

- [ ] Run `git bclean` on a repo with no worktrees — behaves as before
- [ ] Run `git bclean` on a repo with a worktree for a merged branch — worktree is removed, then branch is deleted
- [ ] Run `git bclean` on a repo with a dirty worktree — prompted to force-remove or skip