### PR TITLE
Add token usage tracking to ops-report

### DIFF
--- a/ai/skills/ops-report/SKILL.md
+++ b/ai/skills/ops-report/SKILL.md
@@ -82,6 +82,14 @@ Record these values:
 
 State the computed `{window_start}`, `{window_end}`, and `{window_hours}` values before proceeding to Step 2.
 
+Record the current session JSONL line count for token tracking:
+
+```bash
+claude-session-tokens --line-count
+```
+
+Store the output plus one as `{token_baseline_line}` (i.e., `line_count + 1`) so that `--sum-from` starts after the last pre-existing line.
+
 ### Step 2: Discover Dashboards
 
 Search Grafana for dashboards related to the service. For each active region, run in parallel:
@@ -733,6 +741,22 @@ npx markdownlint-cli {report_path} 2>&1 || true
 
 Fix any lint errors. Then tell the user where the report was saved and offer a brief summary of the findings.
 
+#### Token Usage
+
+Query the token usage for this report:
+
+```bash
+claude-session-tokens --sum-from {token_baseline_line}
+```
+
+Parse the JSON output. Store `{report_tokens}` (the `total_tokens` value) and `{report_output_tokens}` (the `output_tokens` value) for use in the Data Sources section and Slack summary. The count is approximate (excludes the final message that writes the report).
+
+Append the following line to the Data Sources section of the report:
+
+```text
+**Report token usage (approximate):** ~{report_tokens} total ({report_output_tokens} output). Excludes the final report-writing message.
+```
+
 ### Step 11: Copy Slack Summary
 
 After saving the report, generate a condensed Slack summary in HTML format and copy it to the clipboard.
@@ -758,6 +782,7 @@ Use the same HTML conventions as the standup skill:
 <ul>
 <li>Request rate: {value} | Error rate: {value} | P99 latency: {value}</li>
 </ul>
+<p><b>Tokens:</b> ~{report_tokens}</p>
 <p>Full report: <code>{report_path}</code></p>
 ```
 

--- a/ai/skills/ops-report/SKILL.md
+++ b/ai/skills/ops-report/SKILL.md
@@ -731,15 +731,7 @@ These links require VPN access and Cognito authentication:
 {Brief description of how the data was collected}
 ```
 
-### Step 10: Lint and Confirm
-
-Run markdownlint on the report if available:
-
-```bash
-npx markdownlint-cli {report_path} 2>&1 || true
-```
-
-Fix any lint errors. Then tell the user where the report was saved and offer a brief summary of the findings.
+### Step 10: Token Usage, Lint, and Confirm
 
 #### Token Usage
 
@@ -756,6 +748,16 @@ Append the following line to the Data Sources section of the report:
 ```text
 **Report token usage (approximate):** ~{report_tokens} total ({report_output_tokens} output). Excludes the final report-writing message.
 ```
+
+#### Lint
+
+Run markdownlint on the report if available:
+
+```bash
+npx markdownlint-cli {report_path} 2>&1 || true
+```
+
+Fix any lint errors. Then tell the user where the report was saved and offer a brief summary of the findings.
 
 ### Step 11: Copy Slack Summary
 

--- a/bin/claude-session-tokens
+++ b/bin/claude-session-tokens
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""
+Read token usage from the current Claude Code session's JSONL file.
+
+Usage:
+  claude-session-tokens --line-count          Print current JSONL line count
+  claude-session-tokens --sum-from LINE       Sum token usage from LINE onward (1-indexed)
+
+The session JSONL is discovered by encoding $PWD into the Claude Code
+project path format and selecting the most recently modified .jsonl file.
+"""
+
+import argparse
+import glob
+import json
+import os
+import sys
+
+
+def encode_project_path(path):
+    """Encode a directory path the way Claude Code does for project storage."""
+    return path.replace("/", "-").replace(".", "-")
+
+
+def find_session_jsonl(project_dir):
+    """Find the most recently modified session JSONL for the given project directory."""
+    encoded = encode_project_path(project_dir)
+    search_dir = os.path.expanduser(f"~/.claude/projects/{encoded}")
+
+    if not os.path.isdir(search_dir):
+        return None
+
+    jsonl_files = glob.glob(os.path.join(search_dir, "*.jsonl"))
+    if not jsonl_files:
+        return None
+
+    return max(jsonl_files, key=os.path.getmtime)
+
+
+def count_lines(filepath):
+    """Count the number of lines in a file."""
+    with open(filepath) as f:
+        return sum(1 for _ in f)
+
+
+def sum_tokens_from(filepath, start_line):
+    """Sum token usage from start_line onward (1-indexed)."""
+    totals = {
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "cache_creation_input_tokens": 0,
+        "cache_read_input_tokens": 0,
+    }
+
+    with open(filepath) as f:
+        for i, line in enumerate(f, start=1):
+            if i < start_line:
+                continue
+            try:
+                data = json.loads(line.strip())
+                usage = data.get("message", {}).get("usage", {})
+                if usage:
+                    for key in totals:
+                        totals[key] += usage.get(key, 0)
+            except json.JSONDecodeError:
+                continue
+
+    totals["total_tokens"] = sum(totals.values())
+    return totals
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Read token usage from the current Claude Code session",
+    )
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument(
+        "--line-count",
+        action="store_true",
+        help="Print the current number of lines in the session JSONL",
+    )
+    group.add_argument(
+        "--sum-from",
+        type=int,
+        metavar="LINE",
+        help="Sum token usage from LINE onward (1-indexed)",
+    )
+
+    args = parser.parse_args()
+
+    jsonl_path = find_session_jsonl(os.getcwd())
+    if not jsonl_path:
+        print("error: no session data found for current directory", file=sys.stderr)
+        return 1
+
+    if args.line_count:
+        print(count_lines(jsonl_path))
+    else:
+        totals = sum_tokens_from(jsonl_path, args.sum_from)
+        print(json.dumps(totals))
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- Adds `bin/claude-session-tokens` script that reads token usage from Claude Code session JSONL files, supporting `--line-count` (baseline) and `--sum-from LINE` (delta) modes
- Updates the ops-report skill to record a baseline at the start, query the token delta after report generation, and include approximate token usage in both the markdown report (Data Sources section) and Slack summary

## Test plan

- [ ] Run `bin/claude-session-tokens --line-count` and verify it outputs an integer
- [ ] Run `bin/claude-session-tokens --sum-from 1` and verify it outputs valid JSON with token counts
- [ ] Run `/ops-report` and confirm the report includes a token usage line in Data Sources and the Slack summary includes the token count