### PR TITLE
Add ci-monitor skill for GitHub CI monitoring

### DIFF
--- a/ai/skills/ci-monitor/SKILL.md
+++ b/ai/skills/ci-monitor/SKILL.md
@@ -1,0 +1,171 @@
+---
+name: ci-monitor
+description: Monitor CI checks after pushing, detect flaky vs legit failures, and auto-fix
+argument-hint: "[<pr-number>|<pr-url>|--no-fix|--timeout <min>]"
+allowed-tools: Bash(~/.claude/skills/ci-monitor/scripts/*:*, sleep:*, gh:*, git:*), Read(~/.claude/skills/ci-monitor/**), Write, Edit
+---
+
+Monitor GitHub CI checks for the current PR, wait for completion, classify failures as flaky or legit, and guide fixes for legit failures.
+
+**Arguments:**
+
+- `(no argument)` - Detect PR from current branch
+- `<pr-number>` - Monitor checks for a specific PR (e.g., `123`)
+- `<pr-url>` - Monitor checks for PR by URL (e.g., `https://github.com/org/repo/pull/123`)
+
+**Optional Flags:**
+
+- `--no-fix` - Monitor and report only; do not attempt fixes
+- `--timeout <minutes>` - Override default 30-minute timeout
+
+**Usage examples:**
+
+- `/ci-monitor` - Monitor CI for current branch's PR
+- `/ci-monitor 123` - Monitor CI for PR #123
+- `/ci-monitor --no-fix` - Monitor only, report failures without fixing
+- `/ci-monitor https://github.com/org/repo/pull/123 --timeout 45`
+
+---
+
+## Implementation
+
+**CRITICAL:** Follow these steps in order. If any step fails, inform the user and stop.
+
+### Step 1: Parse Arguments
+
+Extract the PR identifier and flags from `$ARGUMENTS`.
+
+**Flags to detect:**
+- `--no-fix` - Set `NO_FIX=true`
+- `--timeout <N>` - Set `TIMEOUT_MINUTES=N` (default: 30)
+
+Remove flags from the argument string, leaving just the PR identifier (number, URL, or empty).
+
+Run the detection script:
+
+```bash
+~/.claude/skills/ci-monitor/scripts/ci-detect-pr.sh ${PR_IDENTIFIER:+"$PR_IDENTIFIER"} 2>&1
+```
+
+Save the output as `PR_DATA`. If the `error` field is non-null, display the error and stop.
+
+Extract and save: `PR_NUMBER`, `ORG`, `REPO`, `HEAD_BRANCH`.
+
+Tell the user: "Monitoring CI checks for PR #$PR_NUMBER ($ORG/$REPO)…"
+
+Record the current time as `START_TIME` for timeout tracking.
+
+Initialize `RETRY_COUNT=0` and `MAX_RETRIES=3`.
+
+### Step 2: Check CI Status
+
+Run the status check:
+
+```bash
+~/.claude/skills/ci-monitor/scripts/ci-check-status.sh $PR_NUMBER "$ORG/$REPO" 2>&1
+```
+
+Save the output as `CHECK_DATA`.
+
+**Route based on status:**
+
+- If `status` is `"no_checks"`: Tell the user "No CI checks found for this PR." and stop.
+- If `all_passed` is `true`: Report "All CI checks passed!" with a summary of check counts and stop.
+- If `status` is `"in_progress"`: Go to **Step 3** (Polling Loop).
+- If `status` is `"completed"` and there are failures: Go to **Step 4** (Triage Failures).
+- If `status` is `"completed"`, there are **no** failures, and `all_passed` is `false` (for example, all remaining checks are skipped, cancelled, or neutral): Report that CI checks have completed with no failures, show a final summary including all buckets (passed, skipped, cancelled, neutral, etc.), and stop.
+
+### Step 3: Polling Loop
+
+Checks are still running. Report progress:
+
+"CI checks in progress: $PASSED/$TOTAL passed, $PENDING pending. Checking again in 30 seconds…"
+
+Wait 30 seconds:
+
+```bash
+sleep 30
+```
+
+**Check timeout:** Calculate elapsed time. If elapsed exceeds `TIMEOUT_MINUTES * 60` seconds, tell the user "Timeout reached after $TIMEOUT_MINUTES minutes. $PENDING checks still pending." and show the current check status. Stop.
+
+Go back to **Step 2** to re-check status.
+
+### Step 4: Triage Failures
+
+For each failed check in the `failed_checks` array:
+
+**4a. Fetch failure logs:**
+
+If the check has a `run_id`:
+
+```bash
+~/.claude/skills/ci-monitor/scripts/ci-fetch-logs.sh $RUN_ID "$ORG/$REPO" 2>&1
+```
+
+Save as `LOG_DATA`.
+
+If the check does **not** have a `run_id` (e.g., a non-GitHub Actions status check):
+- Mark it as `uncertain` — no logs are available to classify it
+- Report the check name and link to the user
+- Do not attempt to classify, re-run via `gh run rerun`, or auto-fix this check
+- Skip steps 4b and 4c for this check; move on to the next failed check
+
+**4b. Classify failure:**
+
+Pass the log excerpt via stdin to the classifier:
+
+```bash
+printf '%s\n' "$LOG_EXCERPT" | ~/.claude/skills/ci-monitor/scripts/ci-classify-failure.sh $PR_NUMBER "$WORKFLOW_NAME" "$ORG/$REPO" 2>&1
+```
+
+Where `$LOG_EXCERPT` is the combined `log_excerpt` from all failed jobs in `LOG_DATA`, and `$WORKFLOW_NAME` is the check's `workflow` field.
+
+Save as `CLASSIFICATION`.
+
+**4c. Present findings to the user:**
+
+For each failure, report:
+- Check name and link
+- Classification: flaky / legit / uncertain
+- Confidence score
+- Reasoning (why classified this way)
+- Key log excerpt (first 20-30 relevant lines)
+
+**4d. Handle by classification:**
+
+**All flaky:** Report as flaky. Ask the user: "All failures appear to be flaky. Re-run failed workflows?" If yes, for each failed check with a `run_id`:
+
+```bash
+gh run rerun $RUN_ID --failed --repo "$ORG/$REPO"
+```
+
+Then go back to **Step 2** to monitor the re-run (this does NOT count against `RETRY_COUNT`).
+
+**All legit or mixed (with `--no-fix`):** Report the findings and stop. Do not attempt fixes.
+
+**All legit or mixed (without `--no-fix`):** Build `LEGIT_FAILURES` (see below), then go to **Step 5**.
+
+**Uncertain classifications:** Present your own analysis of the log excerpt alongside the automated classification. Use your judgment to refine the classification before proceeding. Treat uncertain failures you judge to be legit the same as legit failures when building `LEGIT_FAILURES`.
+
+**Building `LEGIT_FAILURES`:** Before entering Step 5, construct an enriched array containing one entry per legit or uncertain failure. Each entry must include:
+- `check_name` — the check's name
+- `check_link` — the check's URL
+- `run_id` — the run ID (may be null for non-Actions checks)
+- `workflow` — the workflow name
+- `log_data` — the `LOG_DATA` object fetched in step 4a
+- `classification` — the full `CLASSIFICATION` object from step 4b
+
+This array is what the fix handler refers to as `failed_checks`.
+
+### Step 5: Fix Cycle
+
+Check `RETRY_COUNT`: if `>= MAX_RETRIES`, tell the user "Max fix retries (${MAX_RETRIES}) reached. Please investigate manually." and stop.
+
+Load the fix handler:
+
+```
+Read ~/.claude/skills/ci-monitor/handlers/fix.md
+```
+
+Follow the instructions in the handler. After the handler completes (fix committed and pushed), increment `RETRY_COUNT` and go back to **Step 2** to monitor the new push.

--- a/ai/skills/ci-monitor/handlers/fix.md
+++ b/ai/skills/ci-monitor/handlers/fix.md
@@ -1,0 +1,92 @@
+# Fix Handler
+
+Fix legit CI failures based on error logs, commit, and push.
+
+## Prerequisites
+
+Before this handler runs, the following variables should be available from SKILL.md:
+- `PR_NUMBER` - The PR number
+- `ORG` - The GitHub organization or user
+- `REPO` - The repository name
+- `RETRY_COUNT` - Current fix attempt number
+- `failed_checks` - Array of legit/uncertain failures with their log data and classifications
+
+## Instructions
+
+### 1. Present Diagnosis
+
+For each legit or uncertain failure, show:
+- Check name and URL
+- Classification and confidence
+- The most relevant portion of the log excerpt (focus on the actual error, not setup/teardown output)
+- Your analysis of what went wrong
+
+### 2. Ask for Approval
+
+Use AskUserQuestion:
+- Question: "Found N legit CI failure(s). Attempt to fix?"
+- Options:
+  1. "Fix all" - Attempt to fix all legit failures
+  2. "Skip" - Report only, do not fix
+  3. "Re-run instead" - Re-run the failed workflows (treat as potentially flaky)
+
+If user selects "Skip", stop and return to SKILL.md (do not fix).
+
+If user selects "Re-run instead", iterate over `failed_checks` and re-run each entry that has a non-null `run_id`:
+```bash
+# For each failure in failed_checks where run_id is not null, using that entry's run_id:
+gh run rerun "$run_id" --failed --repo "$ORG/$REPO"
+```
+Return to SKILL.md to re-monitor.
+
+### 3. Diagnose and Fix
+
+For each failure the user approved:
+
+**3a. Understand the error:**
+- Read the full log excerpt carefully
+- Identify the specific error message, failing test, or build error
+- Determine which file(s) are involved
+
+**3b. Read the relevant code:**
+- Read the files referenced in the error
+- Understand the context around the failing code
+
+**3c. Apply the fix:**
+- Make targeted, minimal changes to fix the specific error
+- Do not refactor or improve unrelated code
+- If the fix requires changes you are not confident about, tell the user what you think the issue is and ask for guidance instead of guessing
+
+**3d. Verify locally if possible:**
+- If you can identify the test command from the error log (e.g., `pytest`, `npm test`, `cargo test`), run the specific failing test locally
+- If local verification passes, proceed
+- If local verification fails, investigate further before committing
+- If you cannot determine how to run the test locally, skip local verification
+
+### 4. Commit and Push
+
+Stage only the files you changed:
+```bash
+git add <changed-files>
+```
+
+Commit with a descriptive message:
+```bash
+git commit -m "Fix CI: <brief description of fix>"
+```
+
+Push to the branch:
+```bash
+git push
+```
+
+### 5. Return
+
+After pushing, return control to SKILL.md. The main flow will increment `RETRY_COUNT` and go back to polling.
+
+## Safety Rules
+
+- **Never force-push.** If `git push` fails, inform the user.
+- **Never commit unrelated files.** Only stage files you explicitly changed.
+- **Never guess at fixes you are not confident about.** Ask the user instead.
+- **Never modify CI configuration files** (workflow YAML, Dockerfiles, etc.) without explicit user approval.

--- a/ai/skills/ci-monitor/scripts/ci-check-status.sh
+++ b/ai/skills/ci-monitor/scripts/ci-check-status.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# ci-check-status.sh - Check CI status for a PR
+#
+# Usage:
+#   ci-check-status.sh <pr_number> [<org/repo>]
+#
+# Output: JSON with overall status, pass/fail counts, and per-check details
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=helpers/ci-helpers.sh
+source "${SCRIPT_DIR}/helpers/ci-helpers.sh"
+ci_require_cmds gh jq git
+
+pr_number="${1:?Usage: ci-check-status.sh <pr_number> [<org/repo>]}"
+repo_arg="${2:-}"
+
+repo_flag=($(ci_build_repo_flag "${repo_arg}"))
+
+# ── Fetch check status ──────────────────────────────────────────────────────
+
+# gh pr checks returns structured JSON with check details
+checks_json=$(gh pr checks "${pr_number}" \
+    "${repo_flag[@]}" \
+    --json name,state,bucket,link,workflow,event \
+    2> /dev/null) || {
+    ci_json_error "Could not fetch checks for PR #${pr_number}"
+    exit 0
+}
+
+# Count checks by state in a single jq call
+read -r total passed failed pending < <(echo "${checks_json}" | jq -r '[
+    length,
+    ([.[] | select(.bucket == "pass")] | length),
+    ([.[] | select(.bucket == "fail")] | length),
+    ([.[] | select(.bucket == "pending")] | length)
+  ] | @tsv')
+
+if [[ "${total}" -eq 0 ]]; then
+    jq -n '{
+    status: "no_checks",
+    all_passed: false,
+    total: 0,
+    passed: 0,
+    failed: 0,
+    pending: 0,
+    checks: [],
+    failed_checks: []
+  }'
+    exit 0
+fi
+
+# Determine overall status
+if [[ "${pending}" -gt 0 ]]; then
+    status="in_progress"
+else
+    status="completed"
+fi
+
+all_passed="false"
+if [[ "${failed}" -eq 0 ]] && [[ "${pending}" -eq 0 ]] && [[ "${passed}" -gt 0 ]]; then
+    all_passed="true"
+fi
+
+# ── Get run IDs for failed checks ───────────────────────────────────────────
+# We need run IDs to fetch failure logs. gh pr checks doesn't provide them,
+# so we cross-reference with gh run list.
+
+runs_json="[]"
+head_sha=""
+if [[ "${failed}" -gt 0 ]]; then
+    pr_ref_json=$(gh pr view "${pr_number}" "${repo_flag[@]}" --json headRefName,headRefOid 2> /dev/null || echo "{}")
+    head_branch=$(echo "${pr_ref_json}" | jq -r '.headRefName // ""')
+    head_sha=$(echo "${pr_ref_json}" | jq -r '.headRefOid // ""')
+    if [[ -n "${head_branch}" ]]; then
+        runs_json=$(gh run list \
+            --branch "${head_branch}" \
+            "${repo_flag[@]}" \
+            --limit 20 \
+            --json databaseId,status,conclusion,name,workflowName,headSha \
+            2> /dev/null) || runs_json="[]"
+    fi
+fi
+
+# ── Build output ─────────────────────────────────────────────────────────────
+
+# Enrich failed checks with run IDs by matching workflow name and head SHA.
+# Matching on headSha ensures we pick the run for the current commit, not a
+# stale rerun or manual trigger on an older SHA.
+enriched_checks=$(echo "${checks_json}" | jq --argjson runs "${runs_json}" --arg head_sha "${head_sha}" '
+  [.[] | . as $check |
+    {
+      name: .name,
+      state: .state,
+      bucket: .bucket,
+      workflow: .workflow.name,
+      link: .link,
+      run_id: (
+        if .bucket == "fail" then
+          ($runs | map(select(
+            (.conclusion == "failure") and
+            (.workflowName == $check.workflow.name) and
+            ($head_sha == "" or .headSha == $head_sha)
+          )) | first | .databaseId // null)
+        else null end
+      )
+    }
+  ]
+')
+
+failed_checks=$(echo "${enriched_checks}" | jq '[.[] | select(.bucket == "fail")]')
+
+jq -n \
+    --arg status "${status}" \
+    --argjson all_passed "${all_passed}" \
+    --argjson total "${total}" \
+    --argjson passed "${passed}" \
+    --argjson failed "${failed}" \
+    --argjson pending "${pending}" \
+    --argjson checks "${enriched_checks}" \
+    --argjson failed_checks "${failed_checks}" \
+    '{
+    status: $status,
+    all_passed: $all_passed,
+    total: $total,
+    passed: $passed,
+    failed: $failed,
+    pending: $pending,
+    checks: $checks,
+    failed_checks: $failed_checks
+  }'

--- a/ai/skills/ci-monitor/scripts/ci-check-status.sh
+++ b/ai/skills/ci-monitor/scripts/ci-check-status.sh
@@ -16,7 +16,8 @@ ci_require_cmds gh jq git
 pr_number="${1:?Usage: ci-check-status.sh <pr_number> [<org/repo>]}"
 repo_arg="${2:-}"
 
-repo_flag=($(ci_build_repo_flag "${repo_arg}"))
+repo_flag=()
+ci_repo_flag repo_flag "${repo_arg}"
 
 # ── Fetch check status ──────────────────────────────────────────────────────
 

--- a/ai/skills/ci-monitor/scripts/ci-classify-failure.sh
+++ b/ai/skills/ci-monitor/scripts/ci-classify-failure.sh
@@ -19,7 +19,8 @@ pr_number="${1:?Usage: ci-classify-failure.sh <pr_number> <workflow_name> [<org/
 workflow_name="${2:?Usage: ci-classify-failure.sh <pr_number> <workflow_name> [<org/repo>]}"
 repo_arg="${3:-}"
 
-repo_flag=($(ci_build_repo_flag "${repo_arg}"))
+repo_flag=()
+ci_repo_flag repo_flag "${repo_arg}"
 
 # Read log excerpt from stdin
 log_excerpt=$(cat)
@@ -57,33 +58,31 @@ changed_file_matches=""
 changed_files=$(ci_get_pr_changed_files "${pr_number}" "${repo_arg}")
 
 if [[ -n "${changed_files}" ]] && [[ -n "${log_excerpt}" ]]; then
-    matched_files=()
+    declare -A seen_files=()
+    # Build a pattern file with full paths and basenames for a single grep pass
+    patterns=""
+    declare -A file_for_pattern=()
     while IFS= read -r file; do
         [[ -z "${file}" ]] && continue
-        # Check if the file path appears in the log
-        if grep -qF -- "${file}" <<< "${log_excerpt}"; then
-            matched_files+=("${file}")
-        fi
-        # Also check just the filename (tests often reference basenames)
+        patterns+="${file}"$'\n'
+        file_for_pattern["${file}"]="${file}"
         basename_file="${file##*/}"
