### PR TITLE
Add review-code context fallback and framework detection to lang-context hook

### DIFF
--- a/ai/bin/lang-context
+++ b/ai/bin/lang-context
@@ -1,11 +1,18 @@
 #!/usr/bin/env bash
-# lang-context - Output language-specific context for code writing
+# lang-context - Output language and framework context for code writing
 #
 # Used as a PreToolUse hook for Edit/Write tools.
 # Detects language from file extension and outputs context once per session.
+# Falls back to review-code context files when no local override exists.
+# Detects frameworks from project sentinel files and loads framework context.
 #
 # Environment variables (set by Claude Code):
 #   CLAUDE_FILE_PATH - Path to the file being edited/written
+#
+# Configuration environment variables (for testing):
+#   LANG_CONTEXT_DIR      - Local context directory (default: ~/.claude/contexts)
+#   REVIEW_CONTEXT_DIR    - Review-code context directory (default: ~/.claude/skills/review-code/context)
+#   MAX_CONTEXT_LINES     - Token budget cap in lines (default: 600)
 #
 # Session deduplication uses PPID to identify the Claude Code process.
 
@@ -13,7 +20,9 @@ set -euo pipefail
 
 # Configuration
 CONTEXT_DIR="${LANG_CONTEXT_DIR:-${HOME}/.claude/contexts}"
+REVIEW_CONTEXT_DIR="${REVIEW_CONTEXT_DIR:-${HOME}/.claude/skills/review-code/context}"
 CACHE_DIR="${TMPDIR:-/tmp}/claude-lang-context"
+MAX_CONTEXT_LINES="${MAX_CONTEXT_LINES:-600}"
 
 # Get file path from environment or argument
 file_path="${CLAUDE_FILE_PATH:-${1:-}}"
@@ -78,6 +87,9 @@ case "${ext}" in
     .ex | .exs)
         lang="elixir"
         ;;
+    .dart)
+        lang="dart"
+        ;;
     *)
         # No context for this extension
         exit 0
@@ -87,21 +99,178 @@ esac
 # Session deduplication: use PPID as session identifier
 # Claude Code spawns hook processes, so PPID is the Claude process
 mkdir -p "${CACHE_DIR}"
+
+# Clean up stale marker files from terminated sessions (older than 1 day)
+find "${CACHE_DIR}" -type f -mtime +1 -delete 2>/dev/null || true
+
+# Track total lines output this session for token budget
+total_lines=0
+
+# Output a context file, respecting the token budget cap.
+# Usage: output_context "Header" "/path/to/file.md" [preamble]
+output_context() {
+    local header="$1"
+    local file="$2"
+    local preamble="${3:-}"
+
+    local file_lines
+    file_lines=$(wc -l < "${file}")
+
+    if (( total_lines + file_lines > MAX_CONTEXT_LINES )); then
+        return 1
+    fi
+
+    echo "## ${header}"
+    echo ""
+    if [[ -n "${preamble}" ]]; then
+        echo "${preamble}"
+        echo ""
+    fi
+    cat "${file}"
+    echo ""
+
+    total_lines=$(( total_lines + file_lines ))
+    return 0
+}
+
+# --- Language context ---
+
 session_marker="${CACHE_DIR}/${PPID}-${lang}"
 
-# Already shown this language in this session?
-if [[ -f "${session_marker}" ]]; then
-    exit 0
+if [[ ! -f "${session_marker}" ]]; then
+    context_file="${CONTEXT_DIR}/${lang}.md"
+    fallback_file="${REVIEW_CONTEXT_DIR}/languages/${lang}.md"
+
+    if [[ -f "${context_file}" ]]; then
+        # Local override exists — use it (implementation-focused, concise)
+        if output_context "${lang^}: Writing Guidelines (apply when editing)" "${context_file}" \
+            "Apply the following guidelines when writing this code:"; then
+            touch "${session_marker}"
+        fi
+    elif [[ -f "${fallback_file}" ]]; then
+        # Fall back to review-code context with reframing preamble
+        if output_context "${lang^}: Writing Guidelines (apply when editing)" "${fallback_file}" \
+            "Apply these guidelines when writing code. Where the text says \"flag\" or \"detect\" a pattern, treat that as: write code that avoids this pattern:"; then
+            touch "${session_marker}"
+        fi
+    fi
 fi
 
