### PR TITLE
Prevent create-pr from hard-wrapping prose

### DIFF
--- a/ai/skills/create-pr/SKILL.md
+++ b/ai/skills/create-pr/SKILL.md
@@ -80,6 +80,7 @@ If a template was found, fill each section using the commits and diff:
 - Leave checkboxes intact; check the ones clearly satisfied by the diff
 - **Never include customer-specific data** — redact or omit any team IDs, team names, organization names, user IDs, or other identifying customer information found in commits or diffs; describe the fix generically instead (e.g., "fixes flag evaluation for teams with large cohorts" not "fixes team 12345 / Acme Corp")
 - **Never uncomment, fill in, or add LLM/AI context sections** — if the template contains a commented-out LLM context section, leave it commented out or remove it entirely
+- **Never hard-wrap prose** — write each paragraph as a single line and let GitHub's renderer handle wrapping; only insert newlines between paragraphs, list items, or headings
 
 If no template was found, write:
 


### PR DESCRIPTION
- Adds a rule to step 4 of the `create-pr` skill: write each paragraph as a single line and let GitHub's renderer handle wrapping. Only insert newlines between paragraphs, list items, or headings.

## Test plan

- Run `/create-pr` on a future change and confirm the body contains unwrapped paragraphs.