-        if grep -qF -- "${basename_file}" <<< "${log_excerpt}"; then
-            # Avoid duplicates (use literal string comparison)
-            already_matched=false
-            for m in "${matched_files[@]:-}"; do
-                if [[ "${m}" == "${file}" ]]; then
-                    already_matched=true
-                    break
-                fi
-            done
-            if [[ "${already_matched}" == "false" ]]; then
-                matched_files+=("${file}")
-            fi
-        fi
+        patterns+="${basename_file}"$'\n'
+        file_for_pattern["${basename_file}"]="${file}"
     done <<< "${changed_files}"
 
-    if [[ ${#matched_files[@]} -gt 0 ]]; then
+    if [[ -n "${patterns}" ]]; then
+        matched_patterns=$(grep -oF -- "${patterns%$'\n'}" <<< "${log_excerpt}" 2>/dev/null | sort -u) || true
+        while IFS= read -r pat; do
+            [[ -z "${pat}" ]] && continue
+            file="${file_for_pattern["${pat}"]:-}"
+            [[ -n "${file}" ]] && seen_files["${file}"]=1
+        done <<< "${matched_patterns}"
+    fi
+
+    if [[ ${#seen_files[@]} -gt 0 ]]; then
         references_changed_files="true"
-        changed_file_matches=$(printf '%s, ' "${matched_files[@]}")
+        changed_file_matches=$(printf '%s, ' "${!seen_files[@]}")
         changed_file_matches="${changed_file_matches%, }"
     fi
 fi
@@ -114,13 +113,10 @@ flaky_patterns=(
 )
 
 if [[ -n "${log_excerpt}" ]]; then
-    for pattern in "${flaky_patterns[@]}"; do
-        if grep -qiF -- "${pattern}" <<< "${log_excerpt}"; then
-            known_flaky_pattern="true"
-            flaky_pattern_match="${pattern}"
-            break
-        fi
-    done
+    flaky_pattern_match=$(grep -oiFf <(printf '%s\n' "${flaky_patterns[@]}") <<< "${log_excerpt}" | head -1) || true
+    if [[ -n "${flaky_pattern_match}" ]]; then
+        known_flaky_pattern="true"
+    fi
 fi
 
 # ── Combine signals ──────────────────────────────────────────────────────────
@@ -174,7 +170,7 @@ else
     confidence_raw=$((50 - score))
 fi
 # Scale to 0.5-1.0 range (0.5 at score 50, 1.0 at max distance 50)
-confidence=$(awk "BEGIN { printf \"%.2f\", 0.5 + (${confidence_raw} / 100.0) }")
+confidence=$(awk -v raw="${confidence_raw}" 'BEGIN { printf "%.2f", 0.5 + (raw / 100.0) }')
 
 # ── Output ───────────────────────────────────────────────────────────────────
 

--- a/ai/skills/ci-monitor/scripts/ci-classify-failure.sh
+++ b/ai/skills/ci-monitor/scripts/ci-classify-failure.sh
@@ -1,0 +1,201 @@
+#!/usr/bin/env bash
+# ci-classify-failure.sh - Classify a CI failure as flaky or legit
+#
+# Usage:
+#   ci-classify-failure.sh <pr_number> <workflow_name> [<org/repo>]
+#
+# Reads log_excerpt from stdin.
+#
+# Output: JSON with classification (flaky/legit/uncertain), confidence, reasoning, signals
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=helpers/ci-helpers.sh
+source "${SCRIPT_DIR}/helpers/ci-helpers.sh"
+ci_require_cmds gh jq git awk grep
+
+pr_number="${1:?Usage: ci-classify-failure.sh <pr_number> <workflow_name> [<org/repo>]}"
+workflow_name="${2:?Usage: ci-classify-failure.sh <pr_number> <workflow_name> [<org/repo>]}"
+repo_arg="${3:-}"
+
+repo_flag=($(ci_build_repo_flag "${repo_arg}"))
+
+# Read log excerpt from stdin
+log_excerpt=$(cat)
+
+# ── Signal 1: Does the same workflow fail on the default branch? ─────────────
+
+fails_on_default_branch="false"
+main_reasoning=""
+
+# Get default branch
+default_branch=$(gh repo view "${repo_flag[@]}" --json defaultBranchRef -q '.defaultBranchRef.name' 2> /dev/null || echo "main")
+
+# Check recent runs on the default branch
+main_runs=$(gh run list \
+    --branch "${default_branch}" \
+    "${repo_flag[@]}" \
+    --workflow "${workflow_name}" \
+    --limit 5 \
+    --json conclusion \
+    2> /dev/null) || main_runs="[]"
+
+read -r main_failure_count main_total < <(echo "${main_runs}" | jq -r '[([.[] | select(.conclusion == "failure")] | length), length] | @tsv')
+
+if [[ "${main_failure_count}" -gt 0 ]]; then
+    fails_on_default_branch="true"
+    main_reasoning="Workflow '${workflow_name}' has ${main_failure_count}/${main_total} recent failures on ${default_branch}"
+fi
+
+# ── Signal 2: Do error logs reference PR-changed files? ──────────────────────
+
+references_changed_files="false"
+changed_file_matches=""
+
+# Get PR changed files
+changed_files=$(ci_get_pr_changed_files "${pr_number}" "${repo_arg}")
+
+if [[ -n "${changed_files}" ]] && [[ -n "${log_excerpt}" ]]; then
+    matched_files=()
+    while IFS= read -r file; do
+        [[ -z "${file}" ]] && continue
+        # Check if the file path appears in the log
+        if grep -qF -- "${file}" <<< "${log_excerpt}"; then
+            matched_files+=("${file}")
+        fi
+        # Also check just the filename (tests often reference basenames)
+        basename_file="${file##*/}"
+        if grep -qF -- "${basename_file}" <<< "${log_excerpt}"; then
+            # Avoid duplicates (use literal string comparison)
+            already_matched=false
+            for m in "${matched_files[@]:-}"; do
+                if [[ "${m}" == "${file}" ]]; then
+                    already_matched=true
+                    break
+                fi
+            done
+            if [[ "${already_matched}" == "false" ]]; then
+                matched_files+=("${file}")
+            fi
+        fi
+    done <<< "${changed_files}"
+
+    if [[ ${#matched_files[@]} -gt 0 ]]; then
+        references_changed_files="true"
+        changed_file_matches=$(printf '%s, ' "${matched_files[@]}")
+        changed_file_matches="${changed_file_matches%, }"
+    fi
+fi
+
+# ── Signal 3: Known flaky patterns in logs ───────────────────────────────────
+
+known_flaky_pattern="false"
+flaky_pattern_match=""
+
+# Common flaky test indicators
+flaky_patterns=(
+    "timed out"
+    "deadline exceeded"
+    "ETIMEDOUT"
+    "ECONNRESET"
+    "ECONNREFUSED"
+    "connection refused"
+    "socket hang up"
+    "lock timeout"
+    "could not obtain lock"
+    "runner lost communication"
+    "The runner has received a shutdown signal"
+    "net/http: request canceled"
+    "context deadline exceeded"
+    "ResourceExhausted"
+    "Too many open files"
+    "no space left on device"
+)
+
+if [[ -n "${log_excerpt}" ]]; then
+    for pattern in "${flaky_patterns[@]}"; do
+        if grep -qiF -- "${pattern}" <<< "${log_excerpt}"; then
+            known_flaky_pattern="true"
+            flaky_pattern_match="${pattern}"
+            break
+        fi
+    done
+fi
+
+# ── Combine signals ──────────────────────────────────────────────────────────
+
+# Scoring: start at 0.5 (uncertain)
+# Flaky signals decrease score, legit signals increase
+score=50 # Using integers to avoid bash float issues
+
+if [[ "${fails_on_default_branch}" == "true" ]]; then
+    score=$((score - 30))
+fi
+
+if [[ "${references_changed_files}" == "true" ]]; then
+    score=$((score + 30))
+fi
+
+if [[ "${known_flaky_pattern}" == "true" ]]; then
+    score=$((score - 15))
+fi
+
+# Classification thresholds
+if [[ ${score} -le 35 ]]; then
+    classification="flaky"
+elif [[ ${score} -ge 65 ]]; then
+    classification="legit"
+else
+    classification="uncertain"
+fi
+
+# Build reasoning
+reasoning=""
+if [[ "${fails_on_default_branch}" == "true" ]]; then
+    reasoning="${main_reasoning}. "
+fi
+if [[ "${references_changed_files}" == "true" ]]; then
+    reasoning="${reasoning}Error logs reference PR-changed files: ${changed_file_matches}. "
+fi
+if [[ "${known_flaky_pattern}" == "true" ]]; then
+    reasoning="${reasoning}Log contains known flaky pattern: '${flaky_pattern_match}'. "
+fi
+if [[ -z "${reasoning}" ]]; then
+    reasoning="No strong signals detected."
+fi
+# Trim trailing space
+reasoning="${reasoning% }"
+
+# Confidence: distance from 50 (uncertain center)
+if [[ ${score} -ge 50 ]]; then
+    confidence_raw=$((score - 50))
+else
+    confidence_raw=$((50 - score))
+fi
+# Scale to 0.5-1.0 range (0.5 at score 50, 1.0 at max distance 50)
+confidence=$(awk "BEGIN { printf \"%.2f\", 0.5 + (${confidence_raw} / 100.0) }")
+
+# ── Output ───────────────────────────────────────────────────────────────────
+
+jq -n \
+    --arg classification "${classification}" \
+    --arg confidence "${confidence}" \
+    --arg reasoning "${reasoning}" \
+    --argjson fails_on_default_branch "${fails_on_default_branch}" \
+    --argjson references_changed_files "${references_changed_files}" \
+    --argjson known_flaky_pattern "${known_flaky_pattern}" \
+    --arg flaky_pattern_match "${flaky_pattern_match}" \
+    --arg changed_file_matches "${changed_file_matches}" \
+    '{
+    classification: $classification,
+    confidence: ($confidence | tonumber),
+    reasoning: $reasoning,
+    signals: {
+      fails_on_default_branch: $fails_on_default_branch,
+      references_changed_files: $references_changed_files,
+      known_flaky_pattern: $known_flaky_pattern,
+      flaky_pattern_match: $flaky_pattern_match,
+      changed_file_matches: $changed_file_matches
+    }
+  }'

--- a/ai/skills/ci-monitor/scripts/ci-detect-pr.sh
+++ b/ai/skills/ci-monitor/scripts/ci-detect-pr.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# ci-detect-pr.sh - Detect PR from current branch or argument
+#
+# Usage:
+#   ci-detect-pr.sh [<pr-number>|<pr-url>]
+#
+# When no argument is given, detects the PR from the current branch.
+#
+# Output: JSON object with pr_number, org, repo, head_branch, head_sha, error
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=helpers/ci-helpers.sh
+source "${SCRIPT_DIR}/helpers/ci-helpers.sh"
+ci_require_cmds gh jq git
+
+arg="${1:-}"
+
+# ── Parse argument ───────────────────────────────────────────────────────────
+
+if [[ -n "${arg}" ]]; then
+    if [[ "${arg}" =~ ^https?://[^/]+/([^/]+)/([^/]+)/pull/([0-9]+) ]]; then
+        # PR URL
+        org="${BASH_REMATCH[1]}"
+        repo="${BASH_REMATCH[2]}"
+        pr_number="${BASH_REMATCH[3]}"
+
+        # Normalize to lowercase
+        org=$(echo "${org}" | tr '[:upper:]' '[:lower:]')
+        repo=$(echo "${repo}" | tr '[:upper:]' '[:lower:]')
+
+        # Fetch PR metadata
+        pr_json=$(gh pr view "${pr_number}" \
+            --repo "${org}/${repo}" \
+            --json headRefName,headRefOid \
+            2> /dev/null) || {
+            ci_json_error "Could not fetch PR #${pr_number} from ${org}/${repo}"
+            exit 0
+        }
+
+        head_branch=$(echo "${pr_json}" | jq -r '.headRefName')
+        head_sha=$(echo "${pr_json}" | jq -r '.headRefOid')
+
+    elif [[ "${arg}" =~ ^[0-9]+$ ]]; then
+        # PR number - infer org/repo from current directory
+        pr_number="${arg}"
+        org_repo=$(get_git_org_repo 2> /dev/null || echo "unknown|unknown")
+        org="${org_repo%|*}"
+        repo="${org_repo#*|}"
+
+        if [[ "${org}" == "unknown" ]]; then
+            ci_json_error "Could not determine repository. Run from within a git checkout."
+            exit 0
+        fi
+
+        pr_json=$(gh pr view "${pr_number}" \
+            --repo "${org}/${repo}" \
+            --json headRefName,headRefOid \
+            2> /dev/null) || {
+            ci_json_error "Could not fetch PR #${pr_number}"
+            exit 0
+        }
+
+        head_branch=$(echo "${pr_json}" | jq -r '.headRefName')
+        head_sha=$(echo "${pr_json}" | jq -r '.headRefOid')
+    else
+        ci_json_error "Invalid argument: '${arg}'. Expected a PR number or PR URL."
+        exit 0
+    fi
+else
+    # No argument - detect from current branch
+    validate_git_repo 2> /dev/null || {
+        ci_json_error "Could not determine repository. Run from within a git checkout."
+        exit 0
+    }
+
+    org_repo=$(get_git_org_repo 2> /dev/null || echo "unknown|unknown")
+    org="${org_repo%|*}"
+    repo="${org_repo#*|}"
+
+    if [[ "${org}" == "unknown" ]]; then
+        ci_json_error "Could not determine repository. Run from within a git checkout."
+        exit 0
+    fi
+
+    head_branch=$(get_current_branch)
+
+    if [[ -z "${head_branch}" ]]; then
+        ci_json_error "Could not determine current branch (detached HEAD or not on a branch). Pass a PR number or PR URL explicitly."
+        exit 0
+    fi
+
+    # Try to find an associated PR
+    pr_json=$(gh pr view "${head_branch}" \
+        --repo "${org}/${repo}" \
+        --json number,headRefName,headRefOid \
+        2> /dev/null) || {
+        ci_json_error "No PR found for branch '${head_branch}'. Push your branch and create a PR first, or pass a PR number."
+        exit 0
+    }
+
+    pr_number=$(echo "${pr_json}" | jq -r '.number')
+    head_branch=$(echo "${pr_json}" | jq -r '.headRefName')
+    head_sha=$(echo "${pr_json}" | jq -r '.headRefOid')
+fi
+
+# ── Output ───────────────────────────────────────────────────────────────────
+
+jq -n \
+    --arg pr_number "${pr_number}" \
+    --arg org "${org}" \
+    --arg repo "${repo}" \
+    --arg head_branch "${head_branch}" \
+    --arg head_sha "${head_sha}" \
+    '{
+    pr_number: ($pr_number | tonumber),
+    org: $org,
+    repo: $repo,
+    head_branch: $head_branch,
+    head_sha: $head_sha,
+    error: null
+  }'

--- a/ai/skills/ci-monitor/scripts/ci-detect-pr.sh
+++ b/ai/skills/ci-monitor/scripts/ci-detect-pr.sh
@@ -27,8 +27,8 @@ if [[ -n "${arg}" ]]; then
         pr_number="${BASH_REMATCH[3]}"
 
         # Normalize to lowercase
-        org=$(echo "${org}" | tr '[:upper:]' '[:lower:]')
-        repo=$(echo "${repo}" | tr '[:upper:]' '[:lower:]')
+        org="${org,,}"
+        repo="${repo,,}"
 
         # Fetch PR metadata
         pr_json=$(gh pr view "${pr_number}" \

--- a/ai/skills/ci-monitor/scripts/ci-fetch-logs.sh
+++ b/ai/skills/ci-monitor/scripts/ci-fetch-logs.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# ci-fetch-logs.sh - Fetch failure logs for a workflow run
+#
+# Usage:
+#   ci-fetch-logs.sh <run_id> [<org/repo>]
+#
+# Output: JSON with structured failure log excerpts, truncated to last N lines per job
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=helpers/ci-helpers.sh
+source "${SCRIPT_DIR}/helpers/ci-helpers.sh"
+ci_require_cmds gh jq git awk
+
+run_id="${1:?Usage: ci-fetch-logs.sh <run_id> [<org/repo>]}"
+repo_arg="${2:-}"
+
+repo_flag=($(ci_build_repo_flag "${repo_arg}"))
+
+# ── Fetch run metadata ──────────────────────────────────────────────────────
+
+run_json=$(gh run view "${run_id}" \
+    "${repo_flag[@]}" \
+    --json name,workflowName,conclusion,jobs \
+    2> /dev/null) || {
+    ci_json_error "Could not fetch run ${run_id}"
+    exit 0
+}
+
+workflow_name=$(echo "${run_json}" | jq -r '.workflowName // .name // "unknown"')
+
+# ── Fetch failed job logs ────────────────────────────────────────────────────
+
+# gh run view --log-failed outputs logs prefixed with job/step names
+gh_log_exit=0
+raw_logs=$(gh run view "${run_id}" \
+    "${repo_flag[@]}" \
+    --log-failed \
+    2> /dev/null) || gh_log_exit=$?
+
+if [[ ${gh_log_exit} -ne 0 ]]; then
+    ci_json_error "Could not fetch failure logs for run ${run_id} (gh exited ${gh_log_exit})"
+    exit 0
+fi
+
+if [[ -z "${raw_logs}" ]]; then
+    # gh succeeded but returned no output — run was cancelled or logs expired
+    jq -n \
+        --arg run_id "${run_id}" \
+        --arg workflow "${workflow_name}" \
+        '{
+      run_id: ($run_id | tonumber),
+      workflow: $workflow,
+      failed_jobs: [],
+      error: "No failure logs available. The run may have been cancelled or the logs expired."
+    }'
+    exit 0
+fi
+
+# Parse logs by job name (first tab-separated field)
+# Group lines by job, keep last CI_LOG_TAIL_LINES per job
+failed_jobs_json=$(printf '%s\n' "${raw_logs}" | awk -F'\t' -v tail_lines="${CI_LOG_TAIL_LINES}" '
+function json_escape(s) {
+  gsub(/\\/, "\\\\", s)
+  gsub(/"/, "\\\"", s)
+  gsub(/\t/, "\\t", s)
+  gsub(/\r/, "", s)
+  # Escape control characters (0x00-0x1F) that break JSON
+  gsub(/\x00/, "", s)
+  gsub(/\x01/, "", s)
+  gsub(/\x02/, "", s)
+  gsub(/\x03/, "", s)
+  gsub(/\x04/, "", s)
+  gsub(/\x05/, "", s)
+  gsub(/\x06/, "", s)
+  gsub(/\x07/, "", s)
+  gsub(/\x08/, "\\b", s)
+  gsub(/\x0b/, "", s)
+  gsub(/\x0c/, "\\f", s)
+  gsub(/\x0e/, "", s)
+  gsub(/\x0f/, "", s)
+  gsub(/\x1b/, "", s)
+  return s
+}
+BEGIN {
+  job_count = 0
+}
+{
+  job = $1
+  log_line = ""
+  for (i = 2; i <= NF; i++) {
+    if (i > 2) log_line = log_line "\t"
+    log_line = log_line $i
+  }
+
+  if (!(job in seen)) {
+    seen[job] = 1
+    jobs[job_count] = job
+    job_count++
+    line_count[job] = 0
+  }
+
+  idx = line_count[job] % tail_lines
+  lines[job, idx] = log_line
+  line_count[job]++
+}
+END {
+  printf "["
+  for (j = 0; j < job_count; j++) {
+    job = jobs[j]
+    count = line_count[job]
+    start = 0
+    total = count
+    if (count > tail_lines) {
+      start = count % tail_lines
+      total = tail_lines
+    }
+
+    if (j > 0) printf ","
+    printf "{\"name\":\"%s\",\"log_excerpt\":\"", json_escape(job)
+
+    for (k = 0; k < total; k++) {
+      idx = (start + k) % tail_lines
+      line = lines[job, idx]
+      if (k > 0) printf "\\n"
+      printf "%s", json_escape(line)
+    }
+    printf "\"}"
+  }
+  printf "]"
+}
+')
+
+# ── Output ───────────────────────────────────────────────────────────────────
+
+jq -n \
+    --arg run_id "${run_id}" \
+    --arg workflow "${workflow_name}" \
+    --argjson failed_jobs "${failed_jobs_json}" \
+    '{
+    run_id: ($run_id | tonumber),
+    workflow: $workflow,
+    failed_jobs: $failed_jobs,
+    error: null
+  }'

--- a/ai/skills/ci-monitor/scripts/ci-fetch-logs.sh
+++ b/ai/skills/ci-monitor/scripts/ci-fetch-logs.sh
@@ -16,7 +16,8 @@ ci_require_cmds gh jq git awk
 run_id="${1:?Usage: ci-fetch-logs.sh <run_id> [<org/repo>]}"
 repo_arg="${2:-}"
 
-repo_flag=($(ci_build_repo_flag "${repo_arg}"))
+repo_flag=()
+ci_repo_flag repo_flag "${repo_arg}"
 
 # ── Fetch run metadata ──────────────────────────────────────────────────────
 
@@ -80,7 +81,22 @@ function json_escape(s) {
   gsub(/\x0c/, "\\f", s)
   gsub(/\x0e/, "", s)
   gsub(/\x0f/, "", s)
+  gsub(/\x10/, "", s)
+  gsub(/\x11/, "", s)
+  gsub(/\x12/, "", s)
+  gsub(/\x13/, "", s)
+  gsub(/\x14/, "", s)
+  gsub(/\x15/, "", s)
+  gsub(/\x16/, "", s)
+  gsub(/\x17/, "", s)
+  gsub(/\x18/, "", s)
+  gsub(/\x19/, "", s)
+  gsub(/\x1a/, "", s)
   gsub(/\x1b/, "", s)
+  gsub(/\x1c/, "", s)
+  gsub(/\x1d/, "", s)
+  gsub(/\x1e/, "", s)
+  gsub(/\x1f/, "", s)
   return s
 }
 BEGIN {

--- a/ai/skills/ci-monitor/scripts/helpers/ci-helpers.sh
+++ b/ai/skills/ci-monitor/scripts/helpers/ci-helpers.sh
@@ -63,9 +63,7 @@ get_git_org_repo() {
         if [[ -n "${gh_data}" ]]; then
             local org="${gh_data%|*}"
             local repo="${gh_data#*|}"
-            org=$(echo "${org}" | tr '[:upper:]' '[:lower:]')
-            repo=$(echo "${repo}" | tr '[:upper:]' '[:lower:]')
-            echo "${org}|${repo}"
+            echo "${org,,}|${repo,,}"
             return 0
         fi
     fi
@@ -82,9 +80,7 @@ get_git_org_repo() {
     if [[ ${remote_url} =~ ^(https://|git@)github\.com[:/]([a-zA-Z0-9_-]+)/([a-zA-Z0-9._-]+)(\.git)?$ ]]; then
         local org="${BASH_REMATCH[2]}"
         local repo="${BASH_REMATCH[3]}"
-        org=$(echo "${org}" | tr '[:upper:]' '[:lower:]')
-        repo=$(echo "${repo}" | tr '[:upper:]' '[:lower:]')
-        echo "${org}|${repo}"
+        echo "${org,,}|${repo,,}"
         return 0
     fi
 
@@ -97,13 +93,14 @@ get_current_branch() {
 
 # ── CI-specific helpers ──────────────────────────────────────────────────────
 
-# Build --repo flag array from an org/repo string
-# Usage: repo_flag=($(ci_build_repo_flag "$repo_arg"))
-# Returns nothing if repo_arg is empty
-ci_build_repo_flag() {
-    local repo_arg="$1"
+# Build a --repo flag array from an org/repo string.
+# Usage: local repo_flag=(); ci_repo_flag repo_flag "$repo_arg"
+ci_repo_flag() {
+    local -n _arr=$1
+    local repo_arg="$2"
+    _arr=()
     if [[ -n "${repo_arg}" ]]; then
-        echo "--repo" "${repo_arg}"
+        _arr=(--repo "${repo_arg}")
     fi
 }
 
@@ -113,9 +110,7 @@ ci_get_pr_changed_files() {
     local pr_number="$1"
     local repo_arg="${2:-}"
     local repo_flag=()
-    if [[ -n "${repo_arg}" ]]; then
-        repo_flag=(--repo "${repo_arg}")
-    fi
+    ci_repo_flag repo_flag "${repo_arg}"
     gh pr diff "${pr_number}" "${repo_flag[@]}" --name-only 2> /dev/null || echo ""
 }
 

--- a/ai/skills/ci-monitor/scripts/helpers/ci-helpers.sh
+++ b/ai/skills/ci-monitor/scripts/helpers/ci-helpers.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# ci-helpers.sh - Shared constants and utilities for ci-monitor skill
+#
+# Usage:
+#   source "$(dirname "${BASH_SOURCE[0]}")/helpers/ci-helpers.sh"
+
+# ── Constants ────────────────────────────────────────────────────────────────
+
+CI_POLL_INTERVAL=30   # seconds between polls
+CI_TIMEOUT_MINUTES=30 # default overall timeout
+CI_MAX_FIX_RETRIES=3  # max fix-push-monitor cycles
+CI_LOG_TAIL_LINES=200 # lines of log to keep per failed job
+
+# ── gh CLI wrapper ───────────────────────────────────────────────────────────
+# Suppress DEBUG env var that causes gh to emit verbose output
+
+if command -v gh > /dev/null 2>&1; then
+    gh() {
+        DEBUG= command gh "$@"
+    }
+fi
+
+# ── Dependency check ────────────────────────────────────────────────────────
+# Must be called before ci_json_error since that function depends on jq.
+# Uses printf for JSON output so it works even if jq is missing.
+
+ci_require_cmds() {
+    local missing=()
+    for cmd in "$@"; do
+        command -v "${cmd}" > /dev/null 2>&1 || missing+=("${cmd}")
+    done
+    if [[ ${#missing[@]} -gt 0 ]]; then
+        local joined
+        joined=$(printf '%s, ' "${missing[@]}")
+        joined="${joined%, }"
+        printf '{"error":"Required commands not found: %s"}\n' "${joined}" >&1
+        exit 0
+    fi
+}
+
+# ── Error helpers ────────────────────────────────────────────────────────────
+
+error() {
+    echo -e "\033[31mError: $*\033[0m" >&2
+}
+
+# ── Git helpers ──────────────────────────────────────────────────────────────
+
+validate_git_repo() {
+    if ! git rev-parse --git-dir > /dev/null 2>&1; then
+        error "Not in a git repository"
+        return 1
+    fi
+}
+
+# Extract org and repo from git remote URL
+# Returns: "org|repo" on success, "unknown|unknown" on failure
+get_git_org_repo() {
+    # Try gh CLI first (most reliable)
+    if command -v gh > /dev/null 2>&1; then
+        local gh_data
+        gh_data=$(gh repo view --json owner,name -q '"\(.owner.login)|\(.name)"' 2> /dev/null || echo "")
+        if [[ -n "${gh_data}" ]]; then
+            local org="${gh_data%|*}"
+            local repo="${gh_data#*|}"
+            org=$(echo "${org}" | tr '[:upper:]' '[:lower:]')
+            repo=$(echo "${repo}" | tr '[:upper:]' '[:lower:]')
+            echo "${org}|${repo}"
+            return 0
+        fi
+    fi
+
+    # Fallback: Parse git remote URL
+    local remote_url
+    remote_url=$(git remote get-url origin 2> /dev/null || echo "")
+
+    if [[ -z "${remote_url}" ]]; then
+        echo "unknown|unknown"
+        return 0
+    fi
+
+    if [[ ${remote_url} =~ ^(https://|git@)github\.com[:/]([a-zA-Z0-9_-]+)/([a-zA-Z0-9._-]+)(\.git)?$ ]]; then
+        local org="${BASH_REMATCH[2]}"
+        local repo="${BASH_REMATCH[3]}"
+        org=$(echo "${org}" | tr '[:upper:]' '[:lower:]')
+        repo=$(echo "${repo}" | tr '[:upper:]' '[:lower:]')
+        echo "${org}|${repo}"
+        return 0
+    fi
+
+    echo "unknown|unknown"
+}
+
+get_current_branch() {
+    git branch --show-current
+}
+
+# ── CI-specific helpers ──────────────────────────────────────────────────────
+
+# Build --repo flag array from an org/repo string
+# Usage: repo_flag=($(ci_build_repo_flag "$repo_arg"))
+# Returns nothing if repo_arg is empty
+ci_build_repo_flag() {
+    local repo_arg="$1"
+    if [[ -n "${repo_arg}" ]]; then
+        echo "--repo" "${repo_arg}"
+    fi
+}
+
+# Get the list of files changed in a PR
+# Usage: ci_get_pr_changed_files <pr_number> [<org/repo>]
+ci_get_pr_changed_files() {
+    local pr_number="$1"
+    local repo_arg="${2:-}"
+    local repo_flag=()
+    if [[ -n "${repo_arg}" ]]; then
+        repo_flag=(--repo "${repo_arg}")
+    fi
+    gh pr diff "${pr_number}" "${repo_flag[@]}" --name-only 2> /dev/null || echo ""
+}
+
+# JSON output helper
+ci_json_error() {
+    local message="$1"
+    jq -n --arg msg "${message}" '{"error": $msg}'
+}


### PR DESCRIPTION
## Summary

- Adds `/ci-monitor` skill that monitors GitHub CI checks after pushing, classifies failures as flaky vs legit, and optionally auto-fixes legit failures
- Ported from haacked/review-code PR #85, with helpers inlined to make the skill self-contained (no cross-skill dependency)
- Includes 5 bash scripts: PR detection, status checking, log fetching, failure classification, and a fix handler

## Test plan

- [ ] Run `ai/install.sh --skills-only` and verify `~/.claude/skills/ci-monitor` symlink exists
- [ ] Verify scripts are executable: `ls -la ~/.claude/skills/ci-monitor/scripts/*.sh`
- [ ] Test PR detection: `~/.claude/skills/ci-monitor/scripts/ci-detect-pr.sh` from a repo with a PR
- [ ] Test check status: `~/.claude/skills/ci-monitor/scripts/ci-check-status.sh <pr_number>` on a repo with CI checks
- [ ] Invoke `/ci-monitor` from a repo with an open PR to verify end-to-end flow