### PR TITLE
Add review-fix-cycle skill and review-fix-loop script

### DIFF
--- a/ai/skills/review-fix-cycle/SKILL.md
+++ b/ai/skills/review-fix-cycle/SKILL.md
@@ -1,0 +1,168 @@
+---
+name: review-fix-cycle
+description: Run one review-fix iteration — review code, fix findings, simplify, and commit.
+argument-hint: "[<review-target>] [--iteration N]"
+---
+
+Run one full review-fix-simplify-commit cycle. Designed to be invoked repeatedly (with fresh context each time) by the `review-fix-loop.sh` wrapper script, but can also be run standalone.
+
+**Arguments:**
+
+- `<review-target>` — Anything `/review-code` accepts: PR URL, PR number, branch name, commit, range. If omitted, auto-detects (see Step 1).
+- `--iteration N` — Iteration number (default 1). Used for logging and status tracking.
+
+---
+
+## Implementation
+
+### Step 1: Parse Arguments
+
+Extract from `$ARGUMENTS`:
+- `--iteration N` (default to `1`)
+- Everything else is the review target
+
+Determine the review target:
+
+1. If an explicit target was provided, use it as-is.
+2. If no target, auto-detect:
+
+```bash
+gh pr list --head "$(git branch --show-current)" --json number --jq '.[0].number' 2>/dev/null
+```
+
+- If a PR number is returned, use that as the target.
+- Otherwise, use the current branch name: `git branch --show-current`
+
+Save the resolved target as `$REVIEW_TARGET`.
+
+Set up the notes directory:
+
+```bash
+mkdir -p "$(git rev-parse --show-toplevel)/.notes"
+```
+
+### Step 2: Run Review
+
+Invoke the review-code skill:
+
+```
+Skill("review-code", args: "--force --append $REVIEW_TARGET")
+```
+
+Using `--append` ensures each iteration builds upon the previous review. The review agents receive the existing review as context and focus only on NEW findings — they skip already-raised issues, update status for resolved ones, and avoid duplicating work.
+
+Wait for the review to complete before proceeding.
+
+### Step 3: Locate and Read the Review File
+
+Get the review file path:
+
+```bash
+~/.claude/skills/review-code/scripts/review-file-path.sh
+```
+
+Parse the JSON output and extract the `file_path` field. Then use the Read tool to read the review file contents.
+
+### Step 4: Triage Findings
+
+Parse the review markdown for findings from the **latest review section only**. When `--append` is used, the file may contain prior review sections separated by `---`. Focus on findings after the last separator (or the entire file on the first iteration).
+
+Findings are prefixed with code-formatted severity markers:
+
+- `` `blocking` `` — Must fix. Bugs, security issues, breakage.
+- `` `suggestion` `` — Worth considering. Author's call.
+- `` `nit` `` — Minor style/naming. Take it or leave it.
+- `` `question` `` — Clarification needed. Not necessarily a problem.
+
+**Categorize each finding:**
+
+**Fix** (always):
+- All `blocking` findings
+- `suggestion` findings that fix correctness, security, or clarity issues
+- `suggestion` findings with concrete code improvements that make the code simpler or cleaner
+- `nit` findings that are clearly correct and easy to apply
+
+**Skip** (only when):
+- The suggestion is factually wrong or based on a misunderstanding of the code
+- The suggestion is genuinely ambiguous and could go either way
+- The suggestion would make the code worse (more complex, less readable)
+- `question` findings (these are informational, not actionable)
+
+Count the findings: `$TOTAL_FINDINGS`, `$TO_FIX`, `$TO_SKIP`.
+
+**If zero actionable findings:** Jump to Step 8 and write the status file with `"clean": true, "fixed": 0, "skipped": 0, "committed": false`. Skip Steps 5, 6, and 7.
+
+### Step 5: Apply Fixes
+
+Process findings in priority order: blocking first, then suggestions, then nits.
+
+For each actionable finding:
+1. Read the referenced file at the indicated line
+2. Apply the fix:
+   - Use the concrete code fix from the review if one is provided (blocking and suggestion findings always include one)
+   - For nits, use the description to determine the appropriate change
+3. Verify the fix makes sense in context before writing it
+
+For each skipped finding, append to `.notes/review-skipped.md`:
+
+```markdown
+## Iteration $N — $DATE
+
+### Skipped: $FINDING_TITLE
+**Reason:** $WHY_SKIPPED
+**Source:** $AGENT_NAME, `$FILE:$LINE`
+```
+
+Use append mode (do not overwrite previous iterations).
+
+### Step 6: Simplify
+
+Invoke the simplify skill to review the changes just made:
+
+```
+Skill("simplify")
+```
+
+Apply any improvements it suggests.
+
+### Step 7: Commit
+
+Invoke the commit skill with force mode:
+
+```
+Skill("commit", args: "--force Address review feedback (iteration $N)")
+```
+
+### Step 8: Write Status File
+
+Write the status file to `.notes/review-cycle-status.json`:
+
+```bash
+REPO_ROOT=$(git rev-parse --show-toplevel)
+```
+
+Use the Write tool to create `$REPO_ROOT/.notes/review-cycle-status.json`:
+
+```json
+{
+  "iteration": $N,
+  "clean": $CLEAN,
+  "total_findings": $TOTAL_FINDINGS,
+  "fixed": $TO_FIX,
+  "skipped": $TO_SKIP,
+  "committed": $COMMITTED,
+  "timestamp": "$ISO_TIMESTAMP"
+}
+```
+
+Where:
+- `clean` is `true` if zero actionable findings were found
+- `committed` is `true` if a commit was made (false if clean or all skipped)
+
+Report the iteration summary to the user:
+
+```
+Review-fix cycle iteration $N complete.
+Findings: $TOTAL_FINDINGS total, $TO_FIX fixed, $TO_SKIP skipped.
+Status: $STATUS
+```

