### PR TITLE
Collapse previous Copilot review comments each round

### DIFF
--- a/bin/copilot-review-loop.sh
+++ b/bin/copilot-review-loop.sh
@@ -382,6 +382,11 @@ main() {
     fi
     log_success "Copilot review: ${review_id}"
 
+    # Minimize previous Copilot review top-level comments so only this one shows
+    if [[ "$DRY_RUN" != "true" ]]; then
+      minimize_copilot_reviews --exclude "$review_id"
+    fi
+
     # Fetch inline comments for the review
     local comments
     comments=$(fetch_review_comments "$review_id")

--- a/bin/lib/copilot.sh
+++ b/bin/lib/copilot.sh
@@ -16,6 +16,7 @@
 #   request_copilot_review    - Request a Copilot review on the PR
 #   get_copilot_review_for_head - Get or request+poll a review for the current HEAD
 #   fetch_review_comments     - Fetch inline comments for a given review ID
+#   minimize_copilot_reviews  - Collapse previous Copilot review top-level comments
 
 # The short name "copilot" silently no-ops on the requested_reviewers endpoint.
 # The full bot login is required to actually trigger a review.
@@ -143,4 +144,67 @@ fetch_review_comments() {
   local review_id="$1"
   gh api "repos/${REPO}/pulls/${PR_NUMBER}/reviews/${review_id}/comments" \
     --jq '[.[] | {id, path, line, body, diff_hunk}]'
+}
+
+# Minimize (collapse) previous Copilot review top-level comments so only the
+# current review's summary remains visible. Accepts an optional --exclude ID
+# to skip the current round's review.
+#
+# Usage: minimize_copilot_reviews [--exclude REVIEW_ID]
+minimize_copilot_reviews() {
+  local exclude_id=""
+  while [[ $# -gt 0 ]]; do
+    case $1 in
+      --exclude) exclude_id="$2"; shift 2 ;;
+      *)
+        log_warn "minimize_copilot_reviews: unknown argument: $1"
+        return 1
+        ;;
+    esac
+  done
+
+  local reviews
+  reviews=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/reviews" \
+    --jq '[.[] | select(.user.login | test("copilot"; "i")) | {id, node_id, body}]' 2>/dev/null) || {
+    log_warn "Failed to fetch reviews for minimization"
+    return 0
+  }
+
+  # Filter to reviews with non-empty bodies, excluding the current one
+  local to_minimize
+  to_minimize=$(echo "$reviews" | jq --arg exclude "$exclude_id" \
+    '[.[] | select(.body != null and .body != "" and (.id | tostring) != $exclude)]')
+
+  local count
+  count=$(echo "$to_minimize" | jq 'length')
+  if [[ "$count" -eq 0 ]]; then
+    return 0
+  fi
+
+  log_info "Minimizing ${count} previous Copilot review comment(s)…"
+
+  local mutation='
+    mutation($id: ID!) {
+      minimizeComment(input: {subjectId: $id, classifier: OUTDATED}) {
+        minimizedComment { isMinimized }
+      }
+    }
+  '
+
+  local minimized=0
+  local node_id
+  while IFS= read -r node_id; do
+    if gh api graphql \
+      -f query="$mutation" \
+      -f id="$node_id" \
+      --silent 2>/dev/null; then
+      minimized=$((minimized + 1))
+    else
+      log_warn "Failed to minimize review comment (node: ${node_id})"
+    fi
+  done < <(echo "$to_minimize" | jq -r '.[].node_id')
+
+  if [[ "$minimized" -gt 0 ]]; then
+    log_success "Minimized ${minimized} previous review comment(s)"
+  fi
 }

