### PR TITLE
Prevent create-pr from adding LLM context sections

### DIFF
--- a/ai/CLAUDE.md
+++ b/ai/CLAUDE.md
@@ -50,7 +50,7 @@ After 2 failed attempts, stop and use `bug-root-cause-analyzer`. Don't keep push
 
 ## GitHub Operations
 
-Write as the user in all public-facing content — never refer to yourself as an AI. Never include AI/LLM attribution or co-authorship notes.
+Write as the user in all public-facing content — never refer to yourself as an AI. Never include AI/LLM attribution, co-authorship notes, or LLM context sections in PRs, commits, or any public-facing content.
 
 **Always use `gh` CLI** for GitHub operations. Never use GitHub MCP server tools.
 

--- a/ai/skills/create-pr/SKILL.md
+++ b/ai/skills/create-pr/SKILL.md
@@ -79,6 +79,7 @@ If a template was found, fill each section using the commits and diff:
 - Remove unfilled optional sections rather than leaving placeholder text
 - Leave checkboxes intact; check the ones clearly satisfied by the diff
 - **Never include customer-specific data** — redact or omit any team IDs, team names, organization names, user IDs, or other identifying customer information found in commits or diffs; describe the fix generically instead (e.g., "fixes flag evaluation for teams with large cohorts" not "fixes team 12345 / Acme Corp")
+- **Never uncomment, fill in, or add LLM/AI context sections** — if the template contains a commented-out LLM context section, leave it commented out or remove it entirely
 
 If no template was found, write:
 


### PR DESCRIPTION
## Summary

- Add explicit instruction to the create-pr skill to never uncomment or fill in LLM context sections from PR templates
- Broaden the CLAUDE.md GitHub Operations guideline to explicitly mention LLM context sections alongside attribution and co-authorship notes

## Test plan

- Run `/create-pr` on a PostHog branch and verify the `## 🤖 LLM context` section is not present in the PR preview