### PR TITLE
Add one-click Mac bootstrap and sync provisioning with real toolchain

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,21 @@ They're so personal I copied much of them from <https://github.com/holman/dotfil
 
 ## Install
 
+On a brand-new Mac, run the one-liner. It installs the Xcode Command Line Tools (for git), clones this repo to `~/.dotfiles`, and runs `script/bootstrap`:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/haacked/dotfiles/main/install.sh | bash
+```
+
+Prefer to do it by hand (requires git, i.e. Xcode Command Line Tools, already installed):
+
 ```sh
 git clone https://github.com/haacked/dotfiles.git ~/.dotfiles
 cd ~/.dotfiles
 script/bootstrap
 ```
 
-This symlinks the appropriate files in `.dotfiles` into your home directory. Everything is configured and tweaked within `~/.dotfiles`.
+Either way symlinks the appropriate files in `.dotfiles` into your home directory. Everything is configured and tweaked within `~/.dotfiles`. The installer points the `origin` remote at SSH, so add an SSH key to GitHub before you push.
 
 The main file you'll want to change right off the bat is `zsh/zshrc.symlink`, which sets up a few paths that'll be different on your particular machine.
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ cd ~/.dotfiles
 script/bootstrap
 ```
 
-Either way symlinks the appropriate files in `.dotfiles` into your home directory. Everything is configured and tweaked within `~/.dotfiles`. The installer points the `origin` remote at SSH, so add an SSH key to GitHub before you push.
+Either way, bootstrap symlinks the appropriate files in `.dotfiles` into your home directory. Everything is configured and tweaked within `~/.dotfiles`. The installer points the `origin` remote at SSH, so add an SSH key to GitHub before you push.
 
 The main file you'll want to change right off the bat is `zsh/zshrc.symlink`, which sets up a few paths that'll be different on your particular machine.
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ On a brand-new Mac, run the one-liner. It installs the Xcode Command Line Tools 
 curl -fsSL https://raw.githubusercontent.com/haacked/dotfiles/main/install.sh | bash
 ```
 
-Prefer to do it by hand (requires git, i.e. Xcode Command Line Tools, already installed):
+Or, if you prefer to do it by hand (and git, via the Xcode Command Line Tools, is already installed):
 
 ```sh
 git clone https://github.com/haacked/dotfiles.git ~/.dotfiles

--- a/bin/dot
+++ b/bin/dot
@@ -45,10 +45,12 @@ export ZSH=$HOME/.dotfiles
 # Set macOS defaults
 $ZSH/macos/set-defaults.sh
 
-# Upgrade homebrew
-echo "› brew update"
-brew update
+# Upgrade homebrew (skipped on a fresh machine where script/install installs it).
+if command -v brew >/dev/null 2>&1; then
+  echo "› brew update"
+  brew update
+fi
 
-# Install software
+# Install software (installs Homebrew first if it's missing).
 echo "› $ZSH/script/install"
 $ZSH/script/install

--- a/dotnet/install.sh
+++ b/dotnet/install.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+#
+# .NET SDK
+#
+# Installs the .NET SDK directly from Microsoft's signed .pkg into
+# /usr/local/share/dotnet, which zsh/zshrc.symlink already adds to PATH.
+# We use the official installer rather than Homebrew so the SDK and global
+# tools live where the rest of this repo's config expects them.
+
+set -e
+
+# Already installed? The .pkg drops the SDK under /usr/local/share/dotnet.
+if [ -x /usr/local/share/dotnet/dotnet ]; then
+  echo "-> .NET SDK already installed at /usr/local/share/dotnet"
+  exit 0
+fi
+
+arch="$(uname -m)"
+case "$arch" in
+  arm64) pkg_arch="osx-arm64" ;;
+  x86_64) pkg_arch="osx-x64" ;;
+  *) echo "-> Unsupported architecture for .NET install: $arch" ; exit 0 ;;
+esac
+
+# aka.ms redirects to the latest LTS SDK .pkg for this architecture.
+pkg_url="https://aka.ms/dotnet/LTS/dotnet-sdk-${pkg_arch}.pkg"
+pkg_path="$(mktemp -d)/dotnet-sdk.pkg"
+
+echo "-> Downloading .NET LTS SDK ($pkg_arch)…"
+curl -fSL "$pkg_url" -o "$pkg_path"
+
+echo "-> Installing .NET SDK (requires sudo)…"
+sudo installer -pkg "$pkg_path" -target /
+
+rm -f "$pkg_path"
+echo "-> .NET SDK installed"

