### PR TITLE
Re-review PRs with new commits since last review

### DIFF
--- a/bin/lib/github.sh
+++ b/bin/lib/github.sh
@@ -5,9 +5,17 @@
 #   source "${SCRIPT_DIR}/lib/github.sh"
 #
 # Functions:
+#   get_github_user   - Print the authenticated GitHub username, or exit
 #   parse_pr_url      - Parse a GitHub PR URL into OWNER, REPO_NAME, REPO, PR_NUMBER
 #   get_current_repo  - Get the current repo as owner/name
 #   resolve_pr_target - Resolve a PR argument (URL, number, or branch) into OWNER, REPO_NAME, REPO, PR_NUMBER
+
+get_github_user() {
+  gh api user --jq '.login' 2>/dev/null || {
+    log_error "Could not determine GitHub username. Are you logged in with 'gh auth login'?"
+    exit 1
+  }
+}
 
 # Parse a GitHub PR URL into OWNER, REPO_NAME, REPO, and PR_NUMBER.
 # Returns 0 on success, 1 if the string is not a valid PR URL.

--- a/bin/lib/review-filter.jq
+++ b/bin/lib/review-filter.jq
@@ -1,0 +1,29 @@
+# review-filter.jq - Discovery filter for review-all-prs.sh.
+#
+# Variables (pass via --arg / --argjson):
+#   $user             - GitHub username
+#   $include_reviewed - bool; if true, skip the new-commits gate
+#
+# Keeps PRs the user hasn't reviewed and PRs with commits newer than the
+# user's last review. PENDING (draft) reviews have null submittedAt, so fall
+# back to createdAt for the comparison.
+
+map(
+  (.reviews.nodes | map(select(.author.login == $user)) | last) as $last_review
+  | (if $last_review == null then null
+     else ($last_review.submittedAt // $last_review.createdAt) end) as $last_review_at
+  | select($include_reviewed
+          or $last_review_at == null
+          or .commits.nodes[0].commit.committedDate > $last_review_at)
+  | {
+      number: .number,
+      title: .title,
+      url: .url,
+      repo: .repository.nameWithOwner,
+      author: .author.login,
+      updated_at: .updatedAt,
+      user_review_state: $last_review.state
+    }
+)
+| sort_by(.updated_at)
+| reverse

--- a/bin/lib/test-review-filter.sh
+++ b/bin/lib/test-review-filter.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Tests for the jq filtering logic used in review-all-prs.sh.
+# Tests for the discovery jq filter loaded by review-all-prs.sh.
 #
 # Usage: test-review-filter.sh
 
@@ -10,32 +10,26 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=bin/lib/test-helpers.sh
 source "$SCRIPT_DIR/test-helpers.sh"
 
-# The jq filter extracted from review-all-prs.sh. Keep this in sync with the
-# `PROCESSED=...` block in that script.
 filter_prs() {
     local user="$1"
     local include_reviewed="$2"
     local input="$3"
-    echo "$input" | jq --arg user "$user" --argjson include_reviewed "$include_reviewed" '
-      map(
-        (.reviews.nodes | map(select(.author.login == $user)) | last) as $last_review
-        | (if $last_review == null then null
-           else ($last_review.submittedAt // $last_review.createdAt) end) as $last_review_at
-        | .commits.nodes[0].commit.committedDate as $last_commit_at
-        | select($include_reviewed
-                or $last_review_at == null
-                or $last_commit_at > $last_review_at)
-        | {
-            number: .number,
-            url: .url,
-            user_review_state: $last_review.state
-          }
-      )
-      | sort_by(.number)
-    '
+    echo "$input" | jq \
+        --arg user "$user" \
+        --argjson include_reviewed "$include_reviewed" \
+        -f "$SCRIPT_DIR/review-filter.jq"
 }
 
-# Build a PR JSON node for testing.
+make_review() {
+    # login state submittedAt(or empty for null) createdAt
+    jq -n --arg l "$1" --arg s "$2" --arg sub "$3" --arg cre "$4" '{
+        author: {login: $l},
+        state: $s,
+        submittedAt: (if $sub == "" then null else $sub end),
+        createdAt: $cre
+    }'
+}
+
 make_pr() {
     local number="$1"
     local last_commit_at="$2"
@@ -55,38 +49,36 @@ make_pr() {
 # ── Test data ─────────────────────────────────────────────────────────────
 
 USER="me"
+T08="2024-01-15T08:00:00Z"
+T09="2024-01-15T09:00:00Z"
+T0930="2024-01-15T09:30:00Z"
+T10="2024-01-15T10:00:00Z"
+T11="2024-01-15T11:00:00Z"
 
-# 1: never reviewed (no reviews from anyone)
-pr_unreviewed=$(make_pr 1 "2024-01-15T10:00:00Z" "[]")
+# 1: never reviewed
+pr_unreviewed=$(make_pr 1 "$T10" "[]")
 
 # 2: APPROVED with new commits since review (re-review candidate)
-pr_approved_new=$(make_pr 2 "2024-01-15T11:00:00Z" \
-    '[{"author": {"login": "me"}, "state": "APPROVED", "submittedAt": "2024-01-15T10:00:00Z", "createdAt": "2024-01-15T10:00:00Z"}]')
+pr_approved_new=$(make_pr 2 "$T11" "[$(make_review me APPROVED "$T10" "$T10")]")
 
 # 3: APPROVED with no new commits since review (skip)
-pr_approved_stale=$(make_pr 3 "2024-01-15T09:00:00Z" \
-    '[{"author": {"login": "me"}, "state": "APPROVED", "submittedAt": "2024-01-15T10:00:00Z", "createdAt": "2024-01-15T10:00:00Z"}]')
+pr_approved_stale=$(make_pr 3 "$T09" "[$(make_review me APPROVED "$T10" "$T10")]")
 
 # 4: PENDING (submittedAt null), commits after createdAt (refresh draft)
-pr_pending_new=$(make_pr 4 "2024-01-15T11:00:00Z" \
-    '[{"author": {"login": "me"}, "state": "PENDING", "submittedAt": null, "createdAt": "2024-01-15T10:00:00Z"}]')
+pr_pending_new=$(make_pr 4 "$T11" "[$(make_review me PENDING "" "$T10")]")
 
 # 5: PENDING with no new commits since createdAt (skip)
-pr_pending_stale=$(make_pr 5 "2024-01-15T09:00:00Z" \
-    '[{"author": {"login": "me"}, "state": "PENDING", "submittedAt": null, "createdAt": "2024-01-15T10:00:00Z"}]')
+pr_pending_stale=$(make_pr 5 "$T09" "[$(make_review me PENDING "" "$T10")]")
 
 # 6: COMMENTED with no new commits — new filter drops this (old filter kept it)
-pr_commented_stale=$(make_pr 6 "2024-01-15T09:00:00Z" \
-    '[{"author": {"login": "me"}, "state": "COMMENTED", "submittedAt": "2024-01-15T10:00:00Z", "createdAt": "2024-01-15T10:00:00Z"}]')
+pr_commented_stale=$(make_pr 6 "$T09" "[$(make_review me COMMENTED "$T10" "$T10")]")
 
 # 7: only reviewed by another user — treated as unreviewed by me
-pr_other_review=$(make_pr 7 "2024-01-15T09:00:00Z" \
-    '[{"author": {"login": "other"}, "state": "APPROVED", "submittedAt": "2024-01-15T10:00:00Z", "createdAt": "2024-01-15T10:00:00Z"}]')
+pr_other_review=$(make_pr 7 "$T09" "[$(make_review other APPROVED "$T10" "$T10")]")
 
-# 8: multiple reviews by user; "last" should win (older COMMENTED, newer APPROVED with no new commits → skip)
-pr_multi_review=$(make_pr 8 "2024-01-15T09:30:00Z" \
-    '[{"author": {"login": "me"}, "state": "COMMENTED", "submittedAt": "2024-01-15T08:00:00Z", "createdAt": "2024-01-15T08:00:00Z"},
-      {"author": {"login": "me"}, "state": "APPROVED", "submittedAt": "2024-01-15T10:00:00Z", "createdAt": "2024-01-15T10:00:00Z"}]')
+# 8: multiple reviews by user; "last" wins (older COMMENTED, newer APPROVED, no new commits → skip)
+pr_multi_review=$(make_pr 8 "$T0930" \
+    "[$(make_review me COMMENTED "$T08" "$T08"),$(make_review me APPROVED "$T10" "$T10")]")
 
 input=$(jq -s '.' <<EOF
 $pr_unreviewed
@@ -103,7 +95,7 @@ EOF
 # ── Test: default filter keeps unreviewed and PRs with new commits ────────
 
 result=$(filter_prs "$USER" "false" "$input")
-numbers=$(echo "$result" | jq -c '[.[].number]')
+numbers=$(echo "$result" | jq -c '[.[].number] | sort')
 assert "default filter keeps {1, 2, 4, 7}: unreviewed, approved-with-new-commits, pending-with-new-commits, other-reviewer" \
     test "$numbers" = "[1,2,4,7]"
 
@@ -133,8 +125,7 @@ assert "COMMENTED with no new commits is dropped" test "$count" -eq 0
 
 # ── Test: equal timestamps drop (commit must be strictly newer) ──────────
 
-pr_equal=$(make_pr 9 "2024-01-15T10:00:00Z" \
-    '[{"author": {"login": "me"}, "state": "APPROVED", "submittedAt": "2024-01-15T10:00:00Z", "createdAt": "2024-01-15T10:00:00Z"}]')
+pr_equal=$(make_pr 9 "$T10" "[$(make_review me APPROVED "$T10" "$T10")]")
 result=$(filter_prs "$USER" "false" "[$pr_equal]")
 count=$(echo "$result" | jq 'length')
 assert "equal commit and review timestamps drop the PR" test "$count" -eq 0

--- a/bin/lib/test-review-filter.sh
+++ b/bin/lib/test-review-filter.sh
@@ -1,0 +1,162 @@
+#!/bin/bash
+# Tests for the jq filtering logic used in review-all-prs.sh.
+#
+# Usage: test-review-filter.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# shellcheck source=bin/lib/test-helpers.sh
+source "$SCRIPT_DIR/test-helpers.sh"
+
+# The jq filter extracted from review-all-prs.sh. Keep this in sync with the
+# `PROCESSED=...` block in that script.
+filter_prs() {
+    local user="$1"
+    local include_reviewed="$2"
+    local input="$3"
+    echo "$input" | jq --arg user "$user" --argjson include_reviewed "$include_reviewed" '
+      map(
+        (.reviews.nodes | map(select(.author.login == $user)) | last) as $last_review
+        | (if $last_review == null then null
+           else ($last_review.submittedAt // $last_review.createdAt) end) as $last_review_at
+        | .commits.nodes[0].commit.committedDate as $last_commit_at
+        | select($include_reviewed
+                or $last_review_at == null
+                or $last_commit_at > $last_review_at)
+        | {
+            number: .number,
+            url: .url,
+            user_review_state: $last_review.state
+          }
+      )
+      | sort_by(.number)
+    '
+}
+
+# Build a PR JSON node for testing.
+make_pr() {
+    local number="$1"
+    local last_commit_at="$2"
+    local reviews_json="$3"
+    jq -n --argjson n "$number" --arg c "$last_commit_at" --argjson r "$reviews_json" '{
+        number: $n,
+        title: ("PR " + ($n | tostring)),
+        url: ("https://github.com/org/repo/pull/" + ($n | tostring)),
+        repository: {nameWithOwner: "org/repo"},
+        author: {login: "author"},
+        updatedAt: "2024-01-15T10:00:00Z",
+        reviews: {nodes: $r},
+        commits: {nodes: [{commit: {committedDate: $c}}]}
+    }'
+}
+
+# ── Test data ─────────────────────────────────────────────────────────────
+
+USER="me"
+
+# 1: never reviewed (no reviews from anyone)
+pr_unreviewed=$(make_pr 1 "2024-01-15T10:00:00Z" "[]")
+
+# 2: APPROVED with new commits since review (re-review candidate)
+pr_approved_new=$(make_pr 2 "2024-01-15T11:00:00Z" \
+    '[{"author": {"login": "me"}, "state": "APPROVED", "submittedAt": "2024-01-15T10:00:00Z", "createdAt": "2024-01-15T10:00:00Z"}]')
+
+# 3: APPROVED with no new commits since review (skip)
+pr_approved_stale=$(make_pr 3 "2024-01-15T09:00:00Z" \
+    '[{"author": {"login": "me"}, "state": "APPROVED", "submittedAt": "2024-01-15T10:00:00Z", "createdAt": "2024-01-15T10:00:00Z"}]')
+
+# 4: PENDING (submittedAt null), commits after createdAt (refresh draft)
+pr_pending_new=$(make_pr 4 "2024-01-15T11:00:00Z" \
+    '[{"author": {"login": "me"}, "state": "PENDING", "submittedAt": null, "createdAt": "2024-01-15T10:00:00Z"}]')
+
+# 5: PENDING with no new commits since createdAt (skip)
+pr_pending_stale=$(make_pr 5 "2024-01-15T09:00:00Z" \
+    '[{"author": {"login": "me"}, "state": "PENDING", "submittedAt": null, "createdAt": "2024-01-15T10:00:00Z"}]')
+
+# 6: COMMENTED with no new commits — new filter drops this (old filter kept it)
+pr_commented_stale=$(make_pr 6 "2024-01-15T09:00:00Z" \
+    '[{"author": {"login": "me"}, "state": "COMMENTED", "submittedAt": "2024-01-15T10:00:00Z", "createdAt": "2024-01-15T10:00:00Z"}]')
+
+# 7: only reviewed by another user — treated as unreviewed by me
+pr_other_review=$(make_pr 7 "2024-01-15T09:00:00Z" \
+    '[{"author": {"login": "other"}, "state": "APPROVED", "submittedAt": "2024-01-15T10:00:00Z", "createdAt": "2024-01-15T10:00:00Z"}]')
+
+# 8: multiple reviews by user; "last" should win (older COMMENTED, newer APPROVED with no new commits → skip)
+pr_multi_review=$(make_pr 8 "2024-01-15T09:30:00Z" \
+    '[{"author": {"login": "me"}, "state": "COMMENTED", "submittedAt": "2024-01-15T08:00:00Z", "createdAt": "2024-01-15T08:00:00Z"},
+      {"author": {"login": "me"}, "state": "APPROVED", "submittedAt": "2024-01-15T10:00:00Z", "createdAt": "2024-01-15T10:00:00Z"}]')
+
+input=$(jq -s '.' <<EOF
+$pr_unreviewed
+$pr_approved_new
+$pr_approved_stale
+$pr_pending_new
+$pr_pending_stale
+$pr_commented_stale
+$pr_other_review
+$pr_multi_review
+EOF
+)
+
+# ── Test: default filter keeps unreviewed and PRs with new commits ────────
+
+result=$(filter_prs "$USER" "false" "$input")
+numbers=$(echo "$result" | jq -c '[.[].number]')
+assert "default filter keeps {1, 2, 4, 7}: unreviewed, approved-with-new-commits, pending-with-new-commits, other-reviewer" \
+    test "$numbers" = "[1,2,4,7]"
+
+# ── Test: --include-reviewed keeps every PR ───────────────────────────────
+
+result=$(filter_prs "$USER" "true" "$input")
+count=$(echo "$result" | jq 'length')
+assert "include_reviewed=true keeps all 8 PRs" test "$count" -eq 8
+
+# ── Test: PENDING fallback to createdAt admits draft refresh ──────────────
+
+result=$(filter_prs "$USER" "false" "[$pr_pending_new]")
+state=$(echo "$result" | jq -r '.[0].user_review_state')
+assert "PENDING with new commits is kept via createdAt fallback" test "$state" = "PENDING"
+
+# ── Test: PENDING with no new commits drops ───────────────────────────────
+
+result=$(filter_prs "$USER" "false" "[$pr_pending_stale]")
+count=$(echo "$result" | jq 'length')
+assert "PENDING with no new commits is dropped" test "$count" -eq 0
+
+# ── Test: COMMENTED with no new commits drops (new filter behavior) ──────
+
+result=$(filter_prs "$USER" "false" "[$pr_commented_stale]")
+count=$(echo "$result" | jq 'length')
+assert "COMMENTED with no new commits is dropped" test "$count" -eq 0
+
+# ── Test: equal timestamps drop (commit must be strictly newer) ──────────
+
+pr_equal=$(make_pr 9 "2024-01-15T10:00:00Z" \
+    '[{"author": {"login": "me"}, "state": "APPROVED", "submittedAt": "2024-01-15T10:00:00Z", "createdAt": "2024-01-15T10:00:00Z"}]')
+result=$(filter_prs "$USER" "false" "[$pr_equal]")
+count=$(echo "$result" | jq 'length')
+assert "equal commit and review timestamps drop the PR" test "$count" -eq 0
+
+# ── Test: latest review by user wins (multiple reviews) ──────────────────
+
+result=$(filter_prs "$USER" "false" "[$pr_multi_review]")
+count=$(echo "$result" | jq 'length')
+assert "multiple reviews: APPROVED-latest with no new commits drops" test "$count" -eq 0
+
+# ── Test: empty input ─────────────────────────────────────────────────────
+
+result=$(filter_prs "$USER" "false" "[]")
+count=$(echo "$result" | jq 'length')
+assert "empty input returns empty output" test "$count" -eq 0
+
+# ── Test: user_review_state is null for unreviewed PR ─────────────────────
+
+result=$(filter_prs "$USER" "false" "[$pr_unreviewed]")
+state=$(echo "$result" | jq '.[0].user_review_state')
+assert "unreviewed PR has null user_review_state in output" test "$state" = "null"
+
+# ── Results ───────────────────────────────────────────────────────────────
+
+print_results

--- a/bin/pr-review.sh
+++ b/bin/pr-review.sh
@@ -16,13 +16,6 @@ source "${SCRIPT_DIR}/lib/github.sh"
 
 # ── Helpers ──────────────────────────────────────────────────────────────────
 
-get_github_user() {
-  gh api user --jq '.login' 2>/dev/null || {
-    log_error "Could not determine GitHub username. Are you logged in with 'gh auth login'?"
-    exit 1
-  }
-}
-
 # Fetch pending reviews for a single PR. Prints JSON array of matching reviews.
 fetch_pending_reviews() {
   local repo="$1" pr="$2" user="$3"

--- a/bin/review-all-prs.sh
+++ b/bin/review-all-prs.sh
@@ -24,11 +24,18 @@
 #       "repo": "org/repo",
 #       "author": "username",
 #       "updated_at": "2024-01-15T10:30:00Z",
-#       "user_review_state": null
+#       "user_review_state": null,
+#       "my_last_review_at": null,
+#       "last_commit_at": "2024-01-15T10:25:00Z",
+#       "has_new_commits": true
 #     }
 #   ]
 
 set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/lib/logging.sh"
+source "${SCRIPT_DIR}/lib/github.sh"
 
 # Defaults
 ORG="PostHog"
@@ -98,15 +105,8 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-# Get current GitHub username
-GITHUB_USER=$(gh api user --jq '.login')
-if [[ -z "$GITHUB_USER" ]]; then
-  echo "Could not determine GitHub username. Are you logged in with 'gh auth login'?" >&2
-  exit 1
-fi
+GITHUB_USER=$(get_github_user)
 
-# GraphQL query to find PRs where user is requested reviewer
-# Includes review state to filter out already-reviewed PRs
 # shellcheck disable=SC2016 # GraphQL variables use $ syntax, not shell expansion
 QUERY='
 query($searchQuery: String!, $limit: Int!) {
@@ -130,6 +130,15 @@ query($searchQuery: String!, $limit: Int!) {
                 login
               }
               state
+              submittedAt
+              createdAt
+            }
+          }
+          commits(last: 1) {
+            nodes {
+              commit {
+                committedDate
+              }
             }
           }
         }
@@ -171,26 +180,30 @@ done
 # Deduplicate by PR URL
 ALL_RESULTS=$(echo "$ALL_RESULTS" | jq 'unique_by(.url)')
 
-# Process results with jq
-# - Extract PR data
-# - Check if user has already reviewed
-# - Filter based on --include-reviewed flag
+# Filter to PRs never reviewed by the user, or with commits newer than the
+# user's last review. PENDING (draft) reviews have null submittedAt, so fall
+# back to createdAt for the comparison.
 PROCESSED=$(echo "$ALL_RESULTS" | jq --arg user "$GITHUB_USER" --argjson include_reviewed "$INCLUDE_REVIEWED" '
-  map({
-      number: .number,
-      title: .title,
-      url: .url,
-      repo: .repository.nameWithOwner,
-      author: .author.login,
-      updated_at: .updatedAt,
-      user_review_state: (
-        .reviews.nodes
-        | map(select(.author.login == $user))
-        | map(.state)
-        | if length > 0 then .[-1] else null end
-      )
-    })
-  | if $include_reviewed then . else map(select(.user_review_state != "APPROVED")) end
+  map(
+    (.reviews.nodes | map(select(.author.login == $user)) | last) as $last_review
+    | (if $last_review == null then null
+       else ($last_review.submittedAt // $last_review.createdAt) end) as $last_review_at
+    | (.commits.nodes[0].commit.committedDate // null) as $last_commit_at
+    | {
+        number: .number,
+        title: .title,
+        url: .url,
+        repo: .repository.nameWithOwner,
+        author: .author.login,
+        updated_at: .updatedAt,
+        user_review_state: ($last_review.state // null),
+        my_last_review_at: $last_review_at,
+        last_commit_at: $last_commit_at,
+        has_new_commits: ($last_review_at == null or $last_commit_at > $last_review_at)
+      }
+  )
+  | if $include_reviewed then .
+    else map(select(.user_review_state == null or .has_new_commits)) end
   | sort_by(.updated_at)
   | reverse
 ')

--- a/bin/review-all-prs.sh
+++ b/bin/review-all-prs.sh
@@ -177,31 +177,10 @@ done
 # Deduplicate by PR URL
 ALL_RESULTS=$(echo "$ALL_RESULTS" | jq 'unique_by(.url)')
 
-# Keep PRs the user hasn't reviewed and PRs with commits newer than the user's
-# last review. PENDING (draft) reviews have null submittedAt, so fall back to
-# createdAt for the comparison.
-PROCESSED=$(echo "$ALL_RESULTS" | jq --arg user "$GITHUB_USER" --argjson include_reviewed "$INCLUDE_REVIEWED" '
-  map(
-    (.reviews.nodes | map(select(.author.login == $user)) | last) as $last_review
-    | (if $last_review == null then null
-       else ($last_review.submittedAt // $last_review.createdAt) end) as $last_review_at
-    | .commits.nodes[0].commit.committedDate as $last_commit_at
-    | select($include_reviewed
-            or $last_review_at == null
-            or $last_commit_at > $last_review_at)
-    | {
-        number: .number,
-        title: .title,
-        url: .url,
-        repo: .repository.nameWithOwner,
-        author: .author.login,
-        updated_at: .updatedAt,
-        user_review_state: $last_review.state
-      }
-  )
-  | sort_by(.updated_at)
-  | reverse
-')
+PROCESSED=$(echo "$ALL_RESULTS" | jq \
+  --arg user "$GITHUB_USER" \
+  --argjson include_reviewed "$INCLUDE_REVIEWED" \
+  -f "${SCRIPT_DIR}/lib/review-filter.jq")
 
 # Count results
 COUNT=$(echo "$PROCESSED" | jq 'length')

--- a/bin/review-all-prs.sh
+++ b/bin/review-all-prs.sh
@@ -24,10 +24,7 @@
 #       "repo": "org/repo",
 #       "author": "username",
 #       "updated_at": "2024-01-15T10:30:00Z",
-#       "user_review_state": null,
-#       "my_last_review_at": null,
-#       "last_commit_at": "2024-01-15T10:25:00Z",
-#       "has_new_commits": true
+#       "user_review_state": null
 #     }
 #   ]
 
@@ -180,15 +177,18 @@ done
 # Deduplicate by PR URL
 ALL_RESULTS=$(echo "$ALL_RESULTS" | jq 'unique_by(.url)')
 
-# Filter to PRs never reviewed by the user, or with commits newer than the
-# user's last review. PENDING (draft) reviews have null submittedAt, so fall
-# back to createdAt for the comparison.
+# Keep PRs the user hasn't reviewed and PRs with commits newer than the user's
+# last review. PENDING (draft) reviews have null submittedAt, so fall back to
+# createdAt for the comparison.
 PROCESSED=$(echo "$ALL_RESULTS" | jq --arg user "$GITHUB_USER" --argjson include_reviewed "$INCLUDE_REVIEWED" '
   map(
     (.reviews.nodes | map(select(.author.login == $user)) | last) as $last_review
     | (if $last_review == null then null
        else ($last_review.submittedAt // $last_review.createdAt) end) as $last_review_at
-    | (.commits.nodes[0].commit.committedDate // null) as $last_commit_at
+    | .commits.nodes[0].commit.committedDate as $last_commit_at
+    | select($include_reviewed
+            or $last_review_at == null
+            or $last_commit_at > $last_review_at)
     | {
         number: .number,
         title: .title,
@@ -196,14 +196,9 @@ PROCESSED=$(echo "$ALL_RESULTS" | jq --arg user "$GITHUB_USER" --argjson include
         repo: .repository.nameWithOwner,
         author: .author.login,
         updated_at: .updatedAt,
-        user_review_state: ($last_review.state // null),
-        my_last_review_at: $last_review_at,
-        last_commit_at: $last_commit_at,
-        has_new_commits: ($last_review_at == null or $last_commit_at > $last_review_at)
+        user_review_state: $last_review.state
       }
   )
-  | if $include_reviewed then .
-    else map(select(.user_review_state == null or .has_new_commits)) end
   | sort_by(.updated_at)
   | reverse
 ')

--- a/bin/run-pr-reviews.sh
+++ b/bin/run-pr-reviews.sh
@@ -25,9 +25,9 @@
 
 set -euo pipefail
 
-# Source shared logging utilities
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/lib/logging.sh"
+source "${SCRIPT_DIR}/lib/github.sh"
 
 # Configuration
 STATE_DIR="${HOME}/.local/state/review-all-prs"
@@ -306,8 +306,16 @@ run_review() {
   local review_file="${review_dir}/pr-${pr_number}-$(date +%Y%m%d).md"
   mkdir -p "$review_dir"
 
+  # --append targets the skill's persistent per-PR file, which is separate
+  # from the date-stamped file this orchestrator writes.
+  local prompt="/review-code ${pr_url} --force --draft"
+  if review_exists "$pr_number" "$pr_repo"; then
+    prompt+=" --append"
+    log_info "Existing review file detected, will append"
+  fi
+
   if [[ "$DRY_RUN" == "true" ]]; then
-    log_info "[DRY RUN] Would run: claude -p --max-budget-usd ${MAX_BUDGET} \"/review-code ${pr_url} --force --draft\""
+    log_info "[DRY RUN] Would run: claude -p --max-budget-usd ${MAX_BUDGET} \"${prompt}\""
     log_info "[DRY RUN] Output would be saved to: ${review_file}"
     return 0
   fi
@@ -336,7 +344,7 @@ run_review() {
   output_file=$(mktemp)
   start_heartbeat 30 "Claude reviewing PR #${pr_number}"
   set +o pipefail
-  timeout "$REVIEW_TIMEOUT_SECONDS" claude -p --max-budget-usd "$MAX_BUDGET" "/review-code ${pr_url} --force --draft" 2>&1 | tee "$output_file" || true
+  timeout "$REVIEW_TIMEOUT_SECONDS" claude -p --max-budget-usd "$MAX_BUDGET" "$prompt" 2>&1 | tee "$output_file" || true
   exit_code=${PIPESTATUS[0]}
   set -o pipefail
   stop_heartbeat
@@ -422,7 +430,7 @@ main() {
 
   # Get current GitHub username (for skipping self-authored PRs)
   local github_user
-  github_user=$(gh api user --jq '.login')
+  github_user=$(get_github_user)
 
   # Get PR list
   local pr_list
@@ -447,9 +455,7 @@ main() {
   # Process each PR (using process substitution to avoid subshell variable loss)
   while read -r pr; do
     local pr_url pr_number pr_title pr_repo pr_author
-
-    local user_review_state
-    IFS=$'\t' read -r pr_url pr_number pr_title pr_repo pr_author user_review_state < <(echo "$pr" | jq -r '[.url, (.number | tostring), .title, .repo, .author, (.user_review_state // empty)] | @tsv')
+    IFS=$'\t' read -r pr_url pr_number pr_title pr_repo pr_author < <(echo "$pr" | jq -r '[.url, (.number | tostring), .title, .repo, .author] | @tsv')
 
     echo ""
     log_info "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
@@ -464,24 +470,13 @@ main() {
 
     # Check if already reviewed today
     if is_reviewed "$pr_url"; then
-      log_warn "Skipping PR #${pr_number} - already reviewed today"
+      log_warn "Skipping PR #${pr_number}, already reviewed today"
       mark_skipped "$pr_url"
       ((skipped++)) || true
       continue
     fi
 
-    # Best-effort dedup for concurrent runs — not a lock, but catches the
-    # common case where a prior run already completed a review. For re-reviews
-    # (non-empty user_review_state), an old review file on disk is expected, so
-    # skip this check to allow the re-review to proceed.
-    if [[ -z "$user_review_state" ]] && review_exists "$pr_number" "$pr_repo"; then
-      log_warn "Skipping PR #${pr_number} - review already exists"
-      mark_skipped "$pr_url"
-      ((skipped++)) || true
-      continue
-    fi
-
-    # Run the review
+    # Discovery already filtered to PRs with new commits since the last review.
     if run_review "$pr_url" "$pr_number" "$pr_title" "$pr_repo"; then
       ((reviewed++)) || true
     else

--- a/bin/run-pr-reviews.sh
+++ b/bin/run-pr-reviews.sh
@@ -476,7 +476,7 @@ main() {
       continue
     fi
 
-    # Discovery already filtered to PRs with new commits since the last review.
+    # First-time reviews and re-reviews proceed; existing review files extend via --append (set in run_review).
     if run_review "$pr_url" "$pr_number" "$pr_title" "$pr_repo"; then
       ((reviewed++)) || true
     else


### PR DESCRIPTION
The auto-review orchestrator now re-reviews PRs that have new commits since my last review, instead of skipping them once a review exists. PENDING (draft) reviews fall back to `createdAt` since `submittedAt` is null until the draft is submitted.

The discovery filter is extracted to `bin/lib/review-filter.jq`, loaded by both `bin/review-all-prs.sh` and the new test harness via `jq -f`. This kills the duplicated inline filter and gives the logic dedicated test coverage.

Other cleanup:

- `get_github_user` consolidated into `bin/lib/github.sh` so all auto-review scripts share one helper.
- Re-reviews pass `--append` so the existing review file gets extended rather than replaced.
- Removed the stale "review already exists" skip in `run-pr-reviews.sh`; it blocked the re-review path.

## Test plan

- [ ] Run `bin/lib/test-review-filter.sh` and confirm all 9 assertions pass.
- [ ] Run `bin/review-all-prs.sh --json` and spot-check the output shape (includes `repo`, `author`, `updated_at`, `user_review_state`).
- [ ] Approve a real PR, push a new commit, and confirm the next discovery run includes it.
- [ ] Confirm an approved PR with no new commits is filtered out.
- [ ] Confirm a pending draft review with new commits is kept.