### PR TITLE
Prevent create-pr from adding hard line breaks

### DIFF
--- a/ai/skills/create-pr/SKILL.md
+++ b/ai/skills/create-pr/SKILL.md
@@ -90,14 +90,18 @@ If no template was found, write:
 
 If `force` is true, skip to Step 6 immediately — do not show a preview or ask for confirmation.
 
-Otherwise, display the proposed PR to the user:
+Otherwise, display the proposed PR to the user as plain prose. **Do not wrap the body in a fenced code block** — placing the body inside a code block encourages inserting hard line breaks to fit terminal width, and those hard breaks then leak into the actual PR body.
 
-```text
-Title: <title>
-Draft: yes/no
+Format the preview like this (as plain text, not inside a fence):
 
-<body>
-```
+- `Title: <title>`
+- `Draft: yes/no`
+- a blank line
+- `Body:`
+- a blank line
+- the body content itself
+
+The body must be emitted with its natural line structure — paragraphs on single lines, lists with one item per line. Never insert hard line breaks mid-sentence or mid-bullet to fit any column width. Let the terminal soft-wrap.
 
 Ask: "Create this PR? Reply yes to confirm, or describe any changes to make."
 


### PR DESCRIPTION
## Summary

- Replace the fenced `text` code-block preview in the create-pr skill with a plain-prose format. Code blocks don't soft-wrap in terminal rendering, which was encouraging hard line breaks to fit display width — those breaks leaked into the actual PR body sent to GitHub.
- Add explicit rules requiring natural line structure: paragraphs and bullet items on single lines, no mid-sentence or mid-bullet wrapping.

## Test plan

- [ ] Invoke `/create-pr` on a branch and confirm the preview displays without a surrounding code fence
- [ ] Verify the generated `gh pr create --body` output contains no inserted hard line breaks within paragraphs or bullets