--- a/dotnet/install.sh
+++ b/dotnet/install.sh
@@ -24,7 +24,9 @@ esac
 
 # aka.ms redirects to the latest LTS SDK .pkg for this architecture.
 pkg_url="https://aka.ms/dotnet/LTS/dotnet-sdk-${pkg_arch}.pkg"
-pkg_path="$(mktemp -d)/dotnet-sdk.pkg"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+pkg_path="$tmp_dir/dotnet-sdk.pkg"
 
 echo "-> Downloading .NET LTS SDK ($pkg_arch)…"
 curl -fSL "$pkg_url" -o "$pkg_path"
@@ -32,5 +34,4 @@ curl -fSL "$pkg_url" -o "$pkg_path"
 echo "-> Installing .NET SDK (requires sudo)…"
 sudo installer -pkg "$pkg_path" -target /
 
-rm -f "$pkg_path"
 echo "-> .NET SDK installed"

--- a/homebrew/install.sh
+++ b/homebrew/install.sh
@@ -6,7 +6,7 @@
 # using Homebrew.
 
 # Check for Homebrew
-if test ! $(which brew)
+if ! command -v brew >/dev/null 2>&1
 then
   echo "  Installing Homebrew for you."
 
@@ -15,7 +15,7 @@ fi
 
 # Make brew available on PATH for the rest of this script (Apple Silicon installs
 # to /opt/homebrew, which isn't on PATH until the shell is reconfigured).
-if test ! $(which brew)
+if ! command -v brew >/dev/null 2>&1
 then
   if test -x /opt/homebrew/bin/brew
   then

--- a/homebrew/install.sh
+++ b/homebrew/install.sh
@@ -86,6 +86,55 @@ install zed yes
 install zlib
 install zsh
 
+# --- Developer tooling (this repo's shell config and scripts depend on these) ---
+install direnv
+install jq
+install yq
+install fzf
+install shellcheck
+install shfmt
+install ruff
+install pipx
+install helm
+install kubectx
+install watchman
+install withgraphite/tap/graphite
+install oven-sh/bun/bun
+install flox yes
+install orbstack yes
+install ghostty yes
+install supacode yes
+install copilot-cli yes
+
+# --- PostHog local development stack ---
+install postgresql@14
+install postgis
+install redis
+install librdkafka
+install stripe/stripe-cli/stripe
+install mitmproxy yes
+install proxyman yes
+
+# --- iOS development (posthog-ios) ---
+install swiftformat
+install swiftlint
+install ios-deploy
+install xcodes yes
+install zulu@8 yes
+brew tap peripheryapp/periphery
+install periphery yes
+
+# --- .NET and cloud ---
+install azure-cli
+install azure/functions/azure-functions-core-tools@4
+
+# --- Other apps and utilities ---
+install jump-desktop-connect yes
+install pgadmin4 yes
+install httpie
+install cloc
+install bfg
+
 gh extension install seachicken/gh-poi
 
 # Install Rust

--- a/homebrew/install.sh
+++ b/homebrew/install.sh
@@ -26,6 +26,14 @@ then
   fi
 fi
 
+# Bail out early with a clear message rather than letting every later `brew`
+# call fail confusingly if the install or PATH setup above didn't take.
+if ! command -v brew >/dev/null 2>&1
+then
+  echo "  Homebrew is not available on PATH. Install it manually from https://brew.sh and re-run." >&2
+  exit 1
+fi
+
 function install() {
   app=$1
   cask=${2:-}

--- a/homebrew/install.sh
+++ b/homebrew/install.sh
@@ -10,15 +10,20 @@ if test ! $(which brew)
 then
   echo "  Installing Homebrew for you."
 
-  # Install the correct homebrew for each OS type
-  if test "$(uname)" = "Darwin"
-  then
-    ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
-  elif test "$(expr substr $(uname -s) 1 5)" = "Linux"
-  then
-    ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Linuxbrew/install/master/install)"
-  fi
+  NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+fi
 