--- a/bin/lib/test-copilot-filter.sh
+++ b/bin/lib/test-copilot-filter.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# Tests for the jq filtering logic used by minimize_copilot_reviews in copilot.sh.
+#
+# Usage: test-copilot-filter.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# shellcheck source=bin/lib/test-helpers.sh
+source "$SCRIPT_DIR/test-helpers.sh"
+
+# The jq filter extracted from minimize_copilot_reviews (copilot.sh:175-176)
+filter_reviews() {
+    local exclude_id="$1"
+    local reviews_json="$2"
+    echo "$reviews_json" | jq --arg exclude "$exclude_id" \
+        '[.[] | select(.body != null and .body != "" and (.id | tostring) != $exclude)]'
+}
+
+# ── Test data ─────────────────────────────────────────────────────────────
+
+reviews='[
+  {"id": 100, "node_id": "PRR_a", "body": "Copilot reviewed 3 of 5 files"},
+  {"id": 200, "node_id": "PRR_b", "body": "Copilot reviewed 5 of 5 files"},
+  {"id": 300, "node_id": "PRR_c", "body": ""},
+  {"id": 400, "node_id": "PRR_d", "body": null},
+  {"id": 500, "node_id": "PRR_e", "body": "Copilot reviewed 2 of 5 files"}
+]'
+
+# ── Test: excludes specified ID and filters empty/null bodies ─────────────
+
+result=$(filter_reviews "200" "$reviews")
+count=$(echo "$result" | jq 'length')
+assert "excludes ID 200 and empty bodies, keeps 2" test "$count" -eq 2
+ids=$(echo "$result" | jq -c '[.[].id] | sort')
+assert "keeps IDs 100 and 500" test "$ids" = "[100,500]"
+
+# ── Test: excludes nothing when ID doesn't match ─────────────────────────
+
+result=$(filter_reviews "999" "$reviews")
+count=$(echo "$result" | jq 'length')
+assert "keeps all 3 non-empty reviews when exclude misses" test "$count" -eq 3
+
+# ── Test: empty exclude string keeps all non-empty reviews ────────────────
+
+result=$(filter_reviews "" "$reviews")
+count=$(echo "$result" | jq 'length')
+assert "empty exclude keeps all 3 non-empty reviews" test "$count" -eq 3
+
+# ── Test: empty input array ───────────────────────────────────────────────
+
+result=$(filter_reviews "100" "[]")
+count=$(echo "$result" | jq 'length')
+assert "empty input returns empty output" test "$count" -eq 0
+
+# ── Test: all reviews excluded or empty ───────────────────────────────────
+
+sparse='[{"id": 100, "node_id": "PRR_a", "body": "only one"}]'
+result=$(filter_reviews "100" "$sparse")
+count=$(echo "$result" | jq 'length')
+assert "single review excluded returns empty" test "$count" -eq 0
+
+# ── Test: numeric ID comparison works via tostring ────────────────────────
+# The exclude arg is always a string; .id is numeric in the JSON.
+# The filter uses (.id | tostring) to bridge the types.
+
+result=$(filter_reviews "100" "$reviews")
+first_id=$(echo "$result" | jq '.[0].id')
+assert "numeric-to-string comparison excludes ID 100" test "$first_id" -eq 200
+
+# ── Test: node_id values survive filtering for mutation targets ───────────
+
+result=$(filter_reviews "100" "$reviews")
+node_ids=$(echo "$result" | jq -c '[.[].node_id] | sort')
+assert "filtered results preserve correct node_ids" test "$node_ids" = '["PRR_b","PRR_e"]'
+
+# ── Results ───────────────────────────────────────────────────────────────
+
+print_results

--- a/bin/lib/test-heartbeat.sh
+++ b/bin/lib/test-heartbeat.sh
@@ -9,35 +9,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # shellcheck source=bin/lib/logging.sh
 source "$SCRIPT_DIR/logging.sh"
-
-passes=0
-failures=0
-
-assert() {
-    local description="$1"
-    shift
-    local rc=0
-    "$@" || rc=$?
-    if [[ "$rc" -eq 0 ]]; then
-        passes=$((passes + 1))
-    else
-        echo "FAIL: $description"
-        failures=$((failures + 1))
-    fi
-}
-
-assert_not() {
-    local description="$1"
-    shift
-    local rc=0
-    "$@" || rc=$?
-    if [[ "$rc" -ne 0 ]]; then
-        passes=$((passes + 1))
-    else
-        echo "FAIL: $description"
-        failures=$((failures + 1))
-    fi
-}
+# shellcheck source=bin/lib/test-helpers.sh
+source "$SCRIPT_DIR/test-helpers.sh"
 
 # ── Test: start_heartbeat sets a valid PID ─────────────────────────────────
 
@@ -77,6 +50,4 @@ stop_heartbeat
 
 # ── Results ────────────────────────────────────────────────────────────────
 
-echo ""
-echo "Results: $passes passed, $failures failed"
-[[ "$failures" -eq 0 ]]
+print_results

--- a/bin/lib/test-helpers.sh
+++ b/bin/lib/test-helpers.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# Shared test helpers for bin/lib/ test scripts.
+#
+# Usage: source "$SCRIPT_DIR/test-helpers.sh"
+#
+# Provides assert/assert_not functions and a print_results finalizer.
+# Each test file should call print_results at the end.
+
+passes=0
+failures=0
+
+assert() {
+    local description="$1"
+    shift
+    local rc=0
+    "$@" || rc=$?
+    if [[ "$rc" -eq 0 ]]; then
+        passes=$((passes + 1))
+    else
+        echo "FAIL: $description"
+        failures=$((failures + 1))
+    fi
+}
+
+assert_not() {
+    local description="$1"
+    shift
+    local rc=0
+    "$@" || rc=$?
+    if [[ "$rc" -ne 0 ]]; then
+        passes=$((passes + 1))
+    else
+        echo "FAIL: $description"
+        failures=$((failures + 1))
+    fi
+}
+
+print_results() {
+    echo ""
+    echo "Results: $passes passed, $failures failed"
+    [[ "$failures" -eq 0 ]]
+}


### PR DESCRIPTION
## Summary
- Add `minimize_copilot_reviews` function to `copilot.sh` that uses the GitHub GraphQL `minimizeComment` mutation to collapse all prior Copilot review top-level comments, leaving only the latest visible
- Integrate it into `copilot-review-loop.sh` so previous review summaries are automatically collapsed each cycle (skipped in dry-run mode)
- Extract shared `assert`/`assert_not` test helpers into `test-helpers.sh` and add `test-copilot-filter.sh` covering the jq filtering logic

## Test plan
- Run `bash bin/lib/test-copilot-filter.sh` — all 8 assertions pass
- Run `bash bin/lib/test-heartbeat.sh` — existing tests still pass with shared helpers
- Run `copilot-review-loop.sh` on a PR with multiple Copilot reviews and verify previous comments are minimized