### PR TITLE
Restructure create-pr voice rules to reduce AI tells

### DIFF
--- a/ai/skills/create-pr/SKILL.md
+++ b/ai/skills/create-pr/SKILL.md
@@ -8,11 +8,31 @@ argument-hint: "[--draft] [--force] [<title>]"
 
 Create (or update) a GitHub pull request using `gh`, auto-detecting and filling any PR template.
 
+## Writing voice
+
+Write the PR body the way a staff engineer writes a Slack message to a colleague who reviews the code. One direct sentence per idea. No ceremony.
+
+Three things immediately signal AI authorship. Never produce any of them:
+
+- Em dashes (—) or en dashes (–). Use a comma, colon, semicolon, parenthesis, or split into two sentences. No exceptions.
+- Bold inside prose sentences. Bold is for labels at the start of a line only (e.g., `**Test plan:**`). Never bold error messages, key terms, or warnings mid-paragraph.
+- Bolded pseudo-labels like `**Root cause:**`, `**Caveat:**`, `**Note:**`. Make it a real heading or fold the content into a sentence without a label.
+
+For everything else: plain verbs ("is" not "serves as"), Sentence case headings, short paragraphs. No inflation words (critical, pivotal, robust, seamless, leverage, utilize, ensure, facilitate). No hedging meta-commentary ("I'm an agent", "I have not verified"). No closers. No emoji.
+
+How it sounds:
+
+> The workflow calls `getMembershipForUserInOrg()` with the default `GITHUB_TOKEN`, which only has repo scope and can't read org-private team memberships. The API returns `404` (not `403`) when it can't see the membership, producing the misleading error.
+>
+> If the app doesn't have Organization > Members > Read permission, the same error will recur.
+
+Notice two things about that example: the cause and effect are in one sentence connected by a comma, and the caveat is a plain declarative sentence with no label.
+
 ## Arguments
 
-- `--draft` — create the PR as a draft
-- `--force` — skip preview and confirmation; create or update immediately
-- `<title>` — optional title hint; if omitted, derive from commits
+- `--draft`: create the PR as a draft
+- `--force`: skip preview and confirmation; create or update immediately
+- `<title>`: optional title hint; if omitted, derive from commits
 
 Example invocations:
 
@@ -47,7 +67,7 @@ If the helper is not available or `default_branch` is empty, tell the user and *
 Pick the base in this precedence:
 
 ```bash
-# 1. If a PR already exists for this head, honor its base — never silently
+# 1. If a PR already exists for this head, honor its base. Never silently
 #    retarget it. Use `gh pr list --head` (queries the API by branch name)
 #    rather than `gh pr view`, which depends on local upstream tracking and
 #    can miss PRs in worktrees or after re-clones.
@@ -82,7 +102,7 @@ git diff origin/$base...HEAD                                                    
 gh pr list --head "$head" --state open --json number,title,body,isDraft,url --jq '.[0]'  # existing PR, if any
 ```
 
-If a PR already exists, note its number and URL — you will **update** it rather than create a new one (see Step 8). Use `gh pr list --head` rather than `gh pr view`: it queries by branch name (reliable in worktrees and after re-clones) instead of relying on local upstream tracking.
+If a PR already exists, note its number and URL: you will **update** it rather than create a new one (see Step 9). Use `gh pr list --head` rather than `gh pr view`: it queries by branch name (reliable in worktrees and after re-clones) instead of relying on local upstream tracking.
 
 ### 3. Find PR Template
 
@@ -90,7 +110,7 @@ Check these locations in order and stop at the first match:
 
 1. `.github/pull_request_template.md`
 2. `.github/PULL_REQUEST_TEMPLATE.md`
-3. `.github/PULL_REQUEST_TEMPLATE/` — use `default.md` if it exists, otherwise the only file present; if multiple files with no clear default, ask the user which to use
+3. `.github/PULL_REQUEST_TEMPLATE/`: use `default.md` if it exists, otherwise the only file present; if multiple files with no clear default, ask the user which to use
 4. `docs/pull_request_template.md`
 5. `pull_request_template.md`
 
