### PR TITLE
Fix ci-monitor jq error parsing workflow field

### DIFF
--- a/ai/skills/ci-monitor/scripts/ci-check-status.sh
+++ b/ai/skills/ci-monitor/scripts/ci-check-status.sh
@@ -95,13 +95,13 @@ enriched_checks=$(echo "${checks_json}" | jq --argjson runs "${runs_json}" --arg
       name: .name,
       state: .state,
       bucket: .bucket,
-      workflow: .workflow.name,
+      workflow: .workflow,
       link: .link,
       run_id: (
         if .bucket == "fail" then
           ($runs | map(select(
             (.conclusion == "failure") and
-            (.workflowName == $check.workflow.name) and
+            (.workflowName == $check.workflow) and
             ($head_sha == "" or .headSha == $head_sha)
           )) | first | .databaseId // null)
         else null end


### PR DESCRIPTION
## Summary

- `gh pr checks --json workflow` returns `workflow` as a plain string, but the ci-check-status script accessed it as `.workflow.name` (object property), causing a jq error: `Cannot index string with string "name"`
- Replace `.workflow.name` with `.workflow` in the jq expression that enriches failed checks with run IDs

## Test plan

- Run `ci-check-status.sh <pr_number> <org/repo>` against a real PR and verify it returns valid JSON without jq errors