+# Make brew available on PATH for the rest of this script (Apple Silicon installs
+# to /opt/homebrew, which isn't on PATH until the shell is reconfigured).
+if test ! $(which brew)
+then
+  if test -x /opt/homebrew/bin/brew
+  then
+    eval "$(/opt/homebrew/bin/brew shellenv)"
+  elif test -x /usr/local/bin/brew
+  then
+    eval "$(/usr/local/bin/brew shellenv)"
+  fi
 fi
 
 function install() {

--- a/install.sh
+++ b/install.sh
@@ -36,9 +36,17 @@ ensure_xcode_clt() {
   warn "Accept the macOS dialog that appears, then wait for it to finish."
   xcode-select --install &>/dev/null || true
 
-  # Wait for the GUI installer to complete.
+  # Wait for the GUI installer to complete, but don't hang forever if the user
+  # cancels the dialog or it never starts. 30 minutes covers a slow download.
+  local waited=0 timeout=1800
   until xcode-select -p &>/dev/null; do
+    if [ "$waited" -ge "$timeout" ]; then
+      error "Timed out waiting for Xcode Command Line Tools."
+      error "Run 'xcode-select --install', let it finish, then re-run this installer."
+      exit 1
+    fi
     sleep 5
+    waited=$((waited + 5))
   done
   info "Xcode Command Line Tools installed"
 }

--- a/install.sh
+++ b/install.sh
@@ -46,6 +46,9 @@ ensure_xcode_clt() {
 clone_or_update() {
   if [ -d "$DOTFILES/.git" ]; then
     info "Existing dotfiles found at $DOTFILES, updating…"
+    # Fetch over HTTPS so updates work even before an SSH key is set up (a
+    # prior run may have already pointed origin at SSH).
+    git -C "$DOTFILES" remote set-url origin "$REPO_HTTPS"
     git -C "$DOTFILES" fetch origin "$BRANCH"
     git -C "$DOTFILES" checkout "$BRANCH"
     git -C "$DOTFILES" pull --ff-only origin "$BRANCH"
@@ -69,7 +72,8 @@ main() {
   echo ""
 
   if [ "$(uname -s)" != "Darwin" ]; then
-    warn "This installer targets macOS. Continuing, but your mileage may vary."
+    error "This installer only supports macOS."
+    exit 1
   fi
 
   ensure_xcode_clt

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# install.sh - One-liner bootstrap for a fresh Mac.
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/haacked/dotfiles/main/install.sh | bash
+#
+# Or from another branch:
+#   curl -fsSL https://raw.githubusercontent.com/haacked/dotfiles/main/install.sh | BRANCH=somebranch bash
+#
+# This installs the Xcode Command Line Tools (for git), clones the dotfiles to
+# ~/.dotfiles, points the origin remote at SSH, and runs script/bootstrap.
+
+set -euo pipefail
+
+REPO_HTTPS="https://github.com/haacked/dotfiles.git"
+REPO_SSH="git@github.com:haacked/dotfiles.git"
+BRANCH="${BRANCH:-main}"
+DOTFILES="$HOME/.dotfiles"
+
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+info() { echo -e "${GREEN}✓${NC} $1"; }
+warn() { echo -e "${YELLOW}⚠${NC} $1"; }
+error() { echo -e "${RED}✗${NC} $1"; }
+
+ensure_xcode_clt() {
+  if xcode-select -p &>/dev/null; then
+    info "Xcode Command Line Tools already installed"
+    return
+  fi
+
+  info "Installing Xcode Command Line Tools (provides git)…"
+  warn "Accept the macOS dialog that appears, then wait for it to finish."
+  xcode-select --install &>/dev/null || true
+
+  # Wait for the GUI installer to complete.
+  until xcode-select -p &>/dev/null; do
+    sleep 5
+  done
+  info "Xcode Command Line Tools installed"
+}
+
+clone_or_update() {
+  if [ -d "$DOTFILES/.git" ]; then
+    info "Existing dotfiles found at $DOTFILES, updating…"
+    git -C "$DOTFILES" fetch origin "$BRANCH"
+    git -C "$DOTFILES" checkout "$BRANCH"
+    git -C "$DOTFILES" pull --ff-only origin "$BRANCH"
+  elif [ -e "$DOTFILES" ]; then
+    error "$DOTFILES exists but is not a git repo. Move it aside and re-run."
+    exit 1
+  else
+    info "Cloning dotfiles to $DOTFILES (branch: $BRANCH)…"
+    git clone --branch "$BRANCH" "$REPO_HTTPS" "$DOTFILES"
+  fi
+
+  # Prefer SSH for future pushes (keys may not exist yet; that's fine).
+  git -C "$DOTFILES" remote set-url origin "$REPO_SSH"
+}
+
+main() {
+  echo ""
+  echo "═══════════════════════════════════════════════════════"
+  echo "  haacked dotfiles installer"
+  echo "═══════════════════════════════════════════════════════"
+  echo ""
+
+  if [ "$(uname -s)" != "Darwin" ]; then
+    warn "This installer targets macOS. Continuing, but your mileage may vary."
+  fi
+
+  ensure_xcode_clt
+  clone_or_update
+
+  info "Running script/bootstrap…"
+  cd "$DOTFILES"
+  # Redirect stdin from the terminal so bootstrap can prompt (git name/email, link conflicts).
+  if [ -t 0 ]; then
+    script/bootstrap
+  else
+    script/bootstrap < /dev/tty
+  fi
+
+  echo ""
+  echo "═══════════════════════════════════════════════════════"
+  info "Installation complete!"
+  echo ""
+  echo "Next steps:"
+  echo "  • Add an SSH key to GitHub so pushes work (origin is set to SSH)."
+  echo "  • Restart your shell or run: exec zsh"
+  echo "  • Re-run anytime with: dot"
+  echo "═══════════════════════════════════════════════════════"
+  echo ""
+}
+
+main "$@"

--- a/install.sh
+++ b/install.sh
@@ -89,11 +89,18 @@ main() {
 
   info "Running script/bootstrap…"
   cd "$DOTFILES"
-  # Redirect stdin from the terminal so bootstrap can prompt (git name/email, link conflicts).
+  # bootstrap prompts (git name/email, link conflicts), so it needs a real
+  # terminal on stdin. When piped via `curl | bash`, stdin is the pipe, so read
+  # from /dev/tty instead — but only if a controlling terminal actually exists
+  # (it won't under CI or headless automation), otherwise fail clearly.
   if [ -t 0 ]; then
     script/bootstrap
-  else
+  elif [ -r /dev/tty ]; then
     script/bootstrap < /dev/tty
+  else
+    error "No controlling terminal available for bootstrap prompts."
+    error "Clone the repo and run 'script/bootstrap' from an interactive shell instead."
+    exit 1
   fi
 
   echo ""

--- a/macos/set-defaults.sh
+++ b/macos/set-defaults.sh
@@ -16,7 +16,7 @@ defaults write -g ApplePressAndHoldEnabled -bool false
 defaults write com.apple.NetworkBrowser BrowseAllInterfaces 1
 
 # Always open everything in Finder's list view. This is important.
-defaults write com.apple.Finder FXPreferredViewStyle Nlsv
+defaults write com.apple.finder FXPreferredViewStyle -string "Nlsv"
 
 # Show the ~/Library folder.
 chflags nohidden ~/Library
@@ -35,8 +35,8 @@ defaults write com.apple.finder AppleShowAllFiles -bool true
 defaults write com.apple.dock wvous-bl-corner -int 5
 defaults write com.apple.dock wvous-bl-modifier -int 0
 
-# Safari settings (may fail on newer macOS versions due to sandboxing)
-# These settings need to be configured manually in Safari preferences on modern macOS
+# Safari's Develop menu is enabled via Safari > Settings > Advanced on modern
+# macOS; the old WebKitDeveloperExtras default no longer has any effect.
 
-# Global WebKit developer extras (this one still works)
-defaults write NSGlobalDomain WebKitDeveloperExtras -bool true
+# Apply the settings that need a relaunch to take effect.
+killall Finder Dock SystemUIServer 2>/dev/null || true

--- a/script/install
+++ b/script/install
@@ -4,9 +4,10 @@
 
 set -e
 
-cd "$(dirname $0)"/..
+cd "$(dirname "$0")"/..
 
 # find the per-component installers and run them iteratively. -mindepth 2 skips
 # the repo-root install.sh (the curl one-liner bootstrap), which is not a
-# component installer and must not re-run during bootstrap.
-find . -mindepth 2 -name install.sh | while read installer ; do sh -c "${installer}" ; done
+# component installer and must not re-run during bootstrap. -print0/read -d ''
+# and running the path as a file (not via `sh -c`) handle paths with spaces.
+find . -mindepth 2 -name install.sh -print0 | while IFS= read -r -d '' installer ; do sh "$installer" ; done

--- a/script/install
+++ b/script/install
@@ -6,5 +6,7 @@ set -e
 
 cd "$(dirname $0)"/..
 
-# find the installers and run them iteratively
-find . -name install.sh | while read installer ; do sh -c "${installer}" ; done
+# find the per-component installers and run them iteratively. -mindepth 2 skips
+# the repo-root install.sh (the curl one-liner bootstrap), which is not a
+# component installer and must not re-run during bootstrap.
+find . -mindepth 2 -name install.sh | while read installer ; do sh -c "${installer}" ; done


### PR DESCRIPTION
Provisions a new Mac from one command and brings the install scripts back in line with the tools this machine actually uses.

## What's here

Add a root `install.sh` for a one-liner bootstrap:

```sh
curl -fsSL https://raw.githubusercontent.com/haacked/dotfiles/main/install.sh | bash
```

It installs the Xcode Command Line Tools (for git), clones the repo to `~/.dotfiles`, points `origin` at SSH, and runs `script/bootstrap` with prompts intact. It's idempotent: re-running updates an existing checkout instead of failing.

Fix two things that broke a truly fresh machine. `bin/dot` ran `brew update` before Homebrew existed, which aborted bootstrap under `set -e`; it now only updates when brew is present. `homebrew/install.sh` used the long-dead `ruby -e` install method; it now uses the official `install.sh` and sets up `brew shellenv` for Apple Silicon.

Sync `homebrew/install.sh` with the tools actually installed here, grouped by purpose: developer tooling (direnv, jq, yq, fzf, shellcheck, shfmt, ruff, pipx, helm, kubectx, watchman, gt, bun, flox, orbstack, ghostty, supacode, copilot-cli), the PostHog local stack, iOS dev tooling, .NET/cloud, and a few utilities. Several of these are already assumed by this repo's shell config and scripts but were never installed.

Install .NET directly from Microsoft's signed LTS `.pkg` into `/usr/local/share/dotnet`, where `zshrc` already points, instead of Homebrew. The new `dotnet/install.sh` is picked up automatically by `script/install`.

Fix the macOS defaults: the Finder list-view setting wrote to `com.apple.Finder` (capital F), a non-effective domain, so it silently never applied; it now writes to `com.apple.finder`. Drop the dead `WebKitDeveloperExtras` setting, and relaunch Finder/Dock/SystemUIServer so changes apply without a logout.

Scope `script/install` to `-mindepth 2` so the repo-root `install.sh` is not re-run as a component installer.

## Test plan

- [ ] On a fresh Mac (or VM), run the curl one-liner and confirm it installs CLT, clones to `~/.dotfiles`, and completes bootstrap end to end.
- [ ] Re-run the one-liner and confirm it updates the existing checkout without error.
- [ ] Run `bin/dot` and confirm brew installs the new packages and `dotnet/install.sh` lands the SDK in `/usr/local/share/dotnet`.
- [ ] Run `macos/set-defaults.sh` and confirm Finder opens in list view after the relaunch.