--- a/ai/skills/review-fix-cycle/SKILL.md
+++ b/ai/skills/review-fix-cycle/SKILL.md
@@ -105,17 +105,7 @@ For each actionable finding:
    - For nits, use the description to determine the appropriate change
 3. Verify the fix makes sense in context before writing it
 
-For each skipped finding, append to `.notes/review-skipped.md`:
-
-```markdown
-## Iteration $N — $DATE
-
-### Skipped: $FINDING_TITLE
-**Reason:** $WHY_SKIPPED
-**Source:** $AGENT_NAME, `$FILE:$LINE`
-```
-
-Use append mode (do not overwrite previous iterations).
+For each skipped finding, note the title, reason, source, and file/line in memory. The skipped log is written after the commit (see Step 7a) to avoid accidentally staging it.
 
 ### Step 6: Simplify
 
@@ -134,6 +124,22 @@ Invoke the commit skill with force mode:
 ```
 Skill("commit", args: "--force Address review feedback (iteration $N)")
 ```
+
+### Step 7a: Write Skipped Findings Log
+
+After the commit, append any skipped findings to `.notes/review-skipped.md`. Writing after the commit ensures the log file is never accidentally staged alongside the code changes.
+
+For each skipped finding noted in Step 5, append:
+
+```markdown
+## Iteration $N — $DATE
+
+### Skipped: $FINDING_TITLE
+**Reason:** $WHY_SKIPPED
+**Source:** $AGENT_NAME, `$FILE:$LINE`
+```
+
+Use append mode (do not overwrite previous iterations).
 
 ### Step 8: Write Status File
 

--- a/ai/skills/review-fix-cycle/SKILL.md
+++ b/ai/skills/review-fix-cycle/SKILL.md
@@ -4,6 +4,8 @@ description: Run one review-fix iteration — review code, fix findings, simplif
 argument-hint: "[<review-target>] [--iteration N]"
 ---
 
+# Review-Fix Cycle
+
 Run one full review-fix-simplify-commit cycle. Designed to be invoked repeatedly (with fresh context each time) by the `review-fix-loop.sh` wrapper script, but can also be run standalone.
 
 **Arguments:**

--- a/bin/copilot-review-loop.sh
+++ b/bin/copilot-review-loop.sh
@@ -64,51 +64,6 @@ EOF
 
 # ── Helpers ──────────────────────────────────────────────────────────────────
 