@@ -103,7 +123,7 @@ test_plan_path=".context/test-plan.md"
 [ -f "$test_plan_path" ] && test_plan_content=$(cat "$test_plan_path")
 ```
 
-If the file exists, hold its full contents for use in Step 5. If not, skip — the body composition step writes its own short test plan instead.
+If the file exists, hold its full contents for use in Step 5. If not, skip; the body composition step writes its own short test plan instead.
 
 ### 5. Compose Title and Body
 
@@ -116,28 +136,19 @@ If the file exists, hold its full contents for use in Step 5. If not, skip — t
 
 If a template was found, fill each section using the commits and diff:
 
-- Describe final state — what the code does now, not what it replaced
+- Describe final state: what the code does now, not what it replaced
 - Remove unfilled optional sections rather than leaving placeholder text
 - Leave checkboxes intact; check the ones clearly satisfied by the diff
-- **Never include customer-specific data** — redact or omit any team IDs, team names, organization names, user IDs, or other identifying customer information found in commits or diffs; describe the fix generically instead (e.g., "fixes flag evaluation for teams with large cohorts" not "fixes team 12345 / Acme Corp")
-- **Never uncomment, fill in, or add LLM/AI context sections** — if the template contains a commented-out LLM context section, leave it commented out or remove it entirely
-- **Never hard-wrap prose** — write each paragraph as a single line and let GitHub's renderer handle wrapping; only insert newlines between paragraphs, list items, or headings
-- **Never escape backticks, dollar signs, or other markdown** — Step 8 passes the body through a quoted heredoc (`<<'EOF'`), which is literal; write `` `foo` `` not `` \`foo\` ``, and `$var` not `\$var`
+- **Never include customer-specific data.** Redact or omit any team IDs, team names, organization names, user IDs, or other identifying customer information found in commits or diffs; describe the fix generically instead (e.g., "fixes flag evaluation for teams with large cohorts" not "fixes team 12345 / Acme Corp")
+- **Never uncomment, fill in, or add LLM/AI context sections.** If the template contains a commented-out LLM context section, leave it commented out or remove it entirely
+- **Never hard-wrap prose.** Write each paragraph as a single line and let GitHub's renderer handle wrapping; only insert newlines between paragraphs, list items, or headings
+- **Never escape backticks, dollar signs, or other markdown.** Step 9 passes the body through a quoted heredoc (`<<'EOF'`), which is literal; write `` `foo` `` not `` \`foo\` ``, and `$var` not `\$var`
 
-**PR description voice** — write the way an engineer talks, not the way an LLM writes:
-
-- No significance inflation: avoid words like "critical", "pivotal", "essential", "robust", "comprehensive", "powerful", "seamless"
-- No marketing phrasing and no "It's not just X, it's Y" patterns
-- Use plain verbs: prefer "is" over "serves as" / "acts as" / "functions as"
-- Avoid em-dashes; commas, colons, parentheses, and periods read more naturally
-- Plain Sentence case headings, not Title Case
-- No closers like "Hope this helps!" or "Let me know if you have any questions!"
-- No emoji, and no bold for general emphasis (reserve bold for true labels)
-- One concrete sentence beats a paragraph of hedging
+**Voice.** Apply the writing voice from the `## Writing voice` section at the top of this skill throughout the body. The three hard rules (no em dashes, no bold inside prose, no bolded pseudo-labels) apply to every sentence you write here.
 
 If no template was found, write:
 
-- 1–3 bullet points summarizing what the PR does (no customer-specific IDs or names)
+- 1 to 3 bullet points summarizing what the PR does (no customer-specific IDs or names)
 - A short **Test plan** section describing how to verify the change
 
 **Embedding the saved test plan (if `test_plan_content` is set):**
@@ -157,14 +168,18 @@ Insert this block as the section's content (replacing any auto-generated test pl
 
 Notes:
 
-- Strip a leading `## Test plan` (or equivalent) heading from the file contents before insertion — the surrounding section heading already provides that context
+- Strip a leading `## Test plan` (or equivalent) heading from the file contents before insertion (the surrounding section heading already provides that context)
 - Preserve the one-line `- [ ]` checkbox format exactly; do not re-wrap or reformat
 - Keep the blank lines around `<details>` and `</details>` so GitHub renders the collapsible block correctly
 - If the testing section already contains template guidance text (e.g., placeholders), replace that text with the `<details>` block rather than stacking them
 
