### PR TITLE
Add daily ops report LaunchAgent for Flags Platform

### DIFF
--- a/bin/ops-report-daily
+++ b/bin/ops-report-daily
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# ops-report-daily - Generate the Flags Platform daily ops report and DM the draft.
+#
+# Runs the /ops-report skill for each configured service, combines the results into
+# a single Slack-friendly draft, and DMs it to the recipient with instructions for
+# resuming the session to iterate or post the draft to the team channel.
+#
+# Intended to be invoked by launchd (com.haacked.ops-report-daily.plist) or by
+# hand via bin/ops-report-service.sh run.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/lib/logging.sh"
+
+# Services covered by the daily report. Edit this list to add or remove services.
+# Each entry must be a kebab-case slug that resolves to a Grafana dashboard tag
+# and a `{app="<slug>"}` Loki label (see ai/skills/ops-report/SKILL.md).
+SERVICES=(
+  "feature-flags-rust"
+  "flag-definitions"
+)
+
+# Slack DM recipient. Resolved to a channel ID at runtime via slack_search_users.
+SLACK_DM_EMAIL="phil.h@posthog.com"
+
+# Channel where the draft is eventually posted (only when the user requests it
+# in a resumed session). This script never posts; it only DMs the draft.
+SLACK_TARGET_CHANNEL="#team-flags-platform"
+
+# Working dir for the Claude session. Resumption requires the same cwd.
+# Auto-detected from script location so the worker runs correctly whether
+# invoked from ~/.dotfiles (installed) or from a worktree (testing).
+WORKING_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+STATE_DIR="${HOME}/.local/state/ops-report-daily"
+mkdir -p "$STATE_DIR"
+LAST_SESSION_FILE="${STATE_DIR}/last-session-id"
+
+# Budget cap and timeouts. Ops-report involves dozens of Grafana queries; allow
+# enough room without letting a runaway burn through tokens.
+MAX_BUDGET_USD="${OPS_REPORT_MAX_BUDGET_USD:-10}"
+RUN_TIMEOUT_SECONDS="${OPS_REPORT_TIMEOUT_SECONDS:-1800}"   # 30 min
+RUN_KILL_AFTER_SECONDS="${OPS_REPORT_KILL_AFTER_SECONDS:-60}"
+
+# Pre-generate the session UUID so the prompt can embed it in the DM footer.
+SESSION_ID=$(uuidgen | tr '[:upper:]' '[:lower:]')
+echo "$SESSION_ID" > "$LAST_SESSION_FILE"
+
+log_section "ops-report-daily"
+log_info "Session ID:   $SESSION_ID"
+log_info "Services:     ${SERVICES[*]}"
+log_info "DM to:        $SLACK_DM_EMAIL"
+log_info "Target chan:  $SLACK_TARGET_CHANNEL"
+log_info "Budget cap:   \$${MAX_BUDGET_USD}"
+log_info "Working dir:  $WORKING_DIR"
+
+cd "$WORKING_DIR"
+
+# Build a bullet list of services for the prompt.
+SERVICE_LIST=$(printf -- '- %s\n' "${SERVICES[@]}")
+
+PROMPT=$(cat <<EOF
+You are generating the PostHog Flags Platform daily operational health report.
+This run was triggered by a launchd job. Your output goes to one Slack DM,
+not to the team channel.
+
+Your session ID for this run is: ${SESSION_ID}
+
+Do these steps in order.
+
+1. For each service below, invoke the /ops-report skill with a daily window
+   across both regions. Run the services sequentially (not in parallel, to keep
+   memory usage bounded). Capture the full markdown report from each run.
+
+${SERVICE_LIST}
+
+2. Combine the per-service reports into one Slack-friendly draft message:
+   - Top line: "*Flags Platform daily ops report — <UTC date>*"
+   - One section per service, with the service slug as a bolded header
+   - Prioritize anomalies, regressions, and action items over raw metric tables
+   - Use Slack-compatible formatting: single-asterisk *bold*, hyphen bullets,
+     no level-4+ headings. Code blocks are fine for tables.
+   - Keep total length under ~3000 characters; trim verbose tables if needed.
+
+3. Send the draft as a Slack DM to ${SLACK_DM_EMAIL}:
+   a. Use mcp__plugin_slack_slack__slack_search_users with the email to find
+      the user's Slack ID.
+   b. Use mcp__plugin_slack_slack__slack_send_message to DM them. The channel
+      argument is the user ID (Slack opens the DM channel automatically).
+   c. The DM body has three parts, in this order:
+      i.   A subject line: "Daily ops report draft — <UTC date>"
+      ii.  The combined draft from step 2
+      iii. A footer block in a fenced code block, verbatim:
+
+           To iterate or post, from a terminal:
+             cd ${WORKING_DIR}
+             claude --resume ${SESSION_ID}
+
+           Or post the draft as-is right now:
+             cd ${WORKING_DIR}
+             claude --resume ${SESSION_ID} "post the report to ${SLACK_TARGET_CHANNEL}"
+
+4. After the DM is sent, print a one-line summary to stdout: services covered,
+   total anomaly count across services, and the DM channel ID.
+
+Hard constraints:
+- Do NOT post anything to ${SLACK_TARGET_CHANNEL} during this run. Only DM.
+- Do NOT modify any files in the repo.
+- If /ops-report fails for one service, still DM a partial report covering the
+  services that succeeded, with a note about which service failed and why.
+EOF
+)
+
+log_info "Invoking claude --print"
+
+# caffeinate -i blocks idle sleep so the timeout measures real wall-clock time.
+# timeout --kill-after fires SIGKILL if claude ignores SIGTERM.
+start_heartbeat 60 "Generating ops report"
+set +e
+caffeinate -i timeout --kill-after="$RUN_KILL_AFTER_SECONDS" \
+  "$RUN_TIMEOUT_SECONDS" \
+  claude --print \
+    --session-id "$SESSION_ID" \
+    --permission-mode bypassPermissions \
+    --max-budget-usd "$MAX_BUDGET_USD" \
+    --output-format text \
+    "$PROMPT"
+exit_code=$?
+set -e
+stop_heartbeat
+
+if [[ $exit_code -eq 0 ]]; then
+  log_success "ops-report-daily finished (session $SESSION_ID)"
+elif [[ $exit_code -eq 124 ]]; then
+  log_error "ops-report-daily timed out after ${RUN_TIMEOUT_SECONDS}s"
+else
+  log_error "ops-report-daily failed with exit code $exit_code"
+fi
+
+exit "$exit_code"

