### PR TITLE
Add handoff skill for session-to-session context bridges

### DIFF
--- a/ai/install.sh
+++ b/ai/install.sh
@@ -331,18 +331,14 @@ if [ "$INSTALL_HOOKS" = "true" ]; then
         success "Backed up existing settings.json"
     fi
 
-    # Check if hooks are already configured
-    if [ -f "$SETTINGS_FILE" ] && command -v jq > /dev/null 2>&1 && jq -e '.hooks.PostToolUse' "$SETTINGS_FILE" > /dev/null 2>&1; then
-        success "Claude Code hooks already configured"
-    else
-        # Create minimal settings file if it doesn't exist
-        if [ ! -f "$SETTINGS_FILE" ]; then
-            echo '{"model": "sonnet"}' > "$SETTINGS_FILE"
-            success "Created initial settings.json"
-        fi
+    # Create minimal settings file if it doesn't exist
+    if [ ! -f "$SETTINGS_FILE" ]; then
+        echo '{"model": "sonnet"}' > "$SETTINGS_FILE"
+        success "Created initial settings.json"
+    fi
 
-        # Create hooks configuration with separate matchers for each tool
-        HOOKS_CONFIG=$(cat <<'EOF'
+    # Create hooks configuration with separate matchers for each tool
+    HOOKS_CONFIG=$(cat <<'EOF'
 {
   "hooks": {
     "PreToolUse": [
@@ -424,16 +420,31 @@ if [ "$INSTALL_HOOKS" = "true" ]; then
           }
         ]
       }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/skills/handoff/scripts/handoff-detect.sh",
+            "timeout": 5
+          }
+        ]
+      }
     ]
   }
 }
 EOF
-        )
+    )
 
-        # Merge hooks configuration using helper function
-        if merge_json_settings "$SETTINGS_FILE" "$HOOKS_CONFIG" "hooks"; then
-            success "Configured Claude Code hooks"
-        fi
+    # Always run the merge. Do not re-add a `jq -e '.hooks.PostToolUse'` guard:
+    # it would skip the merge for users who already have any PostToolUse entry,
+    # preventing newly-added hook categories (SessionStart, new PreToolUse
+    # matchers, etc.) from ever landing on upgrade. merge_json_settings is
+    # idempotent (jq deep-merge + `unique` on arrays), so re-running is safe.
+    if merge_json_settings "$SETTINGS_FILE" "$HOOKS_CONFIG" "hooks"; then
+        success "Configured Claude Code hooks"
     fi
 fi
 

