### PR TITLE
Add sprint-status skill; centralize sprint team config

### DIFF
--- a/ai/skills/sprint-planning/SKILL.md
+++ b/ai/skills/sprint-planning/SKILL.md
@@ -55,7 +55,7 @@ Format as `MM/DD - MM/DD` in the output.
 
 ## Arguments
 
-- `/sprint-planning archive` — Skip the full sprint planning workflow and jump directly to archiving old Done items from the project board. When this argument is present:
+- `/sprint-planning archive`: Skip the full sprint planning workflow and jump directly to archiving old Done items from the project board. When this argument is present:
   1. Run Step 1 (Detect Sprint Context) to get `sprint_start`
   2. Jump directly to Step 12 (Archive Previous Sprint's Done Items)
   3. Exit after archiving
@@ -339,7 +339,7 @@ After posting the comment (or if the user declines to post), offer to clean up t
    ~/.claude/skills/sprint-planning/scripts/archive-done-items.sh <sprint_start>
    ```
 
-2. If the result is an empty array, skip silently — no prompt needed.
+2. If the result is an empty array, skip silently; no prompt needed.
 
 3. Otherwise, present the list and ask for confirmation:
 
@@ -358,6 +358,6 @@ After posting the comment (or if the user declines to post), offer to clean up t
 
 The output template in Step 10 is the authoritative format reference. These rules cover non-obvious behavior not visible in the template:
 
-- **No status emojis on retro PR links** — the retro lists shipped work, so checkmarks or status indicators are not needed on individual PR entries
-- **Always include a Side quests section in the Plan** — include it even as a placeholder if there are no side quests
-- **Never post without explicit user confirmation** — always ask before running the `gh issue comment` command
+- **No status emojis on retro PR links**: the retro lists shipped work, so checkmarks or status indicators are not needed on individual PR entries
+- **Always include a Side quests section in the Plan**: include it even as a placeholder if there are no side quests
+- **Never post without explicit user confirmation**: always ask before running the `gh issue comment` command

--- a/ai/skills/sprint-planning/SKILL.md
+++ b/ai/skills/sprint-planning/SKILL.md
@@ -4,7 +4,7 @@ description: Write bi-weekly sprint planning updates for a PostHog team (default
 model: sonnet
 color: pink
 allowed-tools: Bash, Read, Grep, Glob
-argument-hint: [archive|goals]
+argument-hint: [archive]
 ---
 
 # Sprint Planning
@@ -28,15 +28,13 @@ The defaults target the **Feature Flags** team:
 | `SPRINT_REPO` | `PostHog/posthog` | Repo holding sprint issues |
 | `SPRINT_FALLBACK_MEMBERS` | _(empty)_ | Space-separated handles used only if the members API fails |
 
-Override any value with an environment variable, or edit the defaults in `config.sh`. To run the update for the **Feature Flags Platform** team instead, export:
+Override any value with an environment variable, or edit the defaults in `config.sh`. To run the update for the **Feature Flags Platform** team instead, select that team before invoking:
 
 ```bash
-export SPRINT_TEAM_SLUG="team-flags-platform"
-export SPRINT_TEAM_NAME="Feature Flags Platform"
-export SPRINT_PROJECT_NUMBER="170"
-export SPRINT_GOALS_URL="https://posthog.com/teams/flags-platform#goals"
-export SPRINT_COMMENT_HEADER="# Team Feature Flags Platform"
+export SPRINT_TEAM=platform
 ```
+
+`config.sh` then resolves the Platform slug, board number (170), goals URL, and comment header. Any individual `SPRINT_*` export still overrides its value.
 
 If the members API fails and `SPRINT_FALLBACK_MEMBERS` is empty, ask the user for the team's members.
 
@@ -62,13 +60,7 @@ Format as `MM/DD - MM/DD` in the output.
   2. Jump directly to Step 12 (Archive Previous Sprint's Done Items)
   3. Exit after archiving
 
-- `/sprint-planning goals` — Show what the team is currently working on by merging the current sprint plan with project board data, grouped by assignee. When this argument is present:
-  1. Run Step G1 (Fetch Team Members)
-  2. Run Step G2 (Determine Current User)
-  3. Run Step G3 (Fetch Current Sprint Plan)
-  4. Run Step G4 (Fetch Board Goals)
-  5. Run Step G5 (Merge and Display)
-  6. Exit after displaying
+To see what the team is currently working on (the current sprint's goals merged with live board status, grouped by member), use the `sprint-status` skill instead.
 
 ## Your Task
 
@@ -361,106 +353,6 @@ After posting the comment (or if the user declines to post), offer to clean up t
    source ~/.claude/skills/sprint-planning/scripts/config.sh
    gh project item-archive "$SPRINT_PROJECT_NUMBER" --owner "$SPRINT_ORG" --id <item-id>
    ```
-
-## Goals Workflow
-
-These steps apply when the `goals` argument is provided. They run independently of the main sprint planning workflow.
-
-### Step G1: Fetch Team Members
-
-Follow Step 2 (Fetch Team Members) from the main workflow.
-
-### Step G2: Determine Current User
-
-```bash
-gh api user --jq .login
-```
-
-This user's section is highlighted in the output. If the API call fails, fall back to the output of `git config user.email` and match against team member handles.
-
-### Step G3: Fetch Current Sprint Plan
-
-1. Detect the current sprint using Step 1 (Detect Sprint Context) from the main workflow.
-
-2. Fetch the team's comment from the current sprint issue:
-
-   ```bash
-   ~/.claude/skills/sprint-planning/scripts/fetch-previous-comment.sh <current_number>
-   ```
-
-3. If the result is "NOT_FOUND", skip this step (no sprint plan exists yet). The output will rely solely on board data from Step G4.
-
-4. If a comment is found, parse the **Plan** section to extract each team member's planned items. Each item may be plain text or a `[title](url)` link.
-
-### Step G4: Fetch Board Goals
-
-Run the helper script to fetch In Progress and Todo items with assignee data:
-
-```bash
-~/.claude/skills/sprint-planning/scripts/fetch-board-goals.sh
-```
-
-This returns a JSON array of items, each with `id`, `title`, `status`, `url`, `type`, `number`, and `assignees` fields.
-
-### Step G5: Merge and Display
-
-Merge the sprint plan (Step G3) with the project board (Step G4) into a single view per team member.
-
-**Merge strategy:**
-
-1. Start from the sprint plan items as the baseline for each person.
-2. For each board item, check if it matches a plan item by URL, issue/PR number, or keyword similarity in the title.
-3. Matched items: use the board item's status (In Progress / Todo) and URL, preserving the plan's item description.
-4. Unmatched plan items (not on the board): include as-is from the plan, without a status subheading.
-5. Unmatched board items (not in the plan): append under a **"New (not in sprint plan):"** subheading.
-6. If no sprint plan exists (Step G3 returned NOT_FOUND), display board items only, grouped by status as before.
-
-**Output format:**
-
-```markdown
-## Team Goals - {SPRINT_TEAM_NAME}
-
-[Project Board](https://github.com/orgs/{SPRINT_ORG}/projects/{SPRINT_PROJECT_NUMBER})
-
-**--> @currentuser** (you)
-
-**In Progress:**
-- [Item from plan that's in progress on board](url)
-
-**Todo:**
-- [Item from plan that's todo on board](url)
-
-**Other planned:**
-- Item from plan not on board
-
-**New (not in sprint plan):**
-- [Board item not in plan](url) - In Progress
-
----
-
-@teammate
-
-**In Progress:**
-- [Their item](url)
-
----
-
-### Unassigned
-- [Orphaned item](url) - In Progress
-- Draft board item title - Todo
-```
-
-**Display rules:**
-
-- Current user appears first with `**-->**` prefix and `(you)` suffix
-- Other team members in alphabetical order
-- Items with URLs use `[title](url)` links
-- DraftIssues (no URL) show plain text title
-- Unassigned items appear at bottom in a separate section
-- Items with multiple assignees appear under each assignee
-- Status subsections only shown if items exist for that status
-- Only show team members who have at least one item assigned
-- Side quests from the sprint plan appear under their own heading per person
 
 ## Formatting Rules
 

--- a/ai/skills/sprint-planning/scripts/archive-done-items.sh
+++ b/ai/skills/sprint-planning/scripts/archive-done-items.sh
@@ -16,7 +16,9 @@
 
 set -euo pipefail
 
-source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/config.sh"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/config.sh"
+BATCH_QUERY="$SCRIPT_DIR/batch-item-query.sh"
 
 if [[ $# -lt 1 ]]; then
   echo "Usage: $0 <sprint_start_date>" >&2
@@ -56,23 +58,11 @@ if [[ "$item_count" -eq 0 ]]; then
   exit 0
 fi
 
-# Build a single GraphQL query to fetch closed/merged dates for all items,
-# replacing N sequential REST API calls with one batched request.
-query=$(echo "$work_items" | jq -r '
-  [to_entries[] |
-    .key as $idx |
-    .value as $item |
-    ($item.repo | split("/")) as $parts |
-    "item_\($idx): repository(owner: \"\($parts[0])\", name: \"\($parts[1])\") { " +
-    if $item.type == "PullRequest" then
-      "pullRequest(number: \($item.number)) { mergedAt closedAt }"
-    else
-      "issue(number: \($item.number)) { closedAt }"
-    end + " }"
-  ] | "query { " + join(" ") + " }"
-')
-
-response=$(gh api graphql -f query="$query" 2>/dev/null) || response=""
+# Resolve closed/merged dates for all items in one batched query. The helper
+# preserves input order, so item_<idx> lines up with work_items below.
+response=$(echo "$work_items" \
+  | jq '[.[] | {owner: (.repo | split("/")[0]), repo: (.repo | split("/")[1]), type: .type, number: .number}]' \
+  | "$BATCH_QUERY" "mergedAt closedAt" "closedAt")
 
 if [[ -z "$response" ]]; then
   echo "[]"

--- a/ai/skills/sprint-planning/scripts/batch-item-query.sh
+++ b/ai/skills/sprint-planning/scripts/batch-item-query.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# Resolve fields for many GitHub issues/PRs in one batched GraphQL query,
+# replacing N REST calls with a single request. Shared by the sprint-planning
+# and sprint-status helper scripts, which each build their own input array and
+# join the response back by index.
+#
+# Usage:
+#   echo '<json-array>' | batch-item-query.sh "<pr_fields>" "<issue_fields>"
+#
+# Stdin: JSON array of items, each: { owner, repo, type, number }
+#   where type is "PullRequest" or "Issue". Extra fields are ignored.
+# Args:
+#   $1 pr_fields    - GraphQL selection set for pull requests,
+#                     e.g. "state isDraft title"
+#   $2 issue_fields - GraphQL selection set for issues,
+#                     e.g. "state stateReason title"
+#
+# Output: the raw GraphQL response JSON. Each input item is aliased
+#   item_<index> (matching input order) under .data, so callers join by index.
+#   Prints nothing (empty string) when the input is empty or the query fails
+#   entirely, including when no .data is returned, so callers apply their own
+#   fallback. A batch where only some items fail still returns .data with the
+#   resolved items present and the failed ones null.
+
+set -euo pipefail
+
+pr_fields="${1:?pr_fields required}"
+issue_fields="${2:?issue_fields required}"
+
+items="$(cat)"
+
+count=$(echo "$items" | jq 'length')
+if [[ "$count" -eq 0 ]]; then
+  exit 0
+fi
+
+# owner/repo are escaped with @json so a malformed value can't break out of
+# the query string; number is a jq number, emitted as bare digits.
+query=$(echo "$items" | jq -r --arg pr "$pr_fields" --arg issue "$issue_fields" '
+  [to_entries[] |
+    .key as $i | .value as $it |
+    "item_\($i): repository(owner: \($it.owner | @json), name: \($it.repo | @json)) { " +
+    (if $it.type == "PullRequest" then
+       "pullRequest(number: \($it.number)) { \($pr) }"
+     else
+       "issue(number: \($it.number)) { \($issue) }"
+     end) + " }"
+  ] | "query { " + join(" ") + " }"
+')
+
+response=$(gh api graphql -f query="$query" 2>/dev/null) || true
+
+# Keep partial data (some items resolved, others null); only stay silent when
+# there is no .data at all.
+if jq -e '.data' <<<"$response" >/dev/null 2>&1; then
+  printf '%s' "$response"
+fi

--- a/ai/skills/sprint-planning/scripts/config.sh
+++ b/ai/skills/sprint-planning/scripts/config.sh
@@ -1,18 +1,14 @@
 #!/bin/bash
-# Team configuration for the sprint-planning skill.
+# Team configuration for the sprint-planning and sprint-status skills.
 #
-# Every value can be overridden by exporting the matching environment variable
-# before invoking the skill, or by editing the defaults below. Scripts source
-# this file; the SKILL.md inline commands source it too.
+# Pick a team with SPRINT_TEAM (default "feature-flags"); the matching defaults
+# below are applied. Any individual value can still be overridden by exporting
+# its SPRINT_* variable before sourcing this file. Scripts source this file;
+# the SKILL.md inline commands source it too.
 #
-# To run a sprint update for the Flags Platform team instead of the default,
-# export these before invoking (or copy them into a wrapper):
+# To run for the Flags Platform team instead of the default:
 #
-#   export SPRINT_TEAM_SLUG="team-flags-platform"
-#   export SPRINT_TEAM_NAME="Feature Flags Platform"
-#   export SPRINT_PROJECT_NUMBER="170"
-#   export SPRINT_GOALS_URL="https://posthog.com/teams/flags-platform#goals"
-#   export SPRINT_COMMENT_HEADER="# Team Feature Flags Platform"
+#   export SPRINT_TEAM="platform"
 
 # GitHub org that owns the team, project board, and repositories.
 SPRINT_ORG="${SPRINT_ORG:-PostHog}"
@@ -20,22 +16,32 @@ SPRINT_ORG="${SPRINT_ORG:-PostHog}"
 # Repository holding the sprint issues and where the update is posted.
 SPRINT_REPO="${SPRINT_REPO:-PostHog/posthog}"
 
-# GitHub team slug under SPRINT_ORG (used for the members API).
-SPRINT_TEAM_SLUG="${SPRINT_TEAM_SLUG:-team-feature-flags}"
-
-# Human-readable team name used in prose and prompts.
-SPRINT_TEAM_NAME="${SPRINT_TEAM_NAME:-Feature Flags}"
-
-# Project board number under SPRINT_ORG.
-SPRINT_PROJECT_NUMBER="${SPRINT_PROJECT_NUMBER:-112}"
-
-# Goals page link included in the update (leave empty to omit).
-SPRINT_GOALS_URL="${SPRINT_GOALS_URL:-https://posthog.com/teams/feature-flags#goals}"
-
-# Markdown heading that identifies this team's sprint comment. Matched as a
-# whole line, so "# Team Feature Flags" will not collide with
-# "# Team Feature Flags Platform".
-SPRINT_COMMENT_HEADER="${SPRINT_COMMENT_HEADER:-# Team Feature Flags}"
+# Team selector. Each case sets that team's defaults; an explicitly exported
+# SPRINT_* variable always wins via the ${VAR:-default} fallbacks.
+#
+# SPRINT_TEAM_SLUG       - GitHub team slug under SPRINT_ORG (members API).
+# SPRINT_TEAM_NAME       - Human-readable name used in prose and prompts.
+# SPRINT_PROJECT_NUMBER  - Project board number under SPRINT_ORG.
+# SPRINT_GOALS_URL       - Goals page link included in the update.
+# SPRINT_COMMENT_HEADER  - Heading that identifies this team's sprint comment.
+#                          Matched as a whole line, so "# Team Feature Flags"
+#                          does not collide with "# Team Feature Flags Platform".
+case "${SPRINT_TEAM:-feature-flags}" in
+  platform | flags-platform)
+    SPRINT_TEAM_SLUG="${SPRINT_TEAM_SLUG:-team-flags-platform}"
+    SPRINT_TEAM_NAME="${SPRINT_TEAM_NAME:-Feature Flags Platform}"
+    SPRINT_PROJECT_NUMBER="${SPRINT_PROJECT_NUMBER:-170}"
+    SPRINT_GOALS_URL="${SPRINT_GOALS_URL:-https://posthog.com/teams/flags-platform#goals}"
+    SPRINT_COMMENT_HEADER="${SPRINT_COMMENT_HEADER:-# Team Feature Flags Platform}"
+    ;;
+  *)
+    SPRINT_TEAM_SLUG="${SPRINT_TEAM_SLUG:-team-feature-flags}"
+    SPRINT_TEAM_NAME="${SPRINT_TEAM_NAME:-Feature Flags}"
+    SPRINT_PROJECT_NUMBER="${SPRINT_PROJECT_NUMBER:-112}"
+    SPRINT_GOALS_URL="${SPRINT_GOALS_URL:-https://posthog.com/teams/feature-flags#goals}"
+    SPRINT_COMMENT_HEADER="${SPRINT_COMMENT_HEADER:-# Team Feature Flags}"
+    ;;
+esac
 
 # Space-separated GitHub handles used only if the members API call fails.
 # Leave empty to fall back to asking the user.

--- a/ai/skills/sprint-planning/scripts/fetch-board-goals.sh
+++ b/ai/skills/sprint-planning/scripts/fetch-board-goals.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 # Fetch In Progress and Todo items from the project board with assignee
-# information. Uses a single batched GraphQL query to resolve assignees
-# for all linkable items (Issues and PRs), keeping API calls to a minimum.
+# information. Uses a single batched GraphQL query (via batch-item-query.sh)
+# to resolve assignees for all linkable items (Issues and PRs), keeping API
+# calls to a minimum.
 #
 # Usage: fetch-board-goals.sh
 #
@@ -15,7 +16,9 @@
 
 set -euo pipefail
 
-source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/config.sh"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/config.sh"
+BATCH_QUERY="$SCRIPT_DIR/batch-item-query.sh"
 
 # Fetch all items and filter to active statuses.
 active_items=$(gh project item-list "$SPRINT_PROJECT_NUMBER" \
@@ -65,22 +68,12 @@ if [[ "$linkable_count" -eq 0 ]]; then
   exit 0
 fi
 
-# Build a single GraphQL query to fetch assignees for all linkable items.
-query=$(echo "$linkable" | jq -r '
-  [to_entries[] |
-    .key as $idx |
-    .value as $item |
-    ($item.repo | split("/")) as $parts |
-    "item_\($idx): repository(owner: \"\($parts[0])\", name: \"\($parts[1])\") { " +
-    if $item.type == "PullRequest" then
-      "pullRequest(number: \($item.number)) { assignees(first: 10) { nodes { login } } }"
-    else
-      "issue(number: \($item.number)) { assignees(first: 10) { nodes { login } } }"
-    end + " }"
-  ] | "query { " + join(" ") + " }"
-')
-
-response=$(gh api graphql -f query="$query" 2>/dev/null) || response=""
+# Resolve assignees for every linkable item in one batched query. The helper
+# preserves input order, so item_<idx> lines up with linkable below.
+assignee_fields="assignees(first: 10) { nodes { login } }"
+response=$(echo "$linkable" \
+  | jq '[.[] | {owner: (.repo | split("/")[0]), repo: (.repo | split("/")[1]), type: .type, number: .number}]' \
+  | "$BATCH_QUERY" "$assignee_fields" "$assignee_fields")
 
 # Join assignee data with linkable items. If the GraphQL call failed,
 # fall back to empty assignees so the caller still gets usable output.

--- a/ai/skills/sprint-status/SKILL.md
+++ b/ai/skills/sprint-status/SKILL.md
@@ -16,15 +16,13 @@ This skill reuses the `sprint-planning` helper scripts for sprint detection, tea
 Team-specific values come from the shared `sprint-planning` config at
 `~/.claude/skills/sprint-planning/scripts/config.sh`. The defaults target the **Feature Flags** team (project board 112).
 
-If the argument is `platform`, export the **Feature Flags Platform** overrides before sourcing anything:
+If the argument is `platform`, select the **Feature Flags Platform** team before sourcing anything:
 
 ```bash
-export SPRINT_TEAM_SLUG="team-flags-platform"
-export SPRINT_TEAM_NAME="Feature Flags Platform"
-export SPRINT_PROJECT_NUMBER="170"
-export SPRINT_GOALS_URL="https://posthog.com/teams/flags-platform#goals"
-export SPRINT_COMMENT_HEADER="# Team Feature Flags Platform"
+export SPRINT_TEAM=platform
 ```
+
+`config.sh` then resolves that team's slug, board number, goals URL, and comment header. Exporting the variable (not just setting it) is what carries the choice into the helper scripts, which run as separate processes.
 
 Note: the two flags teams merged into **Feature Flags** (board 112). Prefer the default unless the user explicitly asks for the Platform board.
 
@@ -45,7 +43,7 @@ Gather all data automatically, then render and copy. Do not prompt the user unle
 
 ### Step 1: Resolve Team Config
 
-If the argument is `platform`, export the overrides above first. Then source the shared config so the helper scripts and your inline commands agree:
+If the argument is `platform`, run `export SPRINT_TEAM=platform` first. Then source the shared config so your inline commands and the helper scripts agree:
 
 ```bash
 source ~/.claude/skills/sprint-planning/scripts/config.sh
@@ -82,7 +80,10 @@ This user's section sorts first and is marked `(you)`. If it fails, fall back to
 ~/.claude/skills/sprint-planning/scripts/fetch-board-goals.sh
 ```
 
-Returns a JSON array of `In Progress` / `Todo` items with `url`, `status`, and `assignees`. Use it to decide 🔄 vs ⬜ for **open issues**: an open issue whose URL appears with status `In Progress` is 🔄, otherwise ⬜. (The `assignees` field is what the Step 4 `NOT_FOUND` fallback groups by.)
+Returns a JSON array of `In Progress` / `Todo` items with `url`, `status`, and `assignees`. Two uses:
+
+1. Decide 🔄 vs ⬜ for **open issues** in the plan: an open issue whose URL appears with status `In Progress` is 🔄, otherwise ⬜. (The `assignees` field is also what the Step 4 `NOT_FOUND` fallback groups by.)
+2. Surface board work that isn't in the plan. A board item whose URL or issue/PR number matches no plan item is "new": it renders under its assignee's **New (not in sprint plan)** subsection, or under a final **Unassigned** section when it has no assignee. Its marker comes from board status (`In Progress` → 🔄, `Todo` → ⬜).
 
 ### Step 6: Resolve Item Statuses
 
@@ -123,6 +124,14 @@ EOF
 <li>✅ <a href="...">…</a></li>
 <li>⬜ <a href="...">…</a></li>
 </ul>
+<p><i>New (not in sprint plan):</i></p>
+<ul>
+<li>🔄 <a href="...">…</a></li>
+</ul>
+<p><b>Unassigned</b></p>
+<ul>
+<li>⬜ <a href="...">…</a></li>
+</ul>
 ```
 
 **Display rules:**
@@ -130,8 +139,10 @@ EOF
 - Current user's section first, header ending in `(you)` (after a space); other members alphabetical.
 - Order each member's items: ✅ first, then 🔄, then ⬜, then 🚫.
 - Items with a URL are links; plain-text items render as plain `<li>` text with the marker.
-- Only include members who have at least one planned item.
-- The summary line's `{done_total}` is the count of ✅ across everyone; `{grand_total}` is every planned item.
+- After a member's planned items, add a **New (not in sprint plan):** subsection for board items assigned to them that no plan item matched (marker from board status). Omit it when empty.
+- End with an **Unassigned** section for board items with no assignee that aren't in any plan. Omit it when empty.
+- Only include members who have at least one planned or new item.
+- The member count (`6/10`) covers planned items only: `{done}` ✅ over total planned. New items are not counted. The summary line's `{done_total}` / `{grand_total}` likewise count planned items across everyone.
 
 ### Step 8: Report
 

--- a/ai/skills/sprint-status/SKILL.md
+++ b/ai/skills/sprint-status/SKILL.md
@@ -1,0 +1,145 @@
+---
+name: sprint-status
+description: Produce a per-team-member sprint status checklist for the current sprint (each member's planned goals with a done / in-progress / not-started marker) and copy it to the clipboard as Slack-ready rich text. Defaults to the Feature Flags team; pass `platform` for Feature Flags Platform.
+allowed-tools: Bash, Read
+argument-hint: [platform]
+---
+
+# Sprint Status
+
+Show where every team member stands on their goals for the **current** sprint, then copy the result to the clipboard as rich text that pastes cleanly into Slack.
+
+This skill reuses the `sprint-planning` helper scripts for sprint detection, team config, the sprint plan comment, and board data, plus the shared `copy-html-to-clipboard.swift` helper. It does not post anything to GitHub or Slack.
+
+## Team Configuration
+
+Team-specific values come from the shared `sprint-planning` config at
+`~/.claude/skills/sprint-planning/scripts/config.sh`. The defaults target the **Feature Flags** team (project board 112).
+
+If the argument is `platform`, export the **Feature Flags Platform** overrides before sourcing anything:
+
+```bash
+export SPRINT_TEAM_SLUG="team-flags-platform"
+export SPRINT_TEAM_NAME="Feature Flags Platform"
+export SPRINT_PROJECT_NUMBER="170"
+export SPRINT_GOALS_URL="https://posthog.com/teams/flags-platform#goals"
+export SPRINT_COMMENT_HEADER="# Team Feature Flags Platform"
+```
+
+Note: the two flags teams merged into **Feature Flags** (board 112). Prefer the default unless the user explicitly asks for the Platform board.
+
+## Status Markers
+
+| Marker | Meaning | Source |
+| --- | --- | --- |
+| ✅ | Done | PR `MERGED`, or Issue `CLOSED` (stateReason `COMPLETED` or null) |
+| 🔄 | In progress / in review | PR `OPEN` (suffix `in review`, or `draft` if `isDraft`), or Issue `OPEN` that the board marks `In Progress` |
+| ⬜ | Not started | Issue `OPEN` not marked `In Progress` on the board |
+| 🚫 | Won't do / dropped | Issue `CLOSED` with stateReason `NOT_PLANNED` or `DUPLICATE` (suffix `closed, not planned`), or PR `CLOSED` without merge (suffix `closed`) |
+
+A member's count is `✅ / total planned items`.
+
+## Your Task
+
+Gather all data automatically, then render and copy. Do not prompt the user unless a step fails and the fallbacks below don't resolve it.
+
+### Step 1: Resolve Team Config
+
+If the argument is `platform`, export the overrides above first. Then source the shared config so the helper scripts and your inline commands agree:
+
+```bash
+source ~/.claude/skills/sprint-planning/scripts/config.sh
+```
+
+### Step 2: Detect the Current Sprint
+
+```bash
+~/.claude/skills/sprint-planning/scripts/detect-sprint.sh
+```
+
+Tab-separated fields; you need `current_number` and `current_title`.
+
+### Step 3: Determine the Current User
+
+```bash
+gh api user --jq .login
+```
+
+This user's section sorts first and is marked `(you)`. If it fails, fall back to matching `git config user.email` against the team handles.
+
+### Step 4: Fetch the Current Sprint Plan
+
+```bash
+~/.claude/skills/sprint-planning/scripts/fetch-previous-comment.sh <current_number>
+```
+
+- If a comment is returned, parse the **Plan** section. Each `@member` heading is followed by their planned items; each item is a `[title](url)` link or plain text. These items are the goals. Capture, per member: the title, the URL (if any), and which member owns it.
+- If the result is `NOT_FOUND`, there's no sprint plan yet. Fall back to board items only: run Step 5, group `In Progress` + `Todo` items by assignee, and treat every item's marker from its board status (`In Progress` → 🔄, `Todo` → ⬜). Skip the plan-based parsing.
+
+### Step 5: Fetch Board Statuses
+
+```bash
+~/.claude/skills/sprint-planning/scripts/fetch-board-goals.sh
+```
+
+Returns a JSON array of `In Progress` / `Todo` items with `url`, `status`, and `assignees`. Use it to decide 🔄 vs ⬜ for **open issues**: an open issue whose URL appears with status `In Progress` is 🔄, otherwise ⬜. (The `assignees` field is what the Step 4 `NOT_FOUND` fallback groups by.)
+
+### Step 6: Resolve Item Statuses
+
+Collect every plan item URL (one per line) and pipe them to the resolver:
+
+```bash
+~/.claude/skills/sprint-status/scripts/resolve-item-status.sh <<'EOF'
+<url1>
+<url2>
+…
+EOF
+```
+
+It returns a JSON array with `state`, `isDraft`, `stateReason`, and `title` per URL via a single batched GraphQL call. Map each item to a marker using the **Status Markers** table, combining this output with the board status from Step 5 for open issues. Plain-text plan items with no URL default to ⬜ unless the user has said otherwise.
+
+### Step 7: Render and Copy
+
+Build the HTML below and copy it with the shared helper, which sets the `public.html` clipboard flavor that Slack reads (a plain-markdown paste does **not** render; it must be this rich-text path):
+
+```bash
+swift ~/.dotfiles/bin/copy-html-to-clipboard.swift <<'EOF'
+<html-here>
+EOF
+```
+
+**HTML structure**: a bold summary line, then per member a bold header and a `<ul>`. Every item is an `<li>` starting with the marker emoji, then the linked title, then an optional status suffix in parentheses. HTML-escape `&`, `<`, and `>` in titles (and the `href`) so a stray character in a GitHub title can't corrupt the pasted output:
+
+```html
+<p><b>{SPRINT_TEAM_NAME}: {current_title} ({done_total}/{grand_total} done)</b></p>
+<p><b>@you: 6/10</b></p>
+<ul>
+<li>✅ <a href="https://github.com/PostHog/posthog/pull/60550">add updated_at to Project model</a></li>
+<li>🔄 <a href="https://github.com/PostHog/posthog/pull/60569">strip non-allowlisted $feature_flag_called properties</a> (in review)</li>
+<li>⬜ <a href="https://github.com/PostHog/posthog/issues/60581">Orphaned person profiles created via $feature_flag_called event</a></li>
+</ul>
+<p><b>@teammate: 1/8</b></p>
+<ul>
+<li>✅ <a href="...">…</a></li>
+<li>⬜ <a href="...">…</a></li>
+</ul>
+```
+
+**Display rules:**
+
+- Current user's section first, header ending in `(you)` (after a space); other members alphabetical.
+- Order each member's items: ✅ first, then 🔄, then ⬜, then 🚫.
+- Items with a URL are links; plain-text items render as plain `<li>` text with the marker.
+- Only include members who have at least one planned item.
+- The summary line's `{done_total}` is the count of ✅ across everyone; `{grand_total}` is every planned item.
+
+### Step 8: Report
+
+Show the user a plain-markdown rendering of the same list for in-terminal review, grouped by member with the same ordering: render `- [x]` for ✅ and 🚫, `- [ ]` for 🔄 and ⬜, keeping the status suffix and `[title](url)` links. Then confirm:
+
+> ✅ Copied to clipboard as rich text; paste directly into Slack.
+
+## Notes
+
+- This is read-only. Never post the result to GitHub or Slack; the user pastes it themselves.
+- Issue "Open" only distinguishes started from not-started via the board's `In Progress` column, so 🔄 vs ⬜ is best-effort for issues without board status.

--- a/ai/skills/sprint-status/scripts/resolve-item-status.sh
+++ b/ai/skills/sprint-status/scripts/resolve-item-status.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 # Resolve the current state of the GitHub issues/PRs referenced in a sprint
 # plan. Reads issue/PR URLs on stdin (one per line, extra text ignored) and
-# returns a JSON array describing each item, using a single batched GraphQL
-# query to keep API calls to a minimum.
+# returns a JSON array describing each item. The batched GraphQL lookup is
+# delegated to sprint-planning's shared batch-item-query.sh.
 #
 # Usage:
 #   echo "https://github.com/PostHog/posthog/pull/60569" | resolve-item-status.sh
@@ -24,6 +24,9 @@
 # so the caller still has the URLs.
 
 set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BATCH_QUERY="$SCRIPT_DIR/../../sprint-planning/scripts/batch-item-query.sh"
 
 input="$(cat)"
 
@@ -48,37 +51,18 @@ if [[ "$count" -eq 0 ]]; then
   exit 0
 fi
 
-# Build a single GraphQL query with one aliased field per item.
-query=$(echo "$refs" | jq -r '
-  [to_entries[] |
-    .key as $i | .value as $it |
-    "item_\($i): repository(owner: \($it.owner | @json), name: \($it.repo | @json)) { " +
-    (if $it.type == "PullRequest" then
-       "pullRequest(number: \($it.number)) { state isDraft title }"
-     else
-       "issue(number: \($it.number)) { state stateReason title }"
-     end) + " }"
-  ] | "query { " + join(" ") + " }"
-')
-
-response=$(gh api graphql -f query="$query" 2>/dev/null) || true
-
-# A batch where one ref fails (e.g. an /issues/N link that is really a PR)
-# still returns every resolved item under .data alongside an .errors array,
-# but gh exits non-zero. Keep that partial data; only fall back to all-null
-# when there is no .data at all. The per-item merge below null-propagates
-# individually unresolved aliases.
-if ! jq -e '.data' <<<"$response" >/dev/null 2>&1; then
-  response=""
-fi
+response=$(echo "$refs" | "$BATCH_QUERY" "state isDraft title" "state stateReason title")
 
 if [[ -z "$response" ]]; then
-  # API failed entirely; return refs with null state so the caller still
+  # Query failed entirely; return refs with null state so the caller still
   # has URLs and can degrade gracefully.
   echo "$refs" | jq '[.[] | . + {state: null, isDraft: null, stateReason: null, title: null}]'
   exit 0
 fi
 
+# Join the batched results back onto the refs by index. A ref that failed
+# individually (e.g. an /issues/N link that is really a PR) has a null node,
+# and jq null-propagates each field for it while the rest stay accurate.
 echo "$refs" | jq --argjson resp "$response" '
   [to_entries[] |
     .key as $i | .value as $it |

--- a/ai/skills/sprint-status/scripts/resolve-item-status.sh
+++ b/ai/skills/sprint-status/scripts/resolve-item-status.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+# Resolve the current state of the GitHub issues/PRs referenced in a sprint
+# plan. Reads issue/PR URLs on stdin (one per line, extra text ignored) and
+# returns a JSON array describing each item, using a single batched GraphQL
+# query to keep API calls to a minimum.
+#
+# Usage:
+#   echo "https://github.com/PostHog/posthog/pull/60569" | resolve-item-status.sh
+#   resolve-item-status.sh < urls.txt
+#
+# Output: JSON array of objects, one per unique URL:
+#   {
+#     url, owner, repo,
+#     type        ("PullRequest" | "Issue"),
+#     number,
+#     state       ("OPEN" | "CLOSED" | "MERGED"),
+#     isDraft     (bool, PRs only; null for issues),
+#     stateReason ("COMPLETED" | "NOT_PLANNED" | null; issues only),
+#     title
+#   }
+#
+# URLs that can't be parsed are skipped. Returns [] for empty input. If the
+# GraphQL call fails entirely, state/isDraft/stateReason/title come back null
+# so the caller still has the URLs.
+
+set -euo pipefail
+
+input="$(cat)"
+
+refs=$(printf '%s\n' "$input" \
+  | { grep -oE 'github\.com/[A-Za-z0-9._-]+/[A-Za-z0-9._-]+/(pull|issues)/[0-9]+' || true; } \
+  | sort -u \
+  | jq -R -s '
+      split("\n") | map(select(length > 0)) | map(
+        split("/") as $p | {
+          url: ("https://" + .),
+          owner: $p[1],
+          repo: $p[2],
+          type: (if $p[3] == "pull" then "PullRequest" else "Issue" end),
+          number: ($p[4] | tonumber)
+        }
+      )
+    ')
+
+count=$(echo "$refs" | jq 'length')
+if [[ "$count" -eq 0 ]]; then
+  echo "[]"
+  exit 0
+fi
+
+# Build a single GraphQL query with one aliased field per item.
+query=$(echo "$refs" | jq -r '
+  [to_entries[] |
+    .key as $i | .value as $it |
+    "item_\($i): repository(owner: \($it.owner | @json), name: \($it.repo | @json)) { " +
+    (if $it.type == "PullRequest" then
+       "pullRequest(number: \($it.number)) { state isDraft title }"
+     else
+       "issue(number: \($it.number)) { state stateReason title }"
+     end) + " }"
+  ] | "query { " + join(" ") + " }"
+')
+
+response=$(gh api graphql -f query="$query" 2>/dev/null) || true
+
+# A batch where one ref fails (e.g. an /issues/N link that is really a PR)
+# still returns every resolved item under .data alongside an .errors array,
+# but gh exits non-zero. Keep that partial data; only fall back to all-null
+# when there is no .data at all. The per-item merge below null-propagates
+# individually unresolved aliases.
+if ! jq -e '.data' <<<"$response" >/dev/null 2>&1; then
+  response=""
+fi
+
+if [[ -z "$response" ]]; then
+  # API failed entirely; return refs with null state so the caller still
+  # has URLs and can degrade gracefully.
+  echo "$refs" | jq '[.[] | . + {state: null, isDraft: null, stateReason: null, title: null}]'
+  exit 0
+fi
+
+echo "$refs" | jq --argjson resp "$response" '
+  [to_entries[] |
+    .key as $i | .value as $it |
+    $resp.data["item_\($i)"] as $d |
+    (if $it.type == "PullRequest" then $d.pullRequest else $d.issue end) as $node |
+    $it + {
+      state: $node.state,
+      isDraft: $node.isDraft,
+      stateReason: $node.stateReason,
+      title: $node.title
+    }
+  ]
+'

--- a/ai/skills/standup/SKILL.md
+++ b/ai/skills/standup/SKILL.md
@@ -51,7 +51,7 @@ If `status` is "found":
 
 ### Step 3: Query GitHub for PR Activity
 
-**Only include PRs from `PostHog/*` repos.** Personal repos (e.g. `haacked/*`) are excluded — standup is a PostHog work update, and personal tooling work isn't relevant to teammates. The `org:PostHog` qualifier in the search queries enforces this.
+**Only include PRs from `PostHog/*` repos.** Personal repos (e.g. `haacked/*`) are excluded; standup is a PostHog work update, and personal tooling work isn't relevant to teammates. The `org:PostHog` qualifier in the search queries enforces this.
 
 **Completed PRs** (merged since last standup):
 
@@ -59,9 +59,9 @@ If `status` is "found":
 gh api search/issues --method GET -f q="author:haacked org:PostHog is:pr is:merged merged:>=${last_standup_date}" --jq '.items[] | {number, title, url: .html_url, repo: .repository_url, merged_at: .pull_request.merged_at}'
 ```
 
-Note: `gh search prs --merged` is unreliable for date filtering — it returns stale results. Always use `gh api search/issues` with the `merged:` qualifier instead, which returns accurate `merged_at` timestamps.
+Note: `gh search prs --merged` is unreliable for date filtering; it returns stale results. Always use `gh api search/issues` with the `merged:` qualifier instead, which returns accurate `merged_at` timestamps.
 
-**Active PRs** (open PRs with recent activity) — include draft status and review requests:
+**Active PRs** (open PRs with recent activity), including draft status and review requests:
 
 ```bash
 gh pr list --author "@me" --state open --json number,title,url,isDraft,reviewRequests --repo PostHog/posthog
@@ -95,9 +95,9 @@ Build standup content and produce two outputs: a plain text archive file and HTM
 **Working on items:**
 
 - Include open PRs with recent activity
-- Carry over items from the previous standup's "Working on" — but verify each one first:
+- Carry over items from the previous standup's "Working on", but verify each one first:
   - For items with a PR URL: `gh pr view <number> --repo <owner/repo> --json state,mergedAt`
-  - If **MERGED** since last standup: move to Completed (deduplicate by PR number — carry-over is the safety net for PRs the merged search may miss)
+  - If **MERGED** since last standup: move to Completed (deduplicate by PR number; carry-over is the safety net for PRs the merged search may miss)
   - If **CLOSED**: drop it entirely
   - If **OPEN**: keep in Working on
 - Determine PR status from the `gh pr list` JSON:
@@ -132,7 +132,7 @@ Zilch
 
 #### HTML for Clipboard
 
-Every section uses `<p><b>Header:</b></p>` followed by `<ul>`. Every item — without exception — is an `<li>` inside the `<ul>`, regardless of whether it contains a link.
+Every section uses `<p><b>Header:</b></p>` followed by `<ul>`. Every item, without exception, is an `<li>` inside the `<ul>`, regardless of whether it contains a link.
 
 ```html
 <p><b>Completed:</b></p>
@@ -170,4 +170,4 @@ Display:
 
 1. The generated standup notes (plain text version for review)
 2. The file path for easy access
-3. A message: "✅ Copied to clipboard as rich text — paste directly into Slack!"
+3. A message: "✅ Copied to clipboard as rich text; paste directly into Slack!"


### PR DESCRIPTION
## What

Adds a `sprint-status` skill that produces a per-team-member checklist of the current sprint's planned goals, each with a done / in-progress / not-started marker, and copies it to the clipboard as Slack-ready rich text. It is read-only and never posts to GitHub or Slack.

While building it, the surrounding `sprint-planning` skill had three pieces of duplication this skill would have grown, so this branch also cleans those up.

## Commits

1. Add sprint-status skill for per-member goal tracking. `SKILL.md` plus `resolve-item-status.sh`, which resolves the live state of every planned PR/issue. Reuses the existing `sprint-planning` helper scripts (sprint detection, team config, plan comment, board data) and the shared `copy-html-to-clipboard.swift` helper.
2. Centralize sprint team config, share GraphQL batch helper, retire goals workflow. `config.sh` gains a `SPRINT_TEAM` selector, so choosing the Flags Platform team is `export SPRINT_TEAM=platform` instead of five copied exports; it uses an env var rather than a positional arg so sourced scripts that take their own args are unaffected. The thrice-duplicated batched-GraphQL builder moves into `batch-item-query.sh`, with `fetch-board-goals.sh`, `archive-done-items.sh`, and `resolve-item-status.sh` routing through it. The `sprint-planning goals` workflow is retired since `sprint-status` supersedes it, with its "New (not in sprint plan)" and "Unassigned" board sections ported into `sprint-status`.
3. Remove em dashes from sprint-planning and standup skill docs. Style sweep.

## Status markers

Done (PR merged or issue closed), in progress or in review, not started, and won't do / dropped.

## Test plan

- `resolve-item-status.sh` verified against live GitHub: PR merged/open/draft, issue closed (completed vs not-planned) and open, markdown-link and duplicate URLs, empty/no-URL input returns `[]`, and a bad ref in a batch nulls only itself while the rest keep accurate state.
- `config.sh` dispatch checked for default (board 112), `platform` (board 170), and explicit-override-wins.
- Refactored `fetch-board-goals.sh` and `archive-done-items.sh` re-run live and produce the same shape as before.
- shellcheck clean on all scripts; markdownlint clean on all docs.

After merge, run `~/.dotfiles/ai/install.sh --skills-only` to relink `~/.claude/skills/sprint-status`.