### PR TITLE
Use three-dot diff in create-pr skill

### DIFF
--- a/ai/skills/create-pr/SKILL.md
+++ b/ai/skills/create-pr/SKILL.md
@@ -48,7 +48,7 @@ Then, using `$base`, run in parallel:
 
 ```bash
 git log origin/$base..HEAD --oneline                    # commits on this branch
-git diff origin/$base..HEAD                             # full diff vs base
+git diff origin/$base...HEAD                            # full diff vs base
 gh pr view --json number,title,body,isDraft,url 2>/dev/null  # existing PR, if any
 ```
 


### PR DESCRIPTION
## Summary
- Changes `git diff origin/$base..HEAD` to `git diff origin/$base...HEAD` in the create-pr skill
- The three-dot form diffs against the merge-base, showing only changes introduced on the branch even if the base has advanced

## Test plan
- Run `/create-pr` on a branch where `main` has advanced since branching
- Verify the generated PR description reflects only branch changes, not base-branch drift