-### 6. Show Preview and Confirm
+### 6. Verify voice before preview
 
-If `force` is true, skip to Step 7 immediately — do not show a preview or ask for confirmation.
+Read the composed body once. If any sentence contains an em dash, bold text outside a line-start label, or a bolded pseudo-label, rewrite that sentence now. Then ask yourself: would a staff engineer write this sentence verbatim in a Slack message to a teammate? If not, simplify it.
+
+### 7. Show Preview and Confirm
+
+If `force` is true, skip to Step 8 immediately, do not show a preview or ask for confirmation.
 
 Otherwise, display the proposed PR to the user. When `stacked=true`, include the base in the header so the non-default target is obvious:
 
@@ -180,9 +195,9 @@ Ask: "Create this PR? Reply yes to confirm, or describe any changes to make."
 
 Wait for confirmation. If the user requests edits, apply them and show the updated preview before proceeding.
 
-### 7. Ensure Branch Is Pushed
+### 8. Ensure Branch Is Pushed
 
-When `stacked=true`, the parent branch must already exist on `origin` — GitHub can't open a PR against a base it doesn't have. Check first:
+When `stacked=true`, the parent branch must already exist on `origin` (GitHub can't open a PR against a base it doesn't have). Check first:
 
 ```bash
 if [ "$stacked" = "true" ] && [ -z "$(git ls-remote --heads origin "$base")" ]; then
@@ -191,7 +206,7 @@ if [ "$stacked" = "true" ] && [ -z "$(git ls-remote --heads origin "$base")" ]; 
 fi
 ```
 
-Don't push the parent automatically — that's a stack-wide action and belongs to `gt`.
+Don't push the parent automatically; that's a stack-wide action and belongs to `gt`.
 
 Then push HEAD:
 
@@ -201,7 +216,7 @@ git push --set-upstream origin HEAD
 
 If the push fails, report the error and stop.
 
-### 8. Create or Update PR
+### 9. Create or Update PR
 
 **New PR:**
 
@@ -216,7 +231,7 @@ EOF
   [--draft if draft=true]
 ```
 
-**Existing PR** (found in Step 2 — note the existing body may already contain a `<details><summary>Manual test plan</summary>…</details>` block; replace it with the new one rather than appending):
+**Existing PR** (found in Step 2; note the existing body may already contain a `<details><summary>Manual test plan</summary>…</details>` block, so replace it with the new one rather than appending):
 
 ```bash
 gh pr edit <number> \
@@ -239,6 +254,6 @@ If `draft=false` and the existing PR is a draft:
 gh pr ready <number>
 ```
 
-### 9. Report Result
+### 10. Report Result
 
-On success, display the PR URL. On failure, show the full error output and stop — do not retry silently.
+On success, display the PR URL. On failure, show the full error output and stop. Do not retry silently.


### PR DESCRIPTION
## Summary

The previous voice rules in the `create-pr` skill failed in practice. PostHog/posthog#56869 produced multiple em dashes, bold text inside prose, and bolded pseudo-labels (`Root cause:`, `Caveat:`) despite existing guidance against them.

Voice was buried as a subsection of body composition, and the self-check ran after the body was already drafted. A review pass on a fresh draft produces stylistic patches, not a rewrite, so the same AI tells slipped through.

## What changed

- Promoted voice to a top-level `## Writing voice` section before `## Arguments`. Top-level sections get higher attention weight than nested ones.
- Reduced hard "Never" rules from eight to three (em dashes, bold inside prose, bolded pseudo-labels). Eight credible-looking rules train the model to budget attention across them; three credible rules plus a positive paragraph carry more weight per rule.
- Led with a paragraph-level example showing how cause-and-effect prose reads in a human voice. Isolated sentence pairs don't model transitions.
- Replaced the five-substep self-check with a single verification sentence in Step 6.
- Removed em dashes from the skill's own prose, since the file was modeling the behavior it prohibits.

## Test plan

- [ ] Run `/create-pr` on a follow-up branch and confirm the body has no em dashes, no bold inside prose, and no `Root cause:` or `Caveat:` style pseudo-labels.
- [ ] Spot-check that the body still describes the change accurately and includes a working test plan.
- [ ] This PR's own description is the first datapoint; if it reads as AI-generated, the rules still need work.