### PR TITLE
Add progress heartbeat for long-running review operations

### DIFF
--- a/bin/copilot-review-loop.sh
+++ b/bin/copilot-review-loop.sh
@@ -347,7 +347,7 @@ main() {
   resume_from_pending_push
 
   TMPDIR_LOOP=$(mktemp -d)
-  trap 'save_state; rm -rf "$TMPDIR_LOOP"' EXIT
+  trap 'stop_heartbeat; save_state; rm -rf "$TMPDIR_LOOP"' EXIT
 
   log_info "Starting Copilot review loop for ${REPO}#${PR_NUMBER}"
   log_info "Max rounds: ${MAX_ROUNDS}, Budget per round: \$${MAX_BUDGET}, Timeout: ${TIMEOUT}s"
@@ -486,12 +486,16 @@ main() {
       )
     fi
 
+    start_heartbeat 30 "Claude reviewing round ${round}"
+
     set +o pipefail
     timeout "$TIMEOUT" "${claude_args[@]}" \
       < "$prompt_file" 2>&1 \
       | tee "$output_file" || true
     exit_code=${PIPESTATUS[0]}
     set -o pipefail
+
+    stop_heartbeat
 
     # Persist Claude's output for debugging, then clean up the temp copy
     local log_file="${STATE_DIR}/${OWNER}-${REPO_NAME}-${PR_NUMBER}-round-${round}.log"

--- a/bin/lib/logging.sh
+++ b/bin/lib/logging.sh
@@ -16,6 +16,7 @@ RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[0;33m'
 BLUE='\033[0;34m'
+DIM='\033[2m'
 NC='\033[0m' # No Color
 
 log_info() {
@@ -39,4 +40,44 @@ log_section() {
   log_info "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
   log_info "$1"
   log_info "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+}
+
+# ── Heartbeat ──────────────────────────────────────────────────────────────
+
+# Global PID for the heartbeat background process
+_HEARTBEAT_PID=""
+
+# Start a background heartbeat that prints elapsed time to stderr every N seconds.
+# IMPORTANT: Must be called from the main shell, not from a subshell or pipeline.
+# If called inside $(...) or a pipe, _HEARTBEAT_PID won't propagate and the
+# process will leak.
+# Usage: start_heartbeat [interval_seconds] [label]
+start_heartbeat() {
+  local interval="${1:-30}"
+  local label="${2:-Working}"
+  stop_heartbeat
+  (
+    exec >/dev/null  # close stdout so we don't hold pipes open
+    trap 'exit 0' TERM
+    local start_time=$SECONDS
+    while true; do
+      # Background sleep + wait so TERM interrupts immediately
+      sleep "$interval" &
+      wait $! 2>/dev/null || exit 0
+      local elapsed=$((SECONDS - start_time))
+      local mins=$((elapsed / 60))
+      local secs=$((elapsed % 60))
+      printf '%b[HEARTBEAT] %s… %dm %02ds elapsed%b\n' "$DIM" "$label" "$mins" "$secs" "$NC" >&2
+    done
+  ) &
+  _HEARTBEAT_PID=$!
+}
+
+# Stop the heartbeat background process. Safe to call when none is running.
+stop_heartbeat() {
+  if [[ -n "${_HEARTBEAT_PID:-}" ]]; then
+    kill "$_HEARTBEAT_PID" 2>/dev/null || true
+    wait "$_HEARTBEAT_PID" 2>/dev/null || true
+    _HEARTBEAT_PID=""
+  fi
 }

--- a/bin/lib/test-heartbeat.sh
+++ b/bin/lib/test-heartbeat.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+# Tests for start_heartbeat/stop_heartbeat in logging.sh.
+#
+# Usage: test-heartbeat.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# shellcheck source=bin/lib/logging.sh
+source "$SCRIPT_DIR/logging.sh"
+
+passes=0
+failures=0
+
+assert() {
+    local description="$1"
+    shift
+    local rc=0
+    "$@" || rc=$?
+    if [[ "$rc" -eq 0 ]]; then
+        passes=$((passes + 1))
+    else
+        echo "FAIL: $description"
+        failures=$((failures + 1))
+    fi
+}
+
+assert_not() {
+    local description="$1"
+    shift
+    local rc=0
+    "$@" || rc=$?
+    if [[ "$rc" -ne 0 ]]; then
+        passes=$((passes + 1))
+    else
+        echo "FAIL: $description"
+        failures=$((failures + 1))
+    fi
+}
+
+# ── Test: start_heartbeat sets a valid PID ─────────────────────────────────
+
+start_heartbeat 60 "test"
+assert "PID is set after start" test -n "$_HEARTBEAT_PID"
+assert "PID is a running process" kill -0 "$_HEARTBEAT_PID"
+stop_heartbeat
+
+# ── Test: stop_heartbeat clears PID and kills process ──────────────────────
+
+start_heartbeat 60 "test"
+saved_pid="$_HEARTBEAT_PID"
+stop_heartbeat
+assert "PID is cleared after stop" test -z "$_HEARTBEAT_PID"
+assert_not "Process is no longer running" kill -0 "$saved_pid" 2>/dev/null
+
+# ── Test: stop_heartbeat is safe when nothing is running ───────────────────
+
+_HEARTBEAT_PID=""
+stop_heartbeat
+assert "No error calling stop when already stopped" test -z "$_HEARTBEAT_PID"
+
+# ── Test: double start kills the first process ─────────────────────────────
+
+start_heartbeat 60 "first"
+first_pid="$_HEARTBEAT_PID"
+start_heartbeat 60 "second"
+assert "PID changed on second start" test "$_HEARTBEAT_PID" != "$first_pid"
+assert_not "First process was killed" kill -0 "$first_pid" 2>/dev/null
+assert "Second process is running" kill -0 "$_HEARTBEAT_PID"
+stop_heartbeat
+
+# ── Test: heartbeat printf uses stderr ─────────────────────────────────────
+# Verified by inspecting the printf format string which ends with >&2.
+# A runtime test would require fd gymnastics that complicate the test
+# more than they're worth for a single line of code.
+
+# ── Results ────────────────────────────────────────────────────────────────
+
+echo ""
+echo "Results: $passes passed, $failures failed"
+[[ "$failures" -eq 0 ]]

--- a/bin/run-pr-reviews.sh
+++ b/bin/run-pr-reviews.sh
@@ -334,7 +334,12 @@ run_review() {
   local exit_code=0
   local output_file
   output_file=$(mktemp)
-  timeout "$REVIEW_TIMEOUT_SECONDS" claude -p --max-budget-usd "$MAX_BUDGET" "/review-code ${pr_url} --force --draft" 2>&1 | tee "$output_file" || exit_code=${PIPESTATUS[0]}
+  start_heartbeat 30 "Claude reviewing PR #${pr_number}"
+  set +o pipefail
+  timeout "$REVIEW_TIMEOUT_SECONDS" claude -p --max-budget-usd "$MAX_BUDGET" "/review-code ${pr_url} --force --draft" 2>&1 | tee "$output_file" || true
+  exit_code=${PIPESTATUS[0]}
+  set -o pipefail
+  stop_heartbeat
 
   local end_time
   end_time=$(date +%s)
@@ -404,7 +409,7 @@ run_review() {
 # Main execution
 main() {
   # Save session state on exit (atomic write)
-  trap 'save_session' EXIT
+  trap 'stop_heartbeat; save_session' EXIT
 
   check_prerequisites
 


### PR DESCRIPTION
## Summary

- Add `start_heartbeat`/`stop_heartbeat` functions to `bin/lib/logging.sh` that print elapsed time to stderr at a configurable interval, providing visibility into long-running Claude review operations
- Integrate heartbeat into `copilot-review-loop.sh` and `run-pr-reviews.sh` so operators see periodic progress updates during review rounds
- Include comprehensive tests in `bin/lib/test-heartbeat.sh`

## Test plan

- Run `bash bin/lib/test-heartbeat.sh` and verify all assertions pass
- Run a PR review loop and confirm heartbeat messages appear on stderr every 30 seconds during Claude invocations
- Verify heartbeat stops cleanly on completion and on EXIT trap