### PR TITLE
Skip dirty and Conductor worktrees in git bclean-local

### DIFF
--- a/bin/git-bclean-local
+++ b/bin/git-bclean-local
@@ -34,6 +34,18 @@ while IFS= read -r branch; do
 
     wt_path="${worktree_for[$branch]:-}"
     if [ -n "$wt_path" ]; then
+        # Skip worktrees managed by Conductor
+        if [ -d "$wt_path/.context" ]; then
+            echo "Skipping $branch (Conductor workspace: $wt_path)"
+            continue
+        fi
+
+        # Skip worktrees with uncommitted changes
+        if [ -n "$(git -C "$wt_path" status --porcelain 2>/dev/null)" ]; then
+            echo "Skipping $branch (worktree has uncommitted changes: $wt_path)"
+            continue
+        fi
+
         if err=$(git worktree remove "$wt_path" 2>&1); then
             echo "Removed worktree: $wt_path"
         else


### PR DESCRIPTION
Prevent `git bclean-local` from aggressively cleaning up worktrees in two cases:

1. **Conductor workspaces** — Skip any worktree with a `.context` directory, which indicates it's managed by Conductor
2. **Dirty worktrees** — Skip any worktree with uncommitted changes

This avoids prompting for force-removal when you're actively working on a branch that hasn't been committed yet.