-# Detect PR from input (URL, number, or current branch).
-# Sets OWNER, REPO_NAME, REPO, PR_NUMBER globals.
-# When the repo is inferred from the working directory (bare number or
-# auto-detect), sets SKIP_REPO_VALIDATION=true to avoid a redundant gh call.
-SKIP_REPO_VALIDATION=false
-
-detect_pr() {
-  local input="${1:-}"
-  if [[ -z "$input" ]]; then
-    # No argument: detect from current branch
-    local pr_url
-    pr_url=$(gh pr view --json url -q '.url' 2>/dev/null) || {
-      log_error "No PR associated with the current branch. Provide a PR URL or number."
-      exit 1
-    }
-    if ! parse_pr_url "$pr_url"; then
-      log_error "Could not parse PR URL from current branch: ${pr_url}"
-      exit 1
-    fi
-    SKIP_REPO_VALIDATION=true
-  elif [[ "$input" =~ ^https://github\.com/ ]]; then
-    if ! parse_pr_url "$input"; then
-      log_error "Invalid GitHub PR URL: ${input}"
-      log_error "Expected format: https://github.com/owner/repo/pull/123"
-      exit 1
-    fi
-  elif [[ "$input" =~ ^[0-9]+$ ]]; then
-    # Bare PR number: infer repo from current directory
-    local repo_full
-    repo_full=$(gh repo view --json nameWithOwner -q '.nameWithOwner' 2>/dev/null) || {
-      log_error "Could not determine repository. Run from inside a repo checkout."
-      exit 1
-    }
-    OWNER="${repo_full%%/*}"
-    REPO_NAME="${repo_full##*/}"
-    REPO="$repo_full"
-    PR_NUMBER="$input"
-    SKIP_REPO_VALIDATION=true
-  else
-    log_error "Unrecognized argument: ${input}"
-    log_error "Provide a PR URL (https://github.com/owner/repo/pull/123), a PR number, or omit to detect from the current branch."
-    exit 1
-  fi
-}
-
 # Validate that the working directory is a checkout of the expected repo.
 validate_working_directory() {
   local expected="$1"
@@ -301,8 +256,8 @@ while [[ $# -gt 0 ]]; do
       MAX_ROUNDS="$2"; shift 2
       ;;
     --max-budget)
-      if [[ ! "${2:-}" =~ ^[0-9]+(\.[0-9]+)?$ ]]; then
-        log_error "--max-budget must be a valid number (e.g., 5.00)"
+      if [[ ! "${2:-}" =~ ^[0-9]+(\.[0-9]+)?$ ]] || [[ "${2:-}" =~ ^0+(\.0+)?$ ]]; then
+        log_error "--max-budget must be a positive number (e.g., 5.00)"
         exit 1
       fi
       MAX_BUDGET="$2"; shift 2
@@ -384,7 +339,7 @@ check_prerequisites() {
 
 main() {
   check_prerequisites
-  detect_pr "$PR_INPUT"
+  resolve_pr_target "$PR_INPUT"
   if [[ "$SKIP_REPO_VALIDATION" != "true" ]]; then
     validate_working_directory "$REPO"
   fi
@@ -405,10 +360,7 @@ main() {
   local total_dismissed=0
 
   for ((round = 1; round <= MAX_ROUNDS; round++)); do
-    echo ""
-    log_info "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-    log_info "Round ${round}/${MAX_ROUNDS}"
-    log_info "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    log_section "Round ${round}/${MAX_ROUNDS}"
 
     # In dry-run mode, skip requesting a new review and fetch the latest existing one
     local review_id
@@ -628,14 +580,11 @@ main() {
   done
 
   # Print summary
-  echo ""
-  log_info "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
   if [[ "$DRY_RUN" == "true" ]]; then
-    log_info "[DRY RUN] Copilot Review Loop Complete"
+    log_section "[DRY RUN] Copilot Review Loop Complete"
   else
-    log_info "Copilot Review Loop Complete"
+    log_section "Copilot Review Loop Complete"
   fi
-  log_info "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
   log_info "PR: ${REPO}#${PR_NUMBER}"
   if [[ "$DRY_RUN" != "true" ]]; then
     log_info "Total fixed: ${total_fixed}"

--- a/bin/lib/github.sh
+++ b/bin/lib/github.sh
@@ -35,26 +35,36 @@ get_current_repo() {
 
 # Resolve a PR argument into OWNER, REPO_NAME, REPO, and PR_NUMBER.
 # Accepts a URL, numeric PR number, or empty string (infers from current branch).
+# Sets SKIP_REPO_VALIDATION=true when the repo is inferred from the working
+# directory (bare number or auto-detect) to avoid a redundant gh call.
 # Returns 0 on success, exits on failure.
 # shellcheck disable=SC2034  # Variables are intentionally set for the caller
+SKIP_REPO_VALIDATION=false
 resolve_pr_target() {
   local pr_arg="${1:-}"
+  SKIP_REPO_VALIDATION=false
   if [[ -z "$pr_arg" ]]; then
-    local pr_json
-    pr_json=$(gh pr view --json number 2>/dev/null) || {
+    local pr_url
+    pr_url=$(gh pr view --json url -q '.url' 2>/dev/null) || {
       log_error "No PR found for the current branch. Specify a PR number or URL."
       exit 1
     }
-    PR_NUMBER=$(echo "$pr_json" | jq -r '.number')
-    REPO=$(get_current_repo)
+    if ! parse_pr_url "$pr_url"; then
+      log_error "Could not parse PR URL from current branch: ${pr_url}"
+      exit 1
+    fi
+    SKIP_REPO_VALIDATION=true
   elif parse_pr_url "$pr_arg"; then
     :
   elif [[ "$pr_arg" =~ ^[0-9]+$ ]]; then
     PR_NUMBER="$pr_arg"
     REPO=$(get_current_repo)
+    OWNER="${REPO%%/*}"
+    REPO_NAME="${REPO##*/}"
+    SKIP_REPO_VALIDATION=true
   else
     log_error "Invalid PR argument: ${pr_arg}"
-    log_error "Expected a PR number or URL."
+    log_error "Expected a PR number or URL (https://github.com/owner/repo/pull/123)."
     exit 1
   fi
   if [[ -z "${OWNER:-}" ]]; then

--- a/bin/lib/logging.sh
+++ b/bin/lib/logging.sh
@@ -9,6 +9,7 @@
 #   log_success - Green [SUCCESS] prefix
 #   log_warn    - Yellow [WARN] prefix
 #   log_error   - Red [ERROR] prefix (outputs to stderr)
+#   log_section - Prints a titled section divider
 
 # Colors for output
 RED='\033[0;31m'
@@ -31,4 +32,11 @@ log_warn() {
 
 log_error() {
   echo -e "${RED}[ERROR]${NC} $1" >&2
+}
+
+log_section() {
+  echo ""
+  log_info "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  log_info "$1"
+  log_info "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 }

--- a/bin/review-fix-loop.sh
+++ b/bin/review-fix-loop.sh
@@ -69,8 +69,8 @@ while [[ $# -gt 0 ]]; do
       MAX_ITERATIONS="$2"; shift 2
       ;;
     --max-budget)
-      if [[ ! "${2:-}" =~ ^[0-9]+(\.[0-9]+)?$ ]]; then
-        log_error "--max-budget must be a valid number (e.g., 5.00)"
+      if [[ ! "${2:-}" =~ ^[0-9]+(\.[0-9]+)?$ ]] || [[ "${2:-}" =~ ^0+(\.0+)?$ ]]; then
+        log_error "--max-budget must be a positive number (e.g., 5.00)"
         exit 1
       fi
       MAX_BUDGET="$2"; shift 2
@@ -179,7 +179,7 @@ main() {
     rm -f "$status_file"
 
     local output_file="${tmpdir}/claude-output-iteration-${iteration}.txt"
-    local prompt="/review-fix-cycle ${REVIEW_TARGET} --iteration ${iteration}"
+    local prompt="/review-fix-cycle${REVIEW_TARGET:+ $REVIEW_TARGET} --iteration ${iteration}"
 
     log_info "Invoking Claude (budget: \$${MAX_BUDGET}, timeout: ${TIMEOUT}s)..."
 
@@ -187,23 +187,31 @@ main() {
     local prompt_file="${tmpdir}/prompt-iteration-${iteration}.txt"
     printf '%s' "$prompt" > "$prompt_file"
 
-    local exit_code=0
-    set +o pipefail
+    local exit_code
+    # Needs broad tool access: chains /review-code, /simplify, and /commit sub-skills
+    set +eo pipefail
     timeout "$TIMEOUT" claude -p \
       --dangerously-skip-permissions \
       --verbose \
       --max-budget-usd "$MAX_BUDGET" \
       < "$prompt_file" 2>&1 \
-      | tee "$output_file" || true
+      | tee "$output_file"
     exit_code=${PIPESTATUS[0]}
-    set -o pipefail
+    set -eo pipefail
+
+    # Only persist output to .notes/ on failure so error messages can reference it
+    local log_file="${repo_root}/.notes/claude-output-iteration-${iteration}.log"
 
     if [[ $exit_code -eq 124 ]]; then
+      cp "$output_file" "$log_file"
       log_error "Claude timed out after ${TIMEOUT}s"
+      log_error "Check output: ${log_file}"
       loop_failed=true
       break
     elif [[ $exit_code -ne 0 ]]; then
+      cp "$output_file" "$log_file"
       log_error "Claude exited with code ${exit_code}"
+      log_error "Check output: ${log_file}"
       loop_failed=true
       break
     fi
@@ -213,8 +221,9 @@ main() {
     if ! read -r clean fixed skipped < <(
       jq -r '[.clean // false, .fixed // 0, .skipped // 0] | @tsv' "$status_file" 2>/dev/null
     ); then
+      cp "$output_file" "$log_file"
       log_error "No valid status file after iteration ${iteration}"
-      log_error "Check output: ${output_file}"
+      log_error "Check output: ${log_file}"
       loop_failed=true
       break
     fi
@@ -260,6 +269,10 @@ main() {
   fi
 
   if [[ "$loop_failed" == "true" ]]; then
+    return 1
+  fi
+
+  if [[ "$final_status" != "Clean" ]]; then
     return 1
   fi
 }

--- a/bin/review-fix-loop.sh
+++ b/bin/review-fix-loop.sh
@@ -170,10 +170,7 @@ main() {
 
   for ((iteration = 1; iteration <= MAX_ITERATIONS; iteration++)); do
     last_iteration=$iteration
-    echo ""
-    log_info "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-    log_info "Iteration ${iteration}/${MAX_ITERATIONS}"
-    log_info "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    log_section "Iteration ${iteration}/${MAX_ITERATIONS}"
 
     # Remove status file so we can detect if the skill wrote a new one
     rm -f "$status_file"
@@ -242,10 +239,7 @@ main() {
   done
 
   # Print summary
-  echo ""
-  log_info "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-  log_info "Review-Fix Loop Complete"
-  log_info "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  log_section "Review-Fix Loop Complete"
 
   local final_status="Unknown"
   if [[ -f "$status_file" ]]; then

--- a/bin/review-fix-loop.sh
+++ b/bin/review-fix-loop.sh
@@ -1,0 +1,267 @@
+#!/usr/bin/env bash
+# review-fix-loop.sh - Automated review-fix-simplify-commit cycle
+#
+# Runs `/review-fix-cycle` in a loop with fresh Claude context per iteration.
+# Stops when the review comes back clean or max iterations are reached.
+#
+# Usage:
+#   review-fix-loop.sh [<review-target>] [OPTIONS]
+#
+# Must be run from within a git repository.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/lib/logging.sh"
+
+# ── Configuration Defaults ───────────────────────────────────────────────────
+
+MAX_ITERATIONS=3
+MAX_BUDGET="5.00"
+TIMEOUT=600
+DRY_RUN=false
+
+# ── Usage ────────────────────────────────────────────────────────────────────
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") [<review-target>] [OPTIONS]
+
+Automated review-fix-simplify-commit cycle. Invokes /review-fix-cycle with
+fresh Claude context per iteration. Stops when the review is clean or max
+iterations are reached.
+
+Must be run from within a git repository.
+
+Arguments:
+  <review-target>       Anything /review-code accepts: PR URL, PR number,
+                        branch name, commit, range. If omitted, auto-detects
+                        PR or current branch.
+
+Options:
+  --max-iterations N    Max review-fix cycles (default: 3)
+  --max-budget USD      Claude budget per iteration in USD (default: 5.00)
+  --timeout SECONDS     Claude timeout per iteration (default: 600)
+  --dry-run             Show what would happen without executing
+  -h, --help            Show this help message
+
+Examples:
+  $(basename "$0")                                # Auto-detect PR or branch
+  $(basename "$0") feature-branch                 # Review specific branch
+  $(basename "$0") https://github.com/o/r/pull/1  # Review specific PR
+  $(basename "$0") --max-iterations 5             # Up to 5 iterations
+  $(basename "$0") --dry-run                      # Preview without running
+EOF
+  exit "${1:-0}"
+}
+
+# ── Argument Parsing ─────────────────────────────────────────────────────────
+
+REVIEW_TARGET=""
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --max-iterations)
+      if [[ ! "${2:-}" =~ ^[1-9][0-9]*$ ]]; then
+        log_error "--max-iterations must be a positive integer"
+        exit 1
+      fi
+      MAX_ITERATIONS="$2"; shift 2
+      ;;
+    --max-budget)
+      if [[ ! "${2:-}" =~ ^[0-9]+(\.[0-9]+)?$ ]]; then
+        log_error "--max-budget must be a valid number (e.g., 5.00)"
+        exit 1
+      fi
+      MAX_BUDGET="$2"; shift 2
+      ;;
+    --timeout)
+      if [[ ! "${2:-}" =~ ^[1-9][0-9]*$ ]]; then
+        log_error "--timeout must be a positive integer"
+        exit 1
+      fi
+      TIMEOUT="$2"; shift 2
+      ;;
+    --dry-run)
+      DRY_RUN=true; shift
+      ;;
+    -h|--help)
+      usage
+      ;;
+    -*)
+      log_error "Unknown option: $1"
+      usage 1
+      ;;
+    *)
+      if [[ -n "$REVIEW_TARGET" ]]; then
+        log_error "Unexpected argument: $1"
+        usage 1
+      fi
+      REVIEW_TARGET="$1"; shift
+      ;;
+  esac
+done
+
+# ── Prerequisites ────────────────────────────────────────────────────────────
+
+check_prerequisites() {
+  if ! command -v claude &> /dev/null; then
+    log_error "Claude CLI not found. Install it first."
+    exit 1
+  fi
+
+  if ! command -v jq &> /dev/null; then
+    log_error "jq not found. Install it: brew install jq"
+    exit 1
+  fi
+
+  if ! command -v timeout &> /dev/null; then
+    log_error "timeout command not found. Install coreutils: brew install coreutils"
+    exit 1
+  fi
+
+  if ! git rev-parse --git-dir > /dev/null 2>&1; then
+    log_error "Not in a git repository."
+    exit 1
+  fi
+
+  if [[ ! -d "$HOME/.claude/skills/review-code" ]]; then
+    log_error "review-code skill not found. Install it first."
+    exit 1
+  fi
+}
+
+# ── Main ─────────────────────────────────────────────────────────────────────
+
+main() {
+  check_prerequisites
+
+  local repo_root
+  repo_root=$(git rev-parse --show-toplevel)
+  local status_file="${repo_root}/.notes/review-cycle-status.json"
+
+  # Ensure .notes directory exists
+  mkdir -p "${repo_root}/.notes"
+
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  trap 'rm -rf "$tmpdir"' EXIT
+
+  log_info "Starting review-fix loop"
+  log_info "Max iterations: ${MAX_ITERATIONS}, Budget per iteration: \$${MAX_BUDGET}, Timeout: ${TIMEOUT}s"
+  if [[ -n "$REVIEW_TARGET" ]]; then
+    log_info "Review target: ${REVIEW_TARGET}"
+  else
+    log_info "Review target: auto-detect"
+  fi
+
+  if [[ "$DRY_RUN" == "true" ]]; then
+    log_warn "Running in DRY RUN mode"
+    log_info "Would run: claude -p --dangerously-skip-permissions --verbose --max-budget-usd ${MAX_BUDGET}"
+    log_info "Prompt: /review-fix-cycle ${REVIEW_TARGET} --iteration 1"
+    log_info "Up to ${MAX_ITERATIONS} iterations"
+    return 0
+  fi
+
+  local total_fixed=0
+  local total_skipped=0
+  local last_iteration=0
+  local loop_failed=false
+
+  for ((iteration = 1; iteration <= MAX_ITERATIONS; iteration++)); do
+    last_iteration=$iteration
+    echo ""
+    log_info "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    log_info "Iteration ${iteration}/${MAX_ITERATIONS}"
+    log_info "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+    # Remove status file so we can detect if the skill wrote a new one
+    rm -f "$status_file"
+
+    local output_file="${tmpdir}/claude-output-iteration-${iteration}.txt"
+    local prompt="/review-fix-cycle ${REVIEW_TARGET} --iteration ${iteration}"
+
+    log_info "Invoking Claude (budget: \$${MAX_BUDGET}, timeout: ${TIMEOUT}s)..."
+
+    # Write prompt to file to avoid shell argument length limits
+    local prompt_file="${tmpdir}/prompt-iteration-${iteration}.txt"
+    printf '%s' "$prompt" > "$prompt_file"
+
+    local exit_code=0
+    set +o pipefail
+    timeout "$TIMEOUT" claude -p \
+      --dangerously-skip-permissions \
+      --verbose \
+      --max-budget-usd "$MAX_BUDGET" \
+      < "$prompt_file" 2>&1 \
+      | tee "$output_file" || true
+    exit_code=${PIPESTATUS[0]}
+    set -o pipefail
+
+    if [[ $exit_code -eq 124 ]]; then
+      log_error "Claude timed out after ${TIMEOUT}s"
+      loop_failed=true
+      break
+    elif [[ $exit_code -ne 0 ]]; then
+      log_error "Claude exited with code ${exit_code}"
+      loop_failed=true
+      break
+    fi
+
+    # Parse status file (handles missing file and corrupt JSON in one shot)
+    local clean fixed skipped
+    if ! read -r clean fixed skipped < <(
+      jq -r '[.clean // false, .fixed // 0, .skipped // 0] | @tsv' "$status_file" 2>/dev/null
+    ); then
+      log_error "No valid status file after iteration ${iteration}"
+      log_error "Check output: ${output_file}"
+      loop_failed=true
+      break
+    fi
+
+    total_fixed=$((total_fixed + fixed))
+    total_skipped=$((total_skipped + skipped))
+
+    log_info "Fixed: ${fixed}, Skipped: ${skipped}"
+
+    if [[ "$clean" = "true" ]]; then
+      log_success "Review came back clean — done!"
+      break
+    fi
+
+    log_success "Iteration ${iteration} complete"
+  done
+
+  # Print summary
+  echo ""
+  log_info "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  log_info "Review-Fix Loop Complete"
+  log_info "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+  local final_status="Unknown"
+  if [[ -f "$status_file" ]]; then
+    local final_clean
+    final_clean=$(jq -r '.clean' "$status_file")
+    if [[ "$final_clean" = "true" ]]; then
+      final_status="Clean"
+    else
+      final_status="Findings remain"
+    fi
+  fi
+
+  log_info "Iterations: ${last_iteration}/${MAX_ITERATIONS}"
+  log_info "Total fixed: ${total_fixed}"
+  log_info "Total skipped: ${total_skipped}"
+  log_info "Status: ${final_status}"
+
+  local skipped_file="${repo_root}/.notes/review-skipped.md"
+  if [[ -f "$skipped_file" ]]; then
+    log_info "Skipped items: ${skipped_file}"
+  fi
+
+  if [[ "$loop_failed" == "true" ]]; then
+    return 1
+  fi
+}
+
+main "$@"

--- a/bin/run-pr-reviews.sh
+++ b/bin/run-pr-reviews.sh
@@ -491,10 +491,7 @@ main() {
   done < <(echo "$pr_list" | jq -c '.[]' | head -n "$MAX_PRS")
 
   # Print summary
-  echo ""
-  log_info "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-  log_info "Review Session Complete"
-  log_info "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  log_section "Review Session Complete"
 
   # Read final session state for summary
   if [[ -f "$SESSION_FILE" ]]; then


### PR DESCRIPTION
## Summary

- Add `review-fix-cycle` skill that runs one review-fix-simplify-commit iteration, designed to be invoked repeatedly with fresh context
- Add `review-fix-loop.sh` wrapper script that runs the skill in a loop, stopping when the review comes back clean or max iterations are reached
- Consolidate PR detection logic into shared `resolve_pr_target` in `bin/lib/github.sh`, removing duplication from `copilot-review-loop.sh`
- Add `log_section` helper to `bin/lib/logging.sh` and use it across scripts
- Reject zero as a `--max-budget` value in `copilot-review-loop.sh`

## Test plan

- Run `review-fix-loop.sh` against an open PR and verify it iterates correctly
- Verify `copilot-review-loop.sh` still works with the refactored `resolve_pr_target`
- Check `--max-budget 0` is rejected with the updated validation