### PR TITLE
Allow re-reviews for non-approved PRs

### DIFF
--- a/bin/review-all-prs.sh
+++ b/bin/review-all-prs.sh
@@ -210,16 +210,24 @@ else
   echo ""
 
   # Print formatted table
-  printf "%-6s %-25s %-50s %s\n" "PR#" "REPO" "TITLE" "AUTHOR"
-  printf "%s\n" "$(printf '%.0s-' {1..120})"
+  printf "%-6s %-25s %-50s %-15s %s\n" "PR#" "REPO" "TITLE" "STATUS" "AUTHOR"
+  printf "%s\n" "$(printf '%.0s-' {1..135})"
 
   echo "$PROCESSED" | jq -r '.[] | [
     .number,
     (.repo | split("/")[1] | .[0:25]),
     (.title | .[0:50]),
+    (.user_review_state // empty |
+      if . == "CHANGES_REQUESTED" then "Changes req"
+      elif . == "COMMENTED" then "Commented"
+      elif . == "APPROVED" then "Approved"
+      elif . == "DISMISSED" then "Dismissed"
+      elif . == "PENDING" then "In progress"
+      else . end
+    ) // "Pending",
     .author
-  ] | @tsv' | while IFS=$'\t' read -r num repo title author; do
-    printf "%-6s %-25s %-50s %s\n" "$num" "$repo" "$title" "$author"
+  ] | @tsv' | while IFS=$'\t' read -r num repo title status author; do
+    printf "%-6s %-25s %-50s %-15s %s\n" "$num" "$repo" "$title" "$status" "$author"
   done
 
   echo ""

--- a/bin/review-all-prs.sh
+++ b/bin/review-all-prs.sh
@@ -190,7 +190,7 @@ PROCESSED=$(echo "$ALL_RESULTS" | jq --arg user "$GITHUB_USER" --argjson include
         | if length > 0 then .[-1] else null end
       )
     })
-  | if $include_reviewed then . else map(select(.user_review_state == null)) end
+  | if $include_reviewed then . else map(select(.user_review_state != "APPROVED")) end
   | sort_by(.updated_at)
   | reverse
 ')

--- a/bin/run-pr-reviews.sh
+++ b/bin/run-pr-reviews.sh
@@ -445,6 +445,10 @@ main() {
 
     IFS=$'\t' read -r pr_url pr_number pr_title pr_repo pr_author < <(echo "$pr" | jq -r '[.url, (.number | tostring), .title, .repo, .author] | @tsv')
 
+    # Extract review state — non-empty means this is a re-review
+    local user_review_state
+    user_review_state=$(echo "$pr" | jq -r '.user_review_state // empty')
+
     echo ""
     log_info "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 
@@ -465,8 +469,10 @@ main() {
     fi
 
     # Best-effort dedup for concurrent runs — not a lock, but catches the
-    # common case where a prior run already completed a review.
-    if review_exists "$pr_number" "$pr_repo"; then
+    # common case where a prior run already completed a review. For re-reviews
+    # (non-empty user_review_state), an old review file on disk is expected, so
+    # skip this check to allow the re-review to proceed.
+    if [[ -z "$user_review_state" ]] && review_exists "$pr_number" "$pr_repo"; then
       log_warn "Skipping PR #${pr_number} - review already exists"
       mark_skipped "$pr_url"
       ((skipped++)) || true

--- a/bin/run-pr-reviews.sh
+++ b/bin/run-pr-reviews.sh
@@ -443,11 +443,8 @@ main() {
   while read -r pr; do
     local pr_url pr_number pr_title pr_repo pr_author
 
-    IFS=$'\t' read -r pr_url pr_number pr_title pr_repo pr_author < <(echo "$pr" | jq -r '[.url, (.number | tostring), .title, .repo, .author] | @tsv')
-
-    # Extract review state — non-empty means this is a re-review
     local user_review_state
-    user_review_state=$(echo "$pr" | jq -r '.user_review_state // empty')
+    IFS=$'\t' read -r pr_url pr_number pr_title pr_repo pr_author user_review_state < <(echo "$pr" | jq -r '[.url, (.number | tostring), .title, .repo, .author, (.user_review_state // empty)] | @tsv')
 
     echo ""
     log_info "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"


### PR DESCRIPTION
## Summary

- Changes the review filter from skipping all previously-reviewed PRs to only skipping ones I've already approved — PRs I commented on or requested changes for will surface again for re-review
- Folds `user_review_state` into the existing jq extraction so `run-pr-reviews.sh` can skip the dedup check for re-reviews (an old review file on disk is expected in that case)

## Test plan

- [ ] Run `review-all-prs.sh` and verify previously-commented/changes-requested PRs appear
- [ ] Verify already-approved PRs are still filtered out
- [ ] Verify re-reviews aren't skipped by the dedup check in `run-pr-reviews.sh`