-# Find and output context file
-context_file="${CONTEXT_DIR}/${lang}.md"
-if [[ -f "${context_file}" ]]; then
-    echo "## ${lang^} Writing Guidelines"
-    echo ""
-    cat "${context_file}"
-    echo ""
+# --- Framework detection ---
+# Runs once per session. Walks up from the file to find the project root,
+# then checks sentinel files to detect frameworks.
 
-    # Mark as shown for this session
-    touch "${session_marker}"
+fw_detection_marker="${CACHE_DIR}/${PPID}-fw-detected"
+
+if [[ ! -f "${fw_detection_marker}" ]] && [[ -d "${REVIEW_CONTEXT_DIR}/frameworks" ]]; then
+    # Find project root by walking up to .git
+    project_root=""
+    search_dir="$(cd "$(dirname "${file_path}")" 2>/dev/null && pwd)" || true
+
+    if [[ -n "${search_dir}" ]]; then
+        levels=0
+        while [[ "${search_dir}" != "/" ]] && (( levels < 10 )); do
+            if [[ -d "${search_dir}/.git" ]]; then
+                project_root="${search_dir}"
+                break
+            fi
+            search_dir="$(dirname "${search_dir}")"
+            levels=$(( levels + 1 ))
+        done
+    fi
+
+    if [[ -n "${project_root}" ]]; then
+        detected_frameworks=()
+
+        # Check if a framework is relevant to the current language.
+        # Prevents Django context loading for TypeScript files in monorepos, etc.
+        is_relevant() {
+            local fw="$1"
+            case "${fw}" in
+                django)         [[ "${lang}" == "python" ]] ;;
+                react|kea|nodejs) [[ "${lang}" == "typescript" || "${lang}" == "javascript" ]] ;;
+                aspnetcore)     [[ "${lang}" == "csharp" ]] ;;
+                ios)            [[ "${lang}" == "swift" ]] ;;
+                flutter)        [[ "${lang}" == "dart" ]] ;;
+                android)        [[ "${lang}" == "kotlin" || "${lang}" == "java" ]] ;;
+                *)              true ;;
+            esac
+        }
+
+        # Django: manage.py or django in requirements
+        if is_relevant "django"; then
+            if [[ -f "${project_root}/manage.py" ]]; then
+                detected_frameworks+=("django")
+            elif compgen -G "${project_root}/requirements*.txt" > /dev/null 2>&1; then
+                if grep -ql 'django' "${project_root}"/requirements*.txt 2>/dev/null; then
+                    detected_frameworks+=("django")
+                fi
+            fi
+        fi
+
+        # Node.js package.json-based detection
+        if [[ -f "${project_root}/package.json" ]]; then
+            pkg="${project_root}/package.json"
+
+            # React
+            if is_relevant "react" && grep -q '"react"' "${pkg}" 2>/dev/null; then
+                detected_frameworks+=("react")
+            fi
+
+            # Kea
+            if is_relevant "kea" && grep -q '"kea"' "${pkg}" 2>/dev/null; then
+                detected_frameworks+=("kea")
+            fi
+
+            # Node.js
+            if is_relevant "nodejs"; then
+                detected_frameworks+=("nodejs")
+            fi
+        fi
+
+        # ASP.NET Core
+        if is_relevant "aspnetcore" && compgen -G "${project_root}/*.csproj" > /dev/null 2>&1; then
+            if grep -ql 'Microsoft.AspNetCore' "${project_root}"/*.csproj 2>/dev/null; then
+                detected_frameworks+=("aspnetcore")
+            fi
+        fi
+
+        # iOS
+        if is_relevant "ios"; then
+            if [[ -f "${project_root}/Podfile" ]] || compgen -G "${project_root}/*.xcodeproj" > /dev/null 2>&1; then
+                detected_frameworks+=("ios")
+            fi
+        fi
+
+        # Flutter
+        if is_relevant "flutter" && [[ -f "${project_root}/pubspec.yaml" ]]; then
+            detected_frameworks+=("flutter")
+        fi
+
+        # Android
+        if is_relevant "android"; then
+            if [[ -f "${project_root}/build.gradle" ]] || [[ -f "${project_root}/build.gradle.kts" ]]; then
+                if grep -ql 'android' "${project_root}"/build.gradle* 2>/dev/null; then
+                    detected_frameworks+=("android")
+                fi
+            fi
+        fi
+
+        # Load context for each detected framework
+        for fw in "${detected_frameworks[@]}"; do
+            fw_marker="${CACHE_DIR}/${PPID}-fw-${fw}"
+            fw_file="${REVIEW_CONTEXT_DIR}/frameworks/${fw}.md"
+
+            if [[ ! -f "${fw_marker}" ]] && [[ -f "${fw_file}" ]]; then
+                if output_context "${fw^}: Framework Guidelines (apply when editing)" "${fw_file}" \
+                    "Apply these framework-specific guidelines. Where the text says \"flag\" or \"detect\" a pattern, treat that as: write code that avoids this pattern:"; then
+                    touch "${fw_marker}"
+                fi
+            fi
+        done
+    fi
+
+    # Mark detection as complete after loading (not before) so budget-capped
+    # sessions can retry on the next hook invocation
+    touch "${fw_detection_marker}"
 fi

--- a/ai/contexts/python.md
+++ b/ai/contexts/python.md
@@ -18,43 +18,39 @@ if TYPE_CHECKING:
 - Use `TypedDict` for structured dicts, not `dict[str, Any]`
 - Run `mypy` to catch type errors
 
-### Django ORM
+### Dictionary Access Patterns
 
-- Use `select_related()` for ForeignKey/OneToOne
-- Use `prefetch_related()` for ManyToMany/reverse FK
-- Use `.count()` not `len(queryset)`
-- Use `bulk_create`/`bulk_update` for batch operations
-- Filter in database, not Python
-- **Foreign keys have indexes** - Django creates indexes for ForeignKey fields automatically
-
-### Bulk Operations & Signals
-
-- **`bulk_update()` and `bulk_create()` don't trigger signals** (`post_save`, `pre_save`, etc.)
-- If signals update caches, manually refresh after bulk operations or use individual `save()` calls
-- Wrap bulk operations in `@transaction.atomic` for atomicity
-- For large datasets, process in batches to limit memory usage:
+- Use `dict["key"]` for required fields (fails fast with `KeyError` if data is malformed)
+- Use `dict.get("key")` only for genuinely optional fields where absence is valid
+- When building lookup dicts, use direct access for the key field:
 
 ```python
-# Good - batched bulk update
-BATCH_SIZE = 1000
-for i in range(0, len(objects), BATCH_SIZE):
-    batch = objects[i:i + BATCH_SIZE]
-    Model.objects.bulk_update(batch, ["field"])
+# Good - fails fast if "id" is missing
+flags_by_id = {flag["id"]: flag for flag in flags}
+
+# Bad - silently maps None as a key, causing subtle bugs later
+flags_by_id = {flag.get("id"): flag for flag in flags}
 ```
+
+### Async/Await Patterns
+
+- Never forget `await` on coroutines — a bare `fetch_data()` without `await` returns a coroutine object, not the result
+- Don't use blocking operations (file I/O, `time.sleep()`) in async functions — use `asyncio.sleep()`, `aiofiles`, or `sync_to_async`
+- Handle floating promises: always `await` or explicitly discard with a comment
 
 ### Error Handling
 
-- Use `get_object_or_404()` in views
-- Handle `DoesNotExist` explicitly
-- Use `@transaction.atomic` for multi-step operations
 - Don't catch broad exceptions without logging
+- Handle specific exception types explicitly
+- Use context managers (`with` statements) for resource cleanup
+- Raise exceptions early, catch them late
 
 ### Security
 
-- Validate all user input (use Django forms)
-- Use ORM - avoid raw SQL
+- Validate all user input before processing
+- Use parameterized queries — avoid string-formatted SQL
 - Check permissions before data access
-- Don't roll custom auth - use Django's
+- Don't roll custom auth — use framework-provided auth
 
 ### Timing and Duration Measurement
 

--- a/ai/contexts/rust.md
+++ b/ai/contexts/rust.md
@@ -14,6 +14,17 @@ Before implementing functionality that operates on a type:
 | `#[derive(Serialize)]` | `serde_json::to_value()` | Manual JSON building |
 | `#[derive(Clone)]` | `.clone()` | Manual field-by-field copy |
 | `#[derive(Default)]` | `Default::default()` | Manual zero-initialization |
+| `#[derive(FromRow)]` | Let sqlx use the derive | Manual `row.get("column")` extraction |
+| `#[derive(Debug)]` | Use the derive | Manual `fmt::Debug` impl with same output |
+
+**Warning signs you're reimplementing a derive:** field-name string literals (`.get("user_id")`), repetitive per-field operations, >50 lines for a type conversion.
+
+### Patterns to Avoid
+
+- **Error type masking**: Don't convert all error types to a single `Ok(None)` or generic error. Distinguish connection failures from key-not-found for monitoring and alerting.
+- **Pass-through without validation**: Validate data structure from external sources (cache, API) before passing through. Malformed data silently accepted causes downstream issues.
+- **Accidental feature removal**: During refactors or migrations, verify existing functionality isn't accidentally removed. Compare old vs new behavior for feature parity.
+- **Avoidable clone**: Unnecessary `.clone()` calls can often be avoided by reordering operations — perform non-consuming operations first, then move the value.
 
 ### Error Handling
 
@@ -70,6 +81,11 @@ if s.chars().count() > max { s.chars().take(max).collect() }
 
 - When optimizing by filtering to a subset (e.g., `flag_keys`), ensure dependencies from the full graph are included in the analysis
 - A flag might not be in the filter set but still get evaluated as a dependency
+
+### Log Safety
+
+- Truncate user-provided strings before logging (User-Agent headers can be KB+ from bots/crawlers)
+- Apply to any user-controlled string in structured logs (256-512 chars max)
 
 ### Quality Checklist
 


### PR DESCRIPTION
## Summary

- Extend the `lang-context` PreToolUse hook to fall back to `review-code` context files when no local language override exists, giving Claude Code implementation-time access to the same guidelines used during review
- Add framework detection via project sentinel files (manage.py, package.json, *.csproj, etc.) with language-relevance filtering to prevent cross-contamination in monorepos
- Enforce a token budget cap (MAX_CONTEXT_LINES=600) to prevent context window bloat, with session deduplication and stale cache cleanup
- Enrich local `rust.md` with anti-patterns (error masking, avoidable clone, log safety) and generalize `python.md` by removing Django-specific content now covered by framework detection

## Test plan

- Verify Go file editing loads review-code fallback context (no local `go.md` exists)
- Verify Rust file editing loads local `rust.md` override, not review-code fallback
- Verify Python file in a Django project loads both `python.md` and `django.md` framework context
- Verify TypeScript file in a monorepo with `manage.py` does NOT load Django context
- Verify context stops loading when MAX_CONTEXT_LINES budget is exceeded
- Verify second edit in same session skips duplicate context output