--- a/ai/skills/handoff/SKILL.md
+++ b/ai/skills/handoff/SKILL.md
@@ -1,0 +1,190 @@
+---
+name: handoff
+description: Write or resume a handoff document so the next Claude session can pick up the current work. Use when context is filling up, when ending a session mid-task, or at the start of a new session that should continue prior work.
+argument-hint: [resume|show|path]
+---
+
+# Session Handoff
+
+Bridge between Claude sessions. Optimized for the next session reading the doc cold, with full tool access but zero conversation history.
+
+## Modes
+
+Parse the first argument from user input.
+
+| Argument | Mode | What it does |
+| --- | --- | --- |
+| (none) | **create** | Write/update the handoff doc for the current work |
+| `resume` | **resume** | Read the existing handoff and bootstrap context for this session |
+| `show` | **show** | Print the existing handoff doc unchanged, then stop |
+| `path` | **path** | Print the resolved storage path and stop |
+
+## Common: resolve the storage path
+
+Always start with the helper. Never construct the path yourself.
+
+```bash
+result=$(~/.claude/skills/handoff/scripts/handoff-path.sh)
+status=$(echo "$result" | cut -f1)   # existing | new
+path=$(echo "$result"   | cut -f2)
+scope=$(echo "$result"  | cut -f3)   # repo:org/name or dir:/abs/path
+```
+
+The helper writes to `<repo-root>/.notes/handoff.md` inside a git repo, or `~/.claude/handoff/dir-<hash>.md` outside one.
+
+---
+
+## Create mode (no argument)
+
+This is the default. Write a handoff doc tuned for the *next Claude session*.
+
+### Step 1: Confirm the scope
+
+Tell the user the resolved scope (e.g., "Writing handoff for `repo:haacked/dotfiles` at `.notes/handoff.md`.").
+
+If `status` is `existing`, **archive the previous handoff** before writing the new one so a trail is preserved. Read the old one first (you may want to carry forward still-relevant content like references or ruled-out approaches), then archive it:
+
+```bash
+archived=$(~/.claude/skills/handoff/scripts/handoff-archive.sh "$path")
+```
+
+The archive script moves the file to `<dir>/handoff-archive/<basename>-<YYYYMMDD-HHMMSS>.md` and prints the new path. Mention to the user that you archived the previous one and where it went.
+
+### Step 2: Bail if there's nothing to hand off
+
+If the conversation contains no concrete work (no files read, no commands run, no decisions made), tell the user:
+
+> No session work to hand off yet. Run `/handoff` again after you've made progress.
+
+Then stop. Do not write a placeholder handoff.
+
+### Step 3: Gather state actively
+
+Do not write the handoff from memory of the conversation. Memory produces narrative; state produces handoffs. Before filling any section, gather concrete state:
+
+- Run `git diff HEAD` and `git status` to see what changed.
+- Read the files you've been working in (don't trust your recall of their current contents).
+- Re-run failing tests or commands you've mentioned, so the verification section reflects reality.
+
+Then capture the git snapshot for embedding:
+
+```bash
+~/.claude/skills/handoff/scripts/handoff-snapshot.sh
+```
+
+This emits a markdown block with branch, HEAD, upstream, and the dirty working tree. Embed it verbatim under the `## Snapshot` heading.
+
+### Step 4: Fill the template
+
+Start from `~/.claude/skills/handoff/templates/handoff.md`. Fill every section from the state you just gathered, not from conversation memory. Optimize for *the next Claude session* specifically:
+
+- **Pointers over prose.** Cite `file.ts:42` instead of paraphrasing code. The next session can read.
+- **Decisions over events.** Don't narrate the session ("first I tried X, then Y"). Record outcomes: what we chose, why, what was ruled out.
+- **Concrete next action.** Name the file, the function, the failing test. "Continue the refactor" is wrong; "edit `foo.ts:42` to handle the null case, then run `pnpm test bar.spec.ts`" is right.
+- **Decay-aware.** The snapshot timestamps the doc. Don't pretend it stays fresh: the doc tells the reader to trust the code over the doc if they conflict.
+- **One page.** If you're past ~1 page, the doc is wrong: split the work smaller or commit in-progress state to a branch and let the diff carry the load.
+
+Anti-example pair, internalize the difference:
+
+- ❌ "We spent the session trying to understand why the tests fail."
+- ✅ "`foo.ts:42` throws when `opts` is null; `pnpm test bar.spec.ts` currently fails at line 67."
+
+Sections to fill (see template for prompts):
+
+1. **Goal** (one sentence, outcome not task)
+2. **Status** (concrete bullets: ✅ works, 🚧 in progress, ❌ broken)
+3. **Next action** (file:line specific)
+4. **Open decisions** (options + tradeoff + leaning, or "None.")
+5. **Ruled out** (approach + one-line reason)
+6. **Verification** (copy-pasteable commands)
+7. **Key locations** (file paths + one-line what's there)
+8. **Gotchas** (non-obvious traps, or "None.")
+9. **References** (PR/issue/Slack links, or omit section)
+
+Deliberately exclude: diff dumps, session narrative, re-explanations of readable code, speculation about future phases.
+
+### Step 5: Write the file
+
+```bash
+mkdir -p "$(dirname "$path")"
+```
+
+Then write the filled-in markdown to `$path`. If a `.notes/` directory exists alongside the file, verify it's gitignored (warn the user if not).
+
+### Step 6: Report
+
+Tell the user the path you wrote. One line. Suggest next steps:
+
+> Wrote handoff to `<path>`. Next session: open this repo and run `/handoff resume`.
+
+---
+
+## Resume mode (`resume`)
+
+Bootstrap the current session from an existing handoff.
+
+### Step 1: Read
+
+If `status` is `new`, tell the user no handoff exists for this scope and stop.
+
+Otherwise, read the file at `$path`.
+
+### Step 2: Reconcile with current state
+
+Run `handoff-snapshot.sh` again and compare to the snapshot embedded in the doc:
+
+- **Same branch + HEAD**: doc is fresh, proceed.
+- **Same branch, HEAD moved**: warn the user that work happened since the handoff was written. Suggest running `git log <doc-head>..HEAD` to see what changed.
+- **Different branch**: ask the user whether to switch branches or treat the handoff as reference only. In reference-only mode, present Goal and Ruled out as probably still valid; treat Status, Next action, and Snapshot as stale and skip them in the summary.
+- **Working tree differs from snapshot**: note it, don't block.
+
+Also check relevance: if the handoff's Goal has no relationship to the current working directory or recent git activity, say so explicitly:
+
+> This handoff describes [goal] but current state suggests different work. Treat as reference only, or archive it and start fresh.
+
+### Step 3: Summarize and propose action
+
+Give the user a tight summary:
+
+- Goal (verbatim from doc)
+- Status (verbatim, unless reference-only mode)
+- The **Next action** the doc names (unless reference-only mode)
+
+Then propose: "Do you want me to start on the next action, or do something else first?" Do not begin the work unilaterally, resuming is the user's call.
+
+### Step 4: Offer to archive (after the user decides)
+
+Hold the archive question until the user has confirmed what they want to do next (accept the proposed action, name a different action, or say they're unsure). Then offer to archive:
+
+```bash
+archived=$(~/.claude/skills/handoff/scripts/handoff-archive.sh "$path")
+```
+
+Default to yes since a stale doc on disk encourages re-loading outdated state. Report the archive path so the user knows the trail exists. If the user is still deciding or declines, leave the file in place.
+
+---
+
+## Show mode (`show`)
+
+Just print the file contents and stop. No interpretation, no reconciliation. Use when the user wants to see the handoff without acting on it.
+
+If the file doesn't exist, say so and stop.
+
+---
+
+## Path mode (`path`)
+
+Print the resolved storage path and the scope. One line. Use when the user wants to know where the handoff lives (e.g., to gitignore it or open it in an editor).
+
+---
+
+## Boundary: /handoff vs /note vs plans
+
+| Use `/handoff` for | Use `/note` for | Use a plan for |
+| --- | --- | --- |
+| Mid-task session bridges | Permanent technical discoveries | Multi-stage implementation roadmap |
+| Disposable, repo-scoped, single file | Indefinite, slug-named, many files | Phased, stage-by-stage |
+| Lives in `.notes/handoff.md` | Lives in `~/dev/.../notes/` | Lives in `~/dev/.../plans/` |
+| Next-session-readable | Future-dev-readable | Implementer-readable |
+
+If the handoff outgrows one page or starts capturing knowledge that outlives the task, promote the relevant parts to `/note` (technical) or a plan (multi-stage work) and keep the handoff tight.

--- a/ai/skills/handoff/scripts/handoff-archive.sh
+++ b/ai/skills/handoff/scripts/handoff-archive.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Move a handoff doc into the sibling handoff-archive/ directory.
+# Usage: handoff-archive.sh <path-to-handoff.md>
+# Output: prints the archived path on success, or nothing if source missing.
+
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+    echo "Usage: handoff-archive.sh <path-to-handoff.md>" >&2
+    exit 1
+fi
+
+src="$1"
+
+if [[ ! -f "$src" ]]; then
+    exit 0
+fi
+
+src_dir=$(dirname "$src")
+src_base=$(basename "$src" .md)
+ts=$(date '+%Y%m%d-%H%M%S')
+archive_dir="${src_dir}/handoff-archive"
+
+mkdir -p "$archive_dir"
+
+# Two archives within the same second would collide on the timestamp.
+# Disambiguate with a numeric suffix so the prior archive is never overwritten.
+target="${archive_dir}/${src_base}-${ts}.md"
+suffix=1
+while [[ -e "$target" ]]; do
+    target="${archive_dir}/${src_base}-${ts}-${suffix}.md"
+    suffix=$((suffix + 1))
+done
+
+mv -n "$src" "$target" || { echo "archive target already exists: $target" >&2; exit 1; }
+echo "$target"

--- a/ai/skills/handoff/scripts/handoff-detect.sh
+++ b/ai/skills/handoff/scripts/handoff-detect.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# SessionStart hook: surface the existence of a handoff doc for the current cwd
+# without reading or loading its contents. Silent when there is nothing to surface.
+#
+# This script is best-effort: any error must not block session start.
+
+set -uo pipefail
+
+path_helper="${HOME}/.claude/skills/handoff/scripts/handoff-path.sh"
+
+if [[ ! -x "$path_helper" ]]; then
+    exit 0
+fi
+
+result=$("$path_helper" 2>/dev/null) || exit 0
+
+status=$(printf '%s' "$result" | cut -f1)
+path=$(printf '%s'   "$result" | cut -f2)
+scope=$(printf '%s'  "$result" | cut -f3)
+
+if [[ "$status" != "existing" ]]; then
+    exit 0
+fi
+
+ts_line=$(grep -m1 '^timestamp:' "$path" 2>/dev/null | sed 's/^timestamp:[[:space:]]*//' || true)
+goal_line=$(grep -m1 '^# Handoff:' "$path" 2>/dev/null | sed 's/^# Handoff:[[:space:]]*//' || true)
+
+cat <<EOF
+[handoff] A handoff doc exists for this work (${scope}):
+  path:      ${path}
+  written:   ${ts_line:-unknown}
+  goal:      ${goal_line:-unknown}
+
+Run \`/handoff resume\` to load it (will offer to archive after reading), or \`/handoff show\` to print it without acting.
+EOF

--- a/ai/skills/handoff/scripts/handoff-path.sh
+++ b/ai/skills/handoff/scripts/handoff-path.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Resolve where the handoff doc lives for the current working directory.
+#
+# Output (tab-separated, single line):
+#   <status>\t<path>\t<scope>
+#
+# status: existing | new
+# scope : repo:<org>/<repo> | dir:<sanitized-cwd>
+#
+# Inside a git repo: <repo-root>/.notes/handoff.md
+# Outside a git repo: ~/.claude/handoff/dir-<hash>.md
+
+set -euo pipefail
+
+if git_root=$(git rev-parse --show-toplevel 2>/dev/null); then
+    path="${git_root}/.notes/handoff.md"
+
+    remote_url=$(git remote get-url origin 2>/dev/null || echo "")
+    if [[ "$remote_url" =~ github\.com[:/]([^/]+)/([^/.]+)(\.git)?$ ]]; then
+        scope="repo:${BASH_REMATCH[1]}/${BASH_REMATCH[2]}"
+    else
+        scope="repo:$(basename "$git_root")"
+    fi
+else
+    cwd=$(pwd)
+    hash=$(printf '%s' "$cwd" | shasum -a 1 | cut -c1-12)
+    path="${HOME}/.claude/handoff/dir-${hash}.md"
+    scope="dir:${cwd}"
+fi
+
+if [[ -f "$path" ]]; then
+    status="existing"
+else
+    status="new"
+fi
+
+printf '%s\t%s\t%s\n' "$status" "$path" "$scope"

--- a/ai/skills/handoff/scripts/handoff-snapshot.sh
+++ b/ai/skills/handoff/scripts/handoff-snapshot.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Capture a snapshot of the current git state for inclusion in a handoff doc.
+# Outputs a markdown fenced block to stdout. Safe to run outside a git repo.
+
+set -euo pipefail
+
+ts=$(date '+%Y-%m-%d %H:%M %Z')
+
+if ! git rev-parse --git-dir > /dev/null 2>&1; then
+    cat <<EOF
+\`\`\`
+timestamp: ${ts}
+cwd:       $(pwd)
+git:       (not a git repo)
+\`\`\`
+EOF
+    exit 0
+fi
+
+branch=$(git branch --show-current 2>/dev/null || echo "(detached)")
+head_hash=$(git rev-parse --short HEAD 2>/dev/null || echo "(no commits)")
+head_subject=$(git log -1 --pretty=%s 2>/dev/null || echo "")
+upstream=$(git rev-parse --abbrev-ref --symbolic-full-name '@{upstream}' 2>/dev/null || echo "(no upstream)")
+ahead_behind=$(git rev-list --left-right --count "@{upstream}...HEAD" 2>/dev/null || echo "")
+
+dirty=$(git status --porcelain=v1 2>/dev/null || true)
+if [[ -z "$dirty" ]]; then
+    dirty_block="(clean working tree)"
+else
+    dirty_block="$dirty"
+fi
+
+cat <<EOF
+\`\`\`
+timestamp: ${ts}
+branch:    ${branch}
+head:      ${head_hash} ${head_subject}
+upstream:  ${upstream}${ahead_behind:+ (behind/ahead: ${ahead_behind})}
+\`\`\`
+
+**Working tree:**
+
+\`\`\`
+${dirty_block}
+\`\`\`
+EOF

--- a/ai/skills/handoff/templates/handoff.md
+++ b/ai/skills/handoff/templates/handoff.md
@@ -1,0 +1,63 @@
+# Handoff: {{ONE_LINE_GOAL}}
+
+> Written for the next Claude session. Read this top to bottom, then start at **Next action**.
+> This doc decays fast. If git state has moved since the snapshot, trust the code, not the doc.
+
+## Snapshot
+
+{{SNAPSHOT_BLOCK}}
+
+## Goal
+
+{{One sentence, outcome not task. Example: "Ship a working /handoff skill that bootstraps the next session." Not: "Finish implementing the skill."}}
+
+## Status
+
+{{Concrete bullets, one fact per bullet.}}
+
+- ✅ {{works}}
+- 🚧 {{in progress, where it stopped}}
+- ❌ {{broken}}
+
+## Next action
+
+{{File:line specific, copy-pasteable if possible.}}
+
+## Open decisions
+
+{{Each: option A vs option B, leaning + reason, cost of changing later. Or "None."}}
+
+- **{{decision}}**: {{A}} vs {{B}}. Leaning {{X}} because {{Y}}. Cost of changing later: {{low/medium/high}}.
+
+## Ruled out
+
+{{Approach + one-line reason.}}
+
+- {{approach}}: {{why}}
+
+## Verification
+
+```bash
+# {{what this verifies}}
+{{command}}
+```
+
+## Key locations
+
+{{Bookmark + one-line. No explanation, the reader can open the file.}}
+
+- `{{path}}:{{line}}`, {{what's there}}
+
+## Gotchas
+
+{{Non-obvious traps not visible from reading code. Or "None."}}
+
+- {{trap}}
+
+## References
+
+{{PR/issue/Slack. Omit section if empty.}}
+
+- PR: {{url}}
+- Issue: {{url}}
+- Related: {{path or url}}

--- a/git/gitignore.global.symlink
+++ b/git/gitignore.global.symlink
@@ -1,2 +1,5 @@
 # Claude Code worktrees
 .claude/worktrees/
+
+# Scratch notes (handoffs, work-in-progress notes, etc.)
+.notes/


### PR DESCRIPTION
Adds `/handoff`, a Claude Code skill that bridges between sessions. The next session opens the repo, sees a SessionStart hook surface "a handoff exists", runs `/handoff resume`, and gets bootstrapped with goal, status, next action, open decisions, and a verification checklist.

## What's in the skill

- `SKILL.md` with four modes: create (default), resume, show, path.
- `handoff-path.sh` resolves storage: `<repo>/.notes/handoff.md` inside a git repo, `~/.claude/handoff/dir-<hash>.md` outside.
- `handoff-snapshot.sh` captures branch, HEAD, upstream, and dirty tree as an embedded markdown block.
- `handoff-archive.sh` moves existing handoffs to `<dir>/handoff-archive/<basename>-<timestamp>.md` before overwrite. Uses a numeric suffix loop plus `mv -n` so two archives in the same second don't collide.
- `handoff-detect.sh` runs as a SessionStart hook. Surfaces existence (path, timestamp, goal) without loading contents. Fail-open: `set -uo pipefail`, no `-e`, every error path short-circuits silently.
- `templates/handoff.md` is the skeleton Claude fills in.

## Prompt design

The `SKILL.md` is tuned for next-Claude-session readers specifically: zero history, full tool access, can't ask follow-ups. The prompt requires active state gathering (`git diff`, file reads) rather than writing from conversation memory, demands file:line specific next actions, and rejects narrative output with a built-in anti-example pair.

Resume mode reconciles the embedded snapshot against current git state and handles branch-moved, branch-changed (reference-only mode), and irrelevant-handoff cases. The archive offer is held until after the user decides what to do next, so it doesn't add admin friction at bootstrap.

## Other changes

- Adds `.notes/` to the global gitignore so handoff docs are ignored everywhere.
- Drops the `jq -e '.hooks.PostToolUse'` short-circuit in `ai/install.sh`. The merge helper is already idempotent (deep-merge plus `unique` on arrays), and the guard prevented existing installs from picking up newly-added hook categories like SessionStart on upgrade.

## Test plan

- [ ] Run `/handoff` in a session with concrete work, confirm a doc lands at `<repo>/.notes/handoff.md` with filled sections.
- [ ] Run `/handoff` twice in the same second, confirm both prior versions land in `handoff-archive/` with no collision.
- [ ] Start a fresh session, confirm the SessionStart hook prints the path, timestamp, and goal.
- [ ] Run `/handoff resume`, confirm reconciliation against current git state runs.
- [ ] In a non-git directory, run `/handoff`, confirm fallback to `~/.claude/handoff/dir-<hash>.md`.
- [ ] On a machine with an existing `~/.claude/settings.json` (already has PostToolUse hooks), re-run `ai/install.sh` and confirm the SessionStart entry now lands.
- [ ] Verify `git check-ignore .notes/handoff.md` returns true in any repo after install.