### PR TITLE
Integrate git bclean-empty into git bclean

### DIFF
--- a/git/gitconfig.aliases.symlink
+++ b/git/gitconfig.aliases.symlink
@@ -14,8 +14,9 @@
     abort = rebase --abort
     aliases = "!git config -l | grep ^alias\\. | cut -c 7-"
     amend = commit -a --amend
-    # Prune remote-merged branches (gh poi) then delete local merged branches and their worktrees
-    bclean = "!f() { gh poi; git bclean-local \"$@\"; }; f"
+    # Prune remote-merged branches (gh poi), delete local merged branches and their worktrees,
+    # then delete stranded local branches (ancestors of default with no upstream, no worktree).
+    bclean = "!f() { gh poi; git bclean-local \"$@\"; git bclean-empty \"$@\"; }; f"
     # Delete local branches that are ancestors of the default branch with no upstream and no worktree.
     # Cleans up stranded Conductor workspace branches. Supports --dry-run. (See bin/git-bclean-empty.)
     bclean-empty = "!git-bclean-empty \"$@\""


### PR DESCRIPTION
## Summary

- `git bclean` now runs three cleanup steps in sequence: `gh poi` (prune remote-merged branches), `git bclean-local` (delete local merged branches and their worktrees), and `git bclean-empty` (delete stranded branches that are ancestors of the default branch with no upstream and no worktree).
- The standalone `bclean-empty` alias is preserved so it can still be run on its own with `--dry-run`.

## Test plan

- [ ] Create a local branch off `main` with no commits and no upstream, then run `git bclean` and confirm the stranded branch is deleted.
- [ ] Run `git bclean-empty --dry-run` and confirm the standalone alias still works.
- [ ] Run `git bclean` on a branch whose remote has been deleted after a PR merge and confirm the local branch and its worktree are removed.