--- a/bin/ops-report-service.sh
+++ b/bin/ops-report-service.sh
@@ -1,0 +1,231 @@
+#!/usr/bin/env bash
+# ops-report-service.sh - Manage the ops-report-daily LaunchAgent.
+#
+# Usage:
+#   ops-report-service.sh [install|uninstall|start|stop|status|logs|run|resume]
+#
+# Commands:
+#   install    Create symlink, log directory, and load the agent
+#   uninstall  Unload the agent and remove symlink
+#   start      Manually trigger the daily run now (via launchctl)
+#   stop       Unload the agent (disable scheduled runs)
+#   status     Show agent status and the last session ID
+#   logs       Tail the launchd log file
+#   run        Run the worker script directly in this terminal (for testing)
+#   resume     Resume the most recent session (claude --resume <last-session-id>)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/lib/logging.sh"
+
+# Auto-detect the worktree/install root from this script's location, so `run`
+# and `resume` work both from ~/.dotfiles (installed) and from a worktree.
+# install/uninstall still pin to ~/.dotfiles since that's where the merged
+# code lives and where the LaunchAgent symlink should point.
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+WORKER="${REPO_ROOT}/bin/ops-report-daily"
+
+PLIST_NAME="com.haacked.ops-report-daily.plist"
+PLIST_SOURCE="${HOME}/.dotfiles/macos/LaunchAgents/${PLIST_NAME}"
+PLIST_DEST="${HOME}/Library/LaunchAgents/${PLIST_NAME}"
+STATE_DIR="${HOME}/.local/state/ops-report-daily"
+LOG_FILE="${STATE_DIR}/launchd.log"
+LAST_SESSION_FILE="${STATE_DIR}/last-session-id"
+LABEL="com.haacked.ops-report-daily"
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") <command>
+
+Manage the ops-report-daily LaunchAgent.
+
+Commands:
+  install    Create symlink and load the agent
+  uninstall  Unload the agent and remove symlink
+  start      Trigger the daily run now (via launchctl)
+  stop       Unload the agent (disable scheduled runs)
+  status     Show agent status and the last session ID
+  logs       Tail the launchd log file
+  run        Run the worker script directly (for testing)
+  resume     Resume the most recent session in an interactive terminal
+
+Examples:
+  $(basename "$0") install   # Set up the 9am-weekday schedule
+  $(basename "$0") run       # Generate today's draft now, foreground
+  $(basename "$0") resume    # Open the most recent session to iterate or post
+  $(basename "$0") logs      # Watch what the LaunchAgent did
+EOF
+  exit 0
+}
+
+cmd_install() {
+  log_info "Installing ops-report-daily LaunchAgent…"
+
+  mkdir -p "$STATE_DIR"
+  log_info "Created state directory: $STATE_DIR"
+
+  if [[ ! -f "$PLIST_SOURCE" ]]; then
+    log_error "Source plist not found: $PLIST_SOURCE"
+    exit 1
+  fi
+
+  if [[ -L "$PLIST_DEST" ]]; then
+    log_warn "Symlink already exists, recreating…"
+    rm "$PLIST_DEST"
+  elif [[ -f "$PLIST_DEST" ]]; then
+    log_error "Regular file exists at $PLIST_DEST. Remove it first."
+    exit 1
+  fi
+
+  ln -s "$PLIST_SOURCE" "$PLIST_DEST"
+  log_info "Created symlink: $PLIST_DEST -> $PLIST_SOURCE"
+
+  if launchctl list | grep -q "$LABEL"; then
+    log_warn "Agent already loaded, reloading…"
+    launchctl unload "$PLIST_DEST" 2>/dev/null || true
+  fi
+
+  launchctl load "$PLIST_DEST"
+  log_success "LaunchAgent installed and loaded"
+  log_info "Runs Mon–Fri at 09:00 local time"
+  log_info "Use '$(basename "$0") run' to test the worker now"
+}
+
+cmd_uninstall() {
+  log_info "Uninstalling ops-report-daily LaunchAgent…"
+
+  if launchctl list | grep -q "$LABEL"; then
+    launchctl unload "$PLIST_DEST" 2>/dev/null || true
+    log_info "Agent unloaded"
+  fi
+
+  if [[ -L "$PLIST_DEST" || -f "$PLIST_DEST" ]]; then
+    rm "$PLIST_DEST"
+    log_info "Removed: $PLIST_DEST"
+  fi
+
+  log_success "LaunchAgent uninstalled"
+}
+
+cmd_start() {
+  log_info "Triggering ops-report-daily run…"
+
+  if ! launchctl list | grep -q "$LABEL"; then
+    log_error "Agent not loaded. Run 'install' first."
+    exit 1
+  fi
+
+  launchctl start "$LABEL"
+  log_success "Run started"
+  log_info "Use '$(basename "$0") logs' to watch progress"
+}
+
+cmd_stop() {
+  log_info "Stopping LaunchAgent…"
+
+  if launchctl list | grep -q "$LABEL"; then
+    launchctl unload "$PLIST_DEST" 2>/dev/null || true
+    log_success "Agent stopped (unloaded)"
+  else
+    log_warn "Agent was not loaded"
+  fi
+}
+
+cmd_status() {
+  echo "LaunchAgent Status:"
+  echo "==================="
+
+  if [[ -L "$PLIST_DEST" ]]; then
+    echo -e "Symlink:  ${GREEN}installed${NC}"
+  elif [[ -f "$PLIST_DEST" ]]; then
+    echo -e "Symlink:  ${YELLOW}regular file (not symlink)${NC}"
+  else
+    echo -e "Symlink:  ${RED}not installed${NC}"
+  fi
+
+  if launchctl list | grep -q "$LABEL"; then
+    echo -e "Agent:    ${GREEN}loaded${NC}"
+    local status
+    status=$(launchctl list | grep "$LABEL" | awk '{print $1}')
+    if [[ "$status" == "-" ]]; then
+      echo "Last run: never (or currently running)"
+    elif [[ "$status" == "0" ]]; then
+      echo -e "Last run: ${GREEN}success (exit 0)${NC}"
+    else
+      echo -e "Last run: ${RED}failed (exit $status)${NC}"
+    fi
+  else
+    echo -e "Agent:    ${RED}not loaded${NC}"
+  fi
+
+  if [[ -f "$LOG_FILE" ]]; then
+    local log_size log_lines
+    log_size=$(du -h "$LOG_FILE" | cut -f1)
+    log_lines=$(wc -l < "$LOG_FILE" | tr -d ' ')
+    echo "Log file: $LOG_FILE ($log_size, $log_lines lines)"
+  else
+    echo "Log file: not created yet"
+  fi
+
+  if [[ -f "$LAST_SESSION_FILE" ]]; then
+    local last_session
+    last_session=$(cat "$LAST_SESSION_FILE")
+    echo "Last session: $last_session"
+    echo "  Resume with: cd ${REPO_ROOT} && claude --resume $last_session"
+  else
+    echo "Last session: none recorded"
+  fi
+}
+
+cmd_logs() {
+  if [[ ! -f "$LOG_FILE" ]]; then
+    log_warn "Log file does not exist yet: $LOG_FILE"
+    log_info "Run 'start' or 'run' to generate output"
+    exit 0
+  fi
+
+  log_info "Tailing log file (Ctrl+C to stop)…"
+  tail -f "$LOG_FILE"
+}
+
+cmd_run() {
+  if [[ ! -x "$WORKER" ]]; then
+    log_error "Worker not found or not executable: $WORKER"
+    exit 1
+  fi
+  log_info "Running worker in foreground…"
+  exec "$WORKER" "$@"
+}
+
+cmd_resume() {
+  if [[ ! -f "$LAST_SESSION_FILE" ]]; then
+    log_error "No recorded session yet. Run '$(basename "$0") run' first."
+    exit 1
+  fi
+  local last_session
+  last_session=$(cat "$LAST_SESSION_FILE")
+  log_info "Resuming session $last_session from $REPO_ROOT"
+  cd "$REPO_ROOT"
+  exec claude --resume "$last_session"
+}
+
+if [[ $# -eq 0 ]]; then
+  usage
+fi
+
+case "${1:-}" in
+  install) cmd_install ;;
+  uninstall) cmd_uninstall ;;
+  start) cmd_start ;;
+  stop) cmd_stop ;;
+  status) cmd_status ;;
+  logs) cmd_logs ;;
+  run) shift; cmd_run "$@" ;;
+  resume) cmd_resume ;;
+  -h|--help|help) usage ;;
+  *)
+    log_error "Unknown command: $1"
+    usage
+    ;;
+esac

