### PR TITLE
Prevent mergiraf from creating .orig backup files

### DIFF
--- a/ai/skills/resolve-conflicts/SKILL.md
+++ b/ai/skills/resolve-conflicts/SKILL.md
@@ -106,7 +106,7 @@ Do not auto-resolve. Ask the user how to proceed for each migration file. Common
 Run mergiraf as a second pass (it may have already run as a merge driver during the git operation itself, but sometimes conflicts remain). It is installed and configured as a git merge driver:
 
 ```bash
-mergiraf solve -- <file> --compact
+mergiraf solve -- <file> --compact --keep-backup=false
 ```
 
 After running mergiraf, read the file and check for remaining conflict markers (`<<<<<<<`). If conflict markers remain, proceed with AI analysis (see Step 2c).


### PR DESCRIPTION
## Summary

- Pass `--keep-backup=false` to `mergiraf solve` in the resolve-conflicts skill so `.orig` backup files are no longer left behind after conflict resolution

## Test plan

- Run `/resolve-conflicts` on a branch with mergiraf-resolvable conflicts and verify no `.orig` files are created