### PR TITLE
Reschedule auto PR review to 6 PM-2 AM window

### DIFF
--- a/bin/review-all-prs-service.sh
+++ b/bin/review-all-prs-service.sh
@@ -87,7 +87,7 @@ cmd_install() {
 
   launchctl load "$PLIST_DEST"
   log_success "LaunchAgent installed and loaded"
-  log_info "Reviews will run at 9am on weekdays"
+  log_info "Reviews will run hourly from 6 PM to 2 AM"
   log_info "Use '$(basename "$0") start' to run immediately"
 }
 

--- a/macos/LaunchAgents/com.haacked.review-all-prs.plist
+++ b/macos/LaunchAgents/com.haacked.review-all-prs.plist
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.haacked.review-all-prs</string>
+
+    <!--
+        Use zsh login shell so .zshenv provides PATH (Homebrew, ~/.local/bin,
+        Cargo) and path_helper picks up entries from /etc/paths.d.
+    -->
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/zsh</string>
+        <string>-lc</string>
+        <string><![CDATA[
+# Ensure log directory exists
+log_dir="$HOME/.local/state/review-all-prs"
+mkdir -p "$log_dir"
+
+# Run the review script with logging
+exec "$HOME/.dotfiles/bin/run-pr-reviews.sh" --auto --max-prs 5 --team team-flags-platform \
+    >> "$log_dir/launchd.log" 2>&1
+]]></string>
+    </array>
+
+    <!--
+        Run every hour from 6 PM to 2 AM (after-work to pre-workday).
+        Schedule ends at 02:00 so the last invocation completes before 03:00,
+        keeping all auto-review messages inside the 23:00-04:00 Claude
+        5-hour window. With workday start at 08:00, the user opens a fresh
+        5-hour quota bucket.
+    -->
+    <key>StartCalendarInterval</key>
+    <array>
+        <dict>
+            <key>Hour</key>
+            <integer>18</integer>
+            <key>Minute</key>
+            <integer>0</integer>
+        </dict>
+        <dict>
+            <key>Hour</key>
+            <integer>19</integer>
+            <key>Minute</key>
+            <integer>0</integer>
+        </dict>
+        <dict>
+            <key>Hour</key>
+            <integer>20</integer>
+            <key>Minute</key>
+            <integer>0</integer>
+        </dict>
+        <dict>
+            <key>Hour</key>
+            <integer>21</integer>
+            <key>Minute</key>
+            <integer>0</integer>
+        </dict>
+        <dict>
+            <key>Hour</key>
+            <integer>22</integer>
+            <key>Minute</key>
+            <integer>0</integer>
+        </dict>
+        <dict>
+            <key>Hour</key>
+            <integer>23</integer>
+            <key>Minute</key>
+            <integer>0</integer>
+        </dict>
+        <dict>
+            <key>Hour</key>
+            <integer>0</integer>
+            <key>Minute</key>
+            <integer>0</integer>
+        </dict>
+        <dict>
+            <key>Hour</key>
+            <integer>1</integer>
+            <key>Minute</key>
+            <integer>0</integer>
+        </dict>
+        <dict>
+            <key>Hour</key>
+            <integer>2</integer>
+            <key>Minute</key>
+            <integer>0</integer>
+        </dict>
+    </array>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary

- Reschedules the auto PR review LaunchAgent to fire hourly from 6 PM through 2 AM instead of 10 PM through 6 AM.
- Restores `macos/LaunchAgents/com.haacked.review-all-prs.plist` (removed in #51) with the new `StartCalendarInterval` and fixes the stale install message in `review-all-prs-service.sh`.

The previous schedule's last run at 6 AM opened a Claude 5-hour quota window that ran through 11 AM, eating morning interactive headroom. The new window ends at 2 AM, so its quota bucket expires by 4 AM and an 8 AM workday opens a fresh window. This only addresses the rolling 5-hour limit, not the weekly Max-plan limit.

## Test plan

- [ ] `plutil -lint macos/LaunchAgents/com.haacked.review-all-prs.plist` returns OK.
- [ ] `bin/review-all-prs-service.sh install` symlinks the plist into `~/Library/LaunchAgents/` and loads it.
- [ ] `bin/review-all-prs-service.sh status` reports `Symlink: installed` and `Agent: loaded`.
- [ ] `launchctl print gui/$(id -u)/com.haacked.review-all-prs` lists 9 calendar-interval entries (18:00 through 02:00).
- [ ] After the first scheduled run, `~/.local/state/review-all-prs/launchd.log` shows activity and a `session-$(date +%Y-%m-%d).json` file is created.
- [ ] Next-day check: at 8 AM, Claude interactive use shows a fresh 5-hour window with no early "approaching limit" warnings.