--- a/macos/LaunchAgents/com.haacked.ops-report-daily.plist
+++ b/macos/LaunchAgents/com.haacked.ops-report-daily.plist
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.haacked.ops-report-daily</string>
+
+    <!--
+        Use zsh login shell so .zshenv provides PATH (Homebrew, ~/.local/bin,
+        Cargo) and path_helper picks up entries from /etc/paths.d.
+    -->
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/zsh</string>
+        <string>-lc</string>
+        <string><![CDATA[
+log_dir="$HOME/.local/state/ops-report-daily"
+mkdir -p "$log_dir"
+exec "$HOME/.dotfiles/bin/ops-report-daily" >> "$log_dir/launchd.log" 2>&1
+]]></string>
+    </array>
+
+    <!--
+        Fire weekdays (Mon-Fri) at 09:00 local time. StartCalendarInterval uses
+        the system's local time zone; Weekday 1=Monday … 5=Friday.
+    -->
+    <key>StartCalendarInterval</key>
+    <array>
+        <dict>
+            <key>Weekday</key>
+            <integer>1</integer>
+            <key>Hour</key>
+            <integer>9</integer>
+            <key>Minute</key>
+            <integer>0</integer>
+        </dict>
+        <dict>
+            <key>Weekday</key>
+            <integer>2</integer>
+            <key>Hour</key>
+            <integer>9</integer>
+            <key>Minute</key>
+            <integer>0</integer>
+        </dict>
+        <dict>
+            <key>Weekday</key>
+            <integer>3</integer>
+            <key>Hour</key>
+            <integer>9</integer>
+            <key>Minute</key>
+            <integer>0</integer>
+        </dict>
+        <dict>
+            <key>Weekday</key>
+            <integer>4</integer>
+            <key>Hour</key>
+            <integer>9</integer>
+            <key>Minute</key>
+            <integer>0</integer>
+        </dict>
+        <dict>
+            <key>Weekday</key>
+            <integer>5</integer>
+            <key>Hour</key>
+            <integer>9</integer>
+            <key>Minute</key>
+            <integer>0</integer>
+        </dict>
+    </array>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary

- Runs `/ops-report` for `feature-flags-rust` and `flag-definitions` on a Mon-Fri 09:00 local schedule, DMs the combined draft to Slack, and includes a session ID so you can resume in a terminal to iterate or post to `#team-flags-platform`.
- `bin/ops-report-daily` is the worker. It pre-generates a session UUID, then runs `claude --print --session-id <uuid> --permission-mode bypassPermissions --max-budget-usd 10` with a prompt that drives the skill, combines results, and sends the Slack DM. Capped at 30 minutes wall clock. Working dir auto-detects from the script location so it works both installed at `~/.dotfiles` and from a worktree.
- `bin/ops-report-service.sh` is the controller, modeled on `bin/review-all-prs-service.sh`. Subcommands: `install`, `uninstall`, `start`, `stop`, `status`, `logs`, `run`, `resume`. The `resume` subcommand does `cd <repo> && claude --resume <last-session-id>` in one shot.
- `macos/LaunchAgents/com.haacked.ops-report-daily.plist` fires Mon-Fri at 09:00 local time and logs to `~/.local/state/ops-report-daily/launchd.log`.

## Test plan

- [x] Ran `./bin/ops-report-service.sh run` from the worktree. Completed in about 4 minutes, Slack self-DM arrived covering both services with a cross-service correlation noted.
- [ ] After merge, run `~/.dotfiles/bin/ops-report-service.sh install` and confirm `launchctl list | grep ops-report-daily` shows the agent loaded.
- [ ] Wait for the next 09:00 weekday fire (or `start` it manually) and confirm the DM arrives.
- [ ] Run `~/.dotfiles/bin/ops-report-service.sh resume` and confirm the session opens with prior context.