### PR TITLE
Add sprint-status and triage automation on a shared LaunchAgent lib

### DIFF
--- a/ai/agents/triage-feature-flags.md
+++ b/ai/agents/triage-feature-flags.md
@@ -1,11 +1,11 @@
 ---
 name: triage-feature-flags
-description: Analyzes GitHub issues to identify those belonging to the Feature Flags team domain (feature flags, cohorts, early access). Used by the triage-issues command.
+description: Analyzes GitHub issues and external PRs to identify those belonging to the Feature Flags team domain (feature flags, cohorts, early access). Used by the triage-issues command.
 model: haiku
 color: orange
 ---
 
-You are a triage specialist for the **Feature Flags team** at PostHog. Your job is to analyze GitHub issues and identify which ones belong to this team's domain.
+You are a triage specialist for the **Feature Flags team** at PostHog. Your job is to analyze GitHub issues and external pull requests and identify which ones belong to this team's domain.
 
 ## Team Domain
 
@@ -21,7 +21,7 @@ The Feature Flags team owns:
 When you identify a relevant issue, suggest one or more of these labels:
 
 | Label | When to use |
-|-------|-------------|
+| ----- | ----------- |
 | `team/feature-flags` | Always add this for issues owned by the team |
 | `feature/feature-flags` | Issues specifically about feature flag functionality |
 | `feature/cohorts` | Issues specifically about cohorts/user segments |
@@ -45,6 +45,14 @@ When you identify a relevant issue, suggest one or more of these labels:
 - "beta" (could be early access or general)
 - "toggle" (could be feature flag or UI toggle)
 
+**File-path signals** (for PRs, when changed file paths are provided; these outweigh a vague title):
+
+- `posthog/api/feature_flag*`, `posthog/models/feature_flag/`
+- `rust/feature-flags/`
+- `frontend/src/scenes/feature-flags/`
+- `posthog/models/cohort/`, `frontend/src/scenes/cohorts/`
+- early access feature code paths
+
 ## What to Skip
 
 Do NOT suggest labeling issues that:
@@ -57,7 +65,7 @@ Do NOT suggest labeling issues that:
 
 ## Output Format
 
-For each candidate issue, provide:
+For each candidate item, provide (use "PR" instead of "Issue" for pull requests, and include the author for external PRs):
 
 ```markdown
 ### Issue #NUMBER - TITLE
@@ -68,4 +76,4 @@ For each candidate issue, provide:
 **Reasoning:** Brief explanation of why this belongs to the Feature Flags team
 ```
 
-After listing all candidates, provide a summary count and ask the user which issues to label.
+After listing all candidates, provide a summary count. Do not ask anything; the invoking command decides what to label.

--- a/ai/skills/babysit-prs/SKILL.md
+++ b/ai/skills/babysit-prs/SKILL.md
@@ -37,7 +37,7 @@ State lives in `~/.local/state/babysit-prs/state.json`, keyed by PR URL:
 }
 ```
 
-A PR is **quiet** (skip it) when its current head SHA matches `head_sha`, its CI conclusion is unchanged and not failing, and it has no review comments newer than `last_comment_at`. Anything else makes it **active**. `updated_at` is a cheap pre-filter: when the search result's `updatedAt` matches it, the PR is quiet by definition and needs no per-PR fetches at all.
+A PR is **quiet** (skip it) when its current head SHA matches `head_sha`, its CI conclusion is unchanged and not failing, and it has no review comments newer than `last_comment_at`. Anything else makes it **active**. `updated_at` is a cheap pre-filter, but only when the stored `ci_conclusion` is terminal-good (`success` or `skipped`): completing check runs do not bump a PR's `updatedAt`, so a PR recorded as pending or failing still needs the per-PR fetch even when `updatedAt` is unchanged.
 
 ## Your Task
 
@@ -52,11 +52,11 @@ If `--owner` was given, add `--owner <org>` to the search. Sort by `updatedAt` d
 
 ### Step 2: Classify Each PR
 
-If a PR's `updatedAt` from Step 1 matches the state file's `updated_at`, mark it quiet without any further calls; on an all-quiet sweep, the search query is the only API call made. For the remaining PRs, fetch the facts needed to compare against state:
+If a PR's `updatedAt` from Step 1 matches the state file's `updated_at` AND its stored `ci_conclusion` is terminal-good (`success` or `skipped`), mark it quiet without any further calls; on an all-quiet sweep, the search query is the only API call made. PRs recorded as pending or failing always get the per-PR fetch until CI concludes green. For the remaining PRs, fetch the facts needed to compare against state:
 
 ```bash
 gh pr view <url> --json headRefOid,statusCheckRollup,reviewDecision,isDraft
-gh api repos/<owner>/<repo>/pulls/<number>/comments --jq '[.[] | {id, user: .user.login, created_at}] | sort_by(.created_at) | reverse | .[0:20]'
+gh api 'repos/<owner>/<repo>/pulls/<number>/comments?sort=created&direction=desc&per_page=20' --jq '[.[] | {id, user: .user.login, created_at}]'
 ```
 
 Classify:
@@ -91,7 +91,7 @@ If a dispatch fails twice for the same PR, record the failure in the summary and
 
 ### Step 5: Update State and Summarize
 
-After handling (or skipping) each PR, write its current `updated_at`, `head_sha`, `ci_conclusion`, and newest `last_comment_at` back to the state file (skip this entirely under `--dry-run`).
+After handling (or skipping) each PR, write its current `updated_at`, `head_sha`, `ci_conclusion`, and newest `last_comment_at` back to the state file, and drop any state keys not present in the Step 1 search results so closed and merged PRs don't accumulate (skip this entirely under `--dry-run`).
 
 End with a summary table:
 

--- a/ai/skills/babysit-prs/SKILL.md
+++ b/ai/skills/babysit-prs/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: babysit-prs
+description: One sweep over all of my open PRs — check CI, handle new review comments, fix and push — tracking state so reruns skip already-handled work. Designed to be driven by /loop.
+argument-hint: "[--owner <org>] [--limit <n>] [--dry-run]"
+allowed-tools: Bash, Read, Write, Edit, Glob, Grep, Skill
+---
+
+# Babysit PRs
+
+Perform **one sweep** over my open pull requests: for each PR, check CI health and unhandled review comments, dispatch fixes through the existing `ci-monitor` and `copilot-review` skills, and record what was handled so the next sweep skips it.
+
+This skill does a single iteration on purpose. Run it continuously with the loop runner:
+
+```text
+/loop 20m /babysit-prs
+/loop /babysit-prs          # self-paced
+```
+
+## Arguments
+
+- `--owner <org>`: only sweep PRs in repos owned by `<org>` (repeatable). Default: all my open PRs.
+- `--limit <n>`: max PRs to process this sweep (default: 10, newest activity first).
+- `--dry-run`: report what would be done; take no fix actions and don't update state.
+
+## State
+
+State lives in `~/.local/state/babysit-prs/state.json`, keyed by PR URL:
+
+```json
+{
+  "https://github.com/PostHog/posthog/pull/123": {
+    "updated_at": "2026-06-09T17:05:00Z",
+    "head_sha": "abc123",
+    "ci_conclusion": "success",
+    "last_comment_at": "2026-06-09T17:00:00Z"
+  }
+}
+```
+
+A PR is **quiet** (skip it) when its current head SHA matches `head_sha`, its CI conclusion is unchanged and not failing, and it has no review comments newer than `last_comment_at`. Anything else makes it **active**. `updated_at` is a cheap pre-filter: when the search result's `updatedAt` matches it, the PR is quiet by definition and needs no per-PR fetches at all.
+
+## Your Task
+
+### Step 1: Enumerate Open PRs
+
+```bash
+gh search prs --author=@me --state=open --limit 50 \
+  --json number,title,url,repository,isDraft,updatedAt
+```
+
+If `--owner` was given, add `--owner <org>` to the search. Sort by `updatedAt` descending and keep the first `--limit` PRs. Read the state file (treat a missing file as `{}`).
+
+### Step 2: Classify Each PR
+
+If a PR's `updatedAt` from Step 1 matches the state file's `updated_at`, mark it quiet without any further calls; on an all-quiet sweep, the search query is the only API call made. For the remaining PRs, fetch the facts needed to compare against state:
+
+```bash
+gh pr view <url> --json headRefOid,statusCheckRollup,reviewDecision,isDraft
+gh api repos/<owner>/<repo>/pulls/<number>/comments --jq '[.[] | {id, user: .user.login, created_at}] | sort_by(.created_at) | reverse | .[0:20]'
+```
+
+Classify:
+
+- **Quiet**: matches the state file as defined above. Skip; no per-PR output beyond the summary table.
+- **CI failing or pending-after-push**: head SHA differs from state, or rollup contains failures.
+- **New comments**: review comments newer than `last_comment_at` from anyone other than me.
+
+### Step 3: Locate a Checkout (only for PRs needing fixes)
+
+Fix work needs a local checkout of the PR branch:
+
+1. Look for an existing clone: `~/dev/posthog/<repo>` for PostHog org, `~/dev/<owner>/<repo>` otherwise, `~/.dotfiles` for dotfiles.
+2. In the clone, check whether the PR branch is already checked out somewhere and use that path if so (never create a second worktree for the same branch):
+
+   ```bash
+   source ~/.dotfiles/bin/lib/git-worktree.sh && worktree_path_for "<branch>"
+   ```
+
+3. Otherwise create one: `git worktree add ~/dev/worktrees/<repo>/<branch> <branch>` (fetch first).
+4. No local clone at all: skip the PR and flag it in the summary so I can clone it.
+
+### Step 4: Dispatch
+
+Handle each active PR, working from its checkout:
+
+- **CI failing** → invoke the `ci-monitor` skill with the PR URL. It classifies flaky vs legit failures and fixes legit ones.
+- **New review comments** → invoke the `copilot-review` skill with the PR URL. It evaluates each comment, fixes legitimate findings, and handles replies per its own rules.
+- Push resulting commits to the PR branch. Never force-push. Never merge, close, or mark ready-for-review.
+
+If a dispatch fails twice for the same PR, record the failure in the summary and move on; don't retry within the sweep.
+
+### Step 5: Update State and Summarize
+
+After handling (or skipping) each PR, write its current `updated_at`, `head_sha`, `ci_conclusion`, and newest `last_comment_at` back to the state file (skip this entirely under `--dry-run`).
+
+End with a summary table:
+
+| PR | Status | Action taken |
+| --- | --- | --- |
+| [posthog#123](…) | CI failing (legit) | Fixed test, pushed `def456` |
+| [posthog#456](…) | 2 new comments | 1 fixed, 1 reply drafted |
+| [charts#12](…) | quiet | skipped |
+
+If every PR was quiet, the summary is the single line: `All <n> open PRs quiet; nothing to do.`

--- a/ai/skills/sprint-status/SKILL.md
+++ b/ai/skills/sprint-status/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: sprint-status
-description: Produce a per-team-member sprint status checklist for the current sprint (each member's planned goals with a done / in-progress / not-started marker) and copy it to the clipboard as Slack-ready rich text. Defaults to the Feature Flags team; pass `platform` for Feature Flags Platform.
+description: Produce a per-team-member sprint status checklist for the current sprint (each member's planned goals with a done / in-progress / not-started marker) and copy it to the clipboard as Slack-ready rich text, or emit Slack markdown with the `slack` argument. Defaults to the Feature Flags team; pass `platform` for Feature Flags Platform.
 allowed-tools: Bash, Read
-argument-hint: [platform]
+argument-hint: "[platform] [slack]"
 ---
 
 # Sprint Status
 
-Show where every team member stands on their goals for the **current** sprint, then copy the result to the clipboard as rich text that pastes cleanly into Slack.
+Show where every team member stands on their goals for the **current** sprint, then copy the result to the clipboard as rich text that pastes cleanly into Slack — or, with the `slack` argument, emit Slack markdown text instead (for headless runs where nobody is at the keyboard to paste).
 
 This skill reuses the `sprint-planning` helper scripts for sprint detection, team config, the sprint plan comment, and board data, plus the shared `copy-html-to-clipboard.swift` helper. It does not post anything to GitHub or Slack.
 
@@ -101,7 +101,9 @@ It returns a JSON array with `state`, `isDraft`, `stateReason`, and `title` per 
 
 ### Step 7: Render and Copy
 
-Build the HTML below and copy it with the shared helper, which sets the `public.html` clipboard flavor that Slack reads (a plain-markdown paste does **not** render; it must be this rich-text path):
+**Slack mode**: if the `slack` argument was given, skip the HTML and clipboard entirely. Render the same content (same sections, ordering, and Display rules below) as Slack markdown and emit it as your final output: a single-asterisk `*bold*` summary line, then per member a `*@handle: x/y*` line followed by `-` bullets, each starting with the marker emoji, then the `[title](url)` link, then the optional status suffix in parentheses. Skip Step 8.
+
+Otherwise, build the HTML below and copy it with the shared helper, which sets the `public.html` clipboard flavor that Slack reads (a plain-markdown paste does **not** render; it must be this rich-text path):
 
 ```bash
 swift ~/.dotfiles/bin/copy-html-to-clipboard.swift <<'EOF'

--- a/ai/skills/triage-issues/SKILL.md
+++ b/ai/skills/triage-issues/SKILL.md
@@ -1,27 +1,29 @@
 ---
 name: triage-issues
-description: Identify unlabeled GitHub issues that may belong to a specific team
-argument-hint: "[days] [limit] [team]"
+description: Identify unlabeled GitHub issues and external PRs that may belong to a specific team
+argument-hint: "[days] [limit] [team] [unattended]"
 disable-model-invocation: true
 ---
 
-# Triage GitHub Issues
+# Triage GitHub Issues and External PRs
 
-Identify unlabeled GitHub issues that may belong to a specific team.
+Identify unlabeled GitHub issues and external (community) pull requests that may belong to a specific team.
 
 ## Arguments (parsed from user input)
 
 - **days**: How many days back to search (default: 14)
-- **limit**: Maximum issues to fetch (default: 30)
+- **limit**: Maximum items to fetch per type (default: 30)
 - **team**: Which team to triage for (default: feature-flags)
+- **unattended**: Run without prompts: auto-apply HIGH-confidence labels and emit a digest instead of asking questions. For scheduled runs.
 
 Example invocations:
 
 - `/triage-issues` → defaults (14 days, 30 issues, feature-flags team)
 - `/triage-issues 7` → last 7 days
-- `/triage-issues 7 50` → last 7 days, up to 50 issues
+- `/triage-issues 7 50` → last 7 days, up to 50 items per type
 - `/triage-issues for web-analytics` → triage for web-analytics team
 - `/triage-issues last 7 days for product-analytics` → natural language works too
+- `/triage-issues 7 unattended` → scheduled mode: auto-label HIGH, output digest
 
 ## Your Task
 
@@ -30,8 +32,9 @@ Example invocations:
 Extract from the user's input (or use defaults):
 
 - `days` = number of days to look back (default: 14)
-- `limit` = max issues to fetch (default: 30)
+- `limit` = max items to fetch per type (default: 30)
 - `team` = team identifier (default: feature-flags)
+- `unattended` = present or absent (default: absent)
 
 Supported team identifiers:
 
@@ -56,42 +59,55 @@ The `{exclusion_labels}` vary by team. For feature-flags:
 
 **Note:** The `date -v-Nd` syntax is macOS-specific. On Linux, use `date -d "N days ago"`.
 
-### Step 3: Spawn Team-Specific Subagent
+### Step 3: Fetch External PRs
+
+Fetch unlabeled open PRs from the same window and keep only external contributions, which otherwise have no team routing and are easy to miss:
+
+```bash
+gh search prs --repo PostHog/posthog --state open --limit {limit} --json number,title,body,labels,url,createdAt,isDraft,authorAssociation -- "created:>=$(date -v-{days}d +%Y-%m-%d) {exclusion_labels}"
+```
+
+Keep only PRs whose `authorAssociation` is NOT one of `MEMBER`, `OWNER`, `COLLABORATOR`.
+
+The issue and PR list queries are independent; run them in parallel (a single Bash invocation or parallel tool calls).
+
+For each external PR, fetch the changed file paths and review state in one call and carry both forward (the paths inform the domain analysis; the review state is reported in the digest):
+
+```bash
+gh pr view {number} --repo PostHog/posthog --json files,reviewDecision --jq '{files: [.files[].path], reviewDecision}'
+```
+
+### Step 4: Spawn Team-Specific Subagent
 
 Use the Task tool to spawn the appropriate triage subagent:
 
 - For `feature-flags`: Use subagent `triage-feature-flags`
 
-Pass the fetched issues to the subagent for analysis. The subagent will:
+Pass the fetched issues and external PRs (marked as such, with file paths where collected) to the subagent for analysis. The subagent will:
 
-1. Analyze each issue against the team's domain
+1. Analyze each item against the team's domain
 2. Return candidates with confidence levels and suggested labels
 
-### Step 4: Present Results
-
-Show the user:
-
-1. Summary: "Found X issues from the last Y days, Z candidates for {team} team"
-2. List of candidates with:
-   - Issue number and title (linked)
-   - Current labels
-   - Suggested labels
-   - Confidence level
-   - Brief reasoning
-
-### Step 5: Apply Labels
-
-Ask the user which issues to label:
-
-- They can specify issue numbers: "43654, 43230"
-- They can say "all" to label all candidates
-- They can say "none" to skip
+### Step 5: Apply Labels and Report
 
 Apply labels using:
 
 ```bash
-gh issue edit --repo PostHog/posthog {number} --add-label "{labels}"
+gh issue edit --repo PostHog/posthog {number} --add-label "{labels}"   # issues
+gh pr edit {number} --repo PostHog/posthog --add-label "{labels}"      # PRs
 ```
+
+**Interactive mode** (default): show the user a summary ("Found X issues and Y external PRs from the last Z days, N candidates for {team} team") and the candidate list — number and title (linked), current labels, suggested labels, confidence, brief reasoning. Then ask which to label: specific numbers, "all", or "none".
+
+**Unattended mode**: do not ask anything. Apply labels to HIGH-confidence candidates only; never label MEDIUM or LOW. If a label application fails, note it in the digest and continue without retrying. Then emit a Slack-friendly digest as your final output:
+
+1. Header: `{team name} triage — <date>` with counts: issues scanned, external PRs scanned, auto-labeled, needing decision.
+2. `External PRs` — every external PR matched to the domain at any confidence: link, title, author, review state (the `reviewDecision` carried from Step 3), labels applied or suggested, confidence. This section comes first; these are the items most often missed.
+3. `Auto-labeled (HIGH)`: item link, title, labels applied.
+4. `Needs a human decision (MEDIUM/LOW)`: item link, title, suggested labels, confidence, one-line reasoning.
+5. Any errors.
+
+If there are no candidates at all, the digest is the single line: `{team name} triage — <date>: nothing to triage.`
 
 ## Adding New Teams
 

--- a/ai/skills/triage-issues/SKILL.md
+++ b/ai/skills/triage-issues/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: triage-issues
-description: Identify unlabeled GitHub issues and external PRs that may belong to a specific team
+description: Identify unlabeled GitHub issues and external PRs that may belong to a specific team, and normalize conventional title scopes to the team's canonical short form
 argument-hint: "[days] [limit] [team] [unattended]"
 disable-model-invocation: true
 ---
@@ -64,20 +64,30 @@ The `{exclusion_labels}` vary by team. For feature-flags:
 Fetch unlabeled open PRs from the same window and keep only external contributions, which otherwise have no team routing and are easy to miss:
 
 ```bash
-gh search prs --repo PostHog/posthog --state open --limit {limit} --json number,title,body,labels,url,createdAt,isDraft,authorAssociation -- "created:>=$(date -v-{days}d +%Y-%m-%d) {exclusion_labels}"
+gh search prs --repo PostHog/posthog --state open --limit {limit} --json number,title,body,labels,url,createdAt,isDraft,author,authorAssociation -- "created:>=$(date -v-{days}d +%Y-%m-%d) {exclusion_labels}"
 ```
 
 Keep only PRs whose `authorAssociation` is NOT one of `MEMBER`, `OWNER`, `COLLABORATOR`.
 
 The issue and PR list queries are independent; run them in parallel (a single Bash invocation or parallel tool calls).
 
-For each external PR, fetch the changed file paths and review state in one call and carry both forward (the paths inform the domain analysis; the review state is reported in the digest):
+For the external PRs, fetch the changed file paths and review state and carry both forward (the paths inform the domain analysis; the review state is reported in the digest). Batch all of them into a single Bash invocation, one tool call rather than one per PR:
 
 ```bash
-gh pr view {number} --repo PostHog/posthog --json files,reviewDecision --jq '{files: [.files[].path], reviewDecision}'
+for n in {external_pr_numbers}; do
+  echo "PR ${n}: $(gh pr view "$n" --repo PostHog/posthog --json files,reviewDecision --jq '{files: [.files[].path], reviewDecision}')"
+done
 ```
 
-### Step 4: Spawn Team-Specific Subagent
+### Step 4: Detect Title Scope Renames
+
+Conventional titles use short team scopes. Scan every fetched item (issues and external PRs alike, whether or not they become candidates) for a title whose conventional scope uses the team's long name, and record a rename that swaps in the canonical scope, keeping the prefix and the rest of the title unchanged.
+
+The scope mapping varies by team. For feature-flags: `(feature-flags)` → `(flags)`, matched case-insensitively under any prefix, e.g. `feat(feature-flags): add bootstrap support` → `feat(flags): add bootstrap support`, `Fix(Feature-Flags): …` → `Fix(flags): …`.
+
+Renames are applied in Step 6, not here.
+
+### Step 5: Spawn Team-Specific Subagent
 
 Use the Task tool to spawn the appropriate triage subagent:
 
@@ -88,26 +98,29 @@ Pass the fetched issues and external PRs (marked as such, with file paths where 
 1. Analyze each item against the team's domain
 2. Return candidates with confidence levels and suggested labels
 
-### Step 5: Apply Labels and Report
+### Step 6: Apply Labels and Renames, and Report
 
-Apply labels using:
+Apply labels and title renames using:
 
 ```bash
 gh issue edit --repo PostHog/posthog {number} --add-label "{labels}"   # issues
 gh pr edit {number} --repo PostHog/posthog --add-label "{labels}"      # PRs
+gh issue edit --repo PostHog/posthog {number} --title "{new title}"    # renames (issues)
+gh pr edit {number} --repo PostHog/posthog --title "{new title}"       # renames (PRs)
 ```
 
-**Interactive mode** (default): show the user a summary ("Found X issues and Y external PRs from the last Z days, N candidates for {team} team") and the candidate list — number and title (linked), current labels, suggested labels, confidence, brief reasoning. Then ask which to label: specific numbers, "all", or "none".
+**Interactive mode** (default): show the user a summary ("Found X issues and Y external PRs from the last Z days, N candidates for {team} team, M title renames") and the candidate list — number and title (linked), current labels, suggested labels, confidence, brief reasoning — plus the proposed renames (old title → new title). Then ask which to apply: specific numbers, "all", or "none".
 
-**Unattended mode**: do not ask anything. Apply labels to HIGH-confidence candidates only; never label MEDIUM or LOW. If a label application fails, note it in the digest and continue without retrying. Then emit a Slack-friendly digest as your final output:
+**Unattended mode**: do not ask anything. Apply labels to HIGH-confidence candidates only; never label MEDIUM or LOW. Apply all Step 4 renames; the scope match is mechanical and needs no confidence gating. If a label application or rename fails, note it in the digest and continue without retrying. Then emit a Slack-friendly digest as your final output:
 
-1. Header: `{team name} triage — <date>` with counts: issues scanned, external PRs scanned, auto-labeled, needing decision.
+1. Header: `{team name} triage — <date>` with counts: issues scanned, external PRs scanned, auto-labeled, renamed, needing decision.
 2. `External PRs` — every external PR matched to the domain at any confidence: link, title, author, review state (the `reviewDecision` carried from Step 3), labels applied or suggested, confidence. This section comes first; these are the items most often missed.
 3. `Auto-labeled (HIGH)`: item link, title, labels applied.
-4. `Needs a human decision (MEDIUM/LOW)`: item link, title, suggested labels, confidence, one-line reasoning.
-5. Any errors.
+4. `Renamed titles`: item link, old title → new title.
+5. `Needs a human decision (MEDIUM/LOW)`: item link, title, suggested labels, confidence, one-line reasoning.
+6. Any errors.
 
-If there are no candidates at all, the digest is the single line: `{team name} triage — <date>: nothing to triage.`
+If there are no candidates and no renames, the digest is the single line: `{team name} triage — <date>: nothing to triage.`
 
 ## Adding New Teams
 
@@ -115,4 +128,5 @@ To add support for a new team:
 
 1. Create a new agent file: `ai/agents/triage-{team-name}.md`
 2. Define the team's domain, owned labels, keywords, and exclusions
-3. Add the team identifier to the "Supported team identifiers" list above
+3. Add the team's title scope mapping (long name → canonical scope) to Step 4
+4. Add the team identifier to the "Supported team identifiers" list above

--- a/bin/lib/claude-worker.sh
+++ b/bin/lib/claude-worker.sh
@@ -1,0 +1,112 @@
+# claude-worker.sh - Shared plumbing for launchd workers that drive a headless
+# claude session and DM the result.
+#
+# A worker sources this file (after logging.sh), sets its budget knobs, calls
+# `claude_worker_init <state-name>`, builds its PROMPT (typically embedding
+# $SESSION_ID and a DM step from `slack_dm_instructions`), and finishes with
+# `claude_worker_run "<heartbeat label>" "$PROMPT"`.
+#
+# Knobs (set before claude_worker_run; all have no defaults here so each
+# worker's env-overridable defaults stay next to its config):
+#   MAX_BUDGET_USD          --max-budget-usd for the claude run
+#   RUN_TIMEOUT_SECONDS     wall-clock timeout for the claude run
+#   RUN_KILL_AFTER_SECONDS  SIGKILL delay if claude ignores SIGTERM
+#   WORKER_ALLOWED_TOOLS    optional array of permission rules. When set, the
+#                           run uses --permission-mode default with exactly
+#                           these rules allowed and loads no settings files,
+#                           so the broad interactive allowlist in
+#                           ~/.claude/settings.json does not apply; any tool
+#                           call outside the list is denied (headless runs
+#                           have nobody to approve a prompt). Required for
+#                           workers that ingest untrusted content (public
+#                           GitHub issue/PR text): without it the run uses
+#                           bypassPermissions, where injected instructions
+#                           can reach Bash and every MCP tool unconfirmed.
+
+# Slack DM recipient for digests and drafts: Phil Haack (phil.h@posthog.com).
+# Hardcoded so scheduled runs don't burn a slack_search_users round trip on a
+# fixed input.
+SLACK_DM_USER_ID="${SLACK_DM_USER_ID:-U086UNZDP37}"
+
+# claude_worker_init <state-name>
+# Sets WORKING_DIR (the repo root, auto-detected so the worker runs correctly
+# whether invoked from ~/.dotfiles or from a worktree), cds into it, creates
+# ~/.local/state/<state-name>, and pre-generates SESSION_ID (recorded in
+# last-session-id) so the prompt can embed it in a DM footer and the service
+# script's `resume` command can find it.
+claude_worker_init() {
+  WORKER_STATE_NAME="$1"
+  WORKING_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+  STATE_DIR="${HOME}/.local/state/${WORKER_STATE_NAME}"
+  mkdir -p "$STATE_DIR"
+  LAST_SESSION_FILE="${STATE_DIR}/last-session-id"
+  SESSION_ID=$(uuidgen | tr '[:upper:]' '[:lower:]')
+  echo "$SESSION_ID" > "$LAST_SESSION_FILE"
+  cd "$WORKING_DIR"
+}
+
+# slack_dm_instructions <step-number> <content-description> <footer-intro>
+# Emits the standard prompt step for DMing the run's output: send via
+# mcp__claude_ai_Slack__slack_send_message to $SLACK_DM_USER_ID, body =
+# content + blank line + fenced footer with the resume command.
+slack_dm_instructions() {
+  local step="$1" content="$2" footer_intro="$3"
+  cat <<EOF
+${step}. Send ${content} as a Slack DM using
+   mcp__claude_ai_Slack__slack_send_message to Slack user ID
+   ${SLACK_DM_USER_ID} (the channel argument is the user ID; Slack opens the
+   DM channel automatically). The DM body has three parts, in this order:
+   a. ${content}
+   b. A blank line
+   c. A footer block in a fenced code block, verbatim:
+
+      ${footer_intro}
+        cd ${WORKING_DIR}
+        claude --resume ${SESSION_ID}
+EOF
+}
+
+# claude_worker_run <heartbeat-label> <prompt>
+# Runs claude headless with the standard guards and logs the outcome.
+# caffeinate -i blocks idle sleep so the timeout measures real wall-clock
+# time; timeout --kill-after fires SIGKILL if claude ignores SIGTERM.
+claude_worker_run() {
+  local heartbeat_label="$1" prompt="$2"
+
+  local -a permission_args
+  if [[ -n "${WORKER_ALLOWED_TOOLS[*]+set}" ]]; then
+    log_info "Tool allowlist: ${WORKER_ALLOWED_TOOLS[*]}"
+    permission_args=(
+      --permission-mode default
+      --setting-sources ""
+      --allowedTools "${WORKER_ALLOWED_TOOLS[@]}"
+    )
+  else
+    permission_args=(--permission-mode bypassPermissions)
+  fi
+
+  log_info "Invoking claude --print"
+  start_heartbeat 60 "$heartbeat_label"
+  set +e
+  caffeinate -i timeout --kill-after="$RUN_KILL_AFTER_SECONDS" \
+    "$RUN_TIMEOUT_SECONDS" \
+    claude --print \
+      --session-id "$SESSION_ID" \
+      "${permission_args[@]}" \
+      --max-budget-usd "$MAX_BUDGET_USD" \
+      --output-format text \
+      "$prompt"
+  local exit_code=$?
+  set -e
+  stop_heartbeat
+
+  if [[ $exit_code -eq 0 ]]; then
+    log_success "${WORKER_STATE_NAME} finished (session $SESSION_ID)"
+  elif [[ $exit_code -eq 124 ]]; then
+    log_error "${WORKER_STATE_NAME} timed out after ${RUN_TIMEOUT_SECONDS}s"
+  else
+    log_error "${WORKER_STATE_NAME} failed with exit code $exit_code"
+  fi
+
+  exit "$exit_code"
+}

--- a/bin/lib/launchd-service.sh
+++ b/bin/lib/launchd-service.sh
@@ -1,8 +1,9 @@
+#!/usr/bin/env bash
 # launchd-service.sh - Shared command implementation for LaunchAgent service
 # scripts (install/uninstall/start/stop/status/logs/run/resume).
 #
-# A service script sets the variables below, sources this file (after
-# logging.sh), optionally defines the hooks, and finally calls
+# A service script sources this file (after logging.sh), sets the variables
+# below, optionally defines the hooks, and finally calls
 # `launchd_service_main "$@"`.
 #
 # Required:
@@ -54,7 +55,7 @@ Commands:
 ${USAGE_EXTRA:+
 ${USAGE_EXTRA}}
 EOF
-  exit 0
+  exit "${1:-0}"
 }
 
 cmd_install() {
@@ -217,7 +218,7 @@ cmd_resume() {
 launchd_service_main() {
   _svc_init
 
-  if [[ $# -eq 0 || -z "${1:-}" ]]; then
+  if [[ $# -eq 0 ]]; then
     usage
   fi
 
@@ -235,7 +236,7 @@ launchd_service_main() {
     -h|--help|help) usage ;;
     *)
       log_error "Unknown command: $command"
-      usage
+      usage 64
       ;;
   esac
 }

--- a/bin/lib/launchd-service.sh
+++ b/bin/lib/launchd-service.sh
@@ -1,0 +1,241 @@
+# launchd-service.sh - Shared command implementation for LaunchAgent service
+# scripts (install/uninstall/start/stop/status/logs/run/resume).
+#
+# A service script sets the variables below, sources this file (after
+# logging.sh), optionally defines the hooks, and finally calls
+# `launchd_service_main "$@"`.
+#
+# Required:
+#   SERVICE_NAME   short name, e.g. triage-daily. Derives the launchd label
+#                  (com.haacked.<name>), the plist basename, and the state
+#                  directory (~/.local/state/<name>, which also holds the
+#                  launchd log and the last recorded session id).
+#   WORKER         absolute path to the worker executable used by `run`
+#
+# Optional:
+#   WORKER_ARGS    array of arguments `run` passes to the worker
+#   SCHEDULE_DESC  human-readable schedule shown by `install`
+#   REPO_ROOT      working dir for `resume` (default: this repo's root)
+#   USAGE_ARGS     extra argument hint appended to the usage line
+#   USAGE_DESC     description paragraph for usage (default names the agent)
+#   USAGE_EXTRA    extra usage text (e.g. an Examples block)
+#
+# Hooks (define after sourcing to extend behavior):
+#   service_status_extra   called at the end of `status`
+
+_svc_init() {
+  SERVICE_LABEL="com.haacked.${SERVICE_NAME}"
+  PLIST_NAME="${SERVICE_LABEL}.plist"
+  PLIST_SOURCE="${HOME}/.dotfiles/macos/LaunchAgents/${PLIST_NAME}"
+  PLIST_DEST="${HOME}/Library/LaunchAgents/${PLIST_NAME}"
+  STATE_DIR="${HOME}/.local/state/${SERVICE_NAME}"
+  LOG_FILE="${STATE_DIR}/launchd.log"
+  LAST_SESSION_FILE="${STATE_DIR}/last-session-id"
+  if [[ -z "${REPO_ROOT:-}" ]]; then
+    REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+  fi
+}
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") <command>${USAGE_ARGS:+ ${USAGE_ARGS}}
+
+${USAGE_DESC:-Manage the ${SERVICE_LABEL} LaunchAgent.}
+
+Commands:
+  install    Create symlink and load the agent
+  uninstall  Unload the agent and remove symlink
+  start      Trigger the run now (via launchctl)
+  stop       Unload the agent (disable scheduled runs)
+  status     Show agent status
+  logs       Tail the launchd log file
+  run        Run the worker script directly (for testing)
+  resume     Resume the most recent session in an interactive terminal
+${USAGE_EXTRA:+
+${USAGE_EXTRA}}
+EOF
+  exit 0
+}
+
+cmd_install() {
+  log_info "Installing ${SERVICE_LABEL} LaunchAgent…"
+
+  mkdir -p "$STATE_DIR"
+  log_info "Created state directory: $STATE_DIR"
+
+  if [[ ! -f "$PLIST_SOURCE" ]]; then
+    log_error "Source plist not found: $PLIST_SOURCE"
+    exit 1
+  fi
+
+  if [[ -L "$PLIST_DEST" ]]; then
+    log_warn "Symlink already exists, recreating…"
+    rm "$PLIST_DEST"
+  elif [[ -f "$PLIST_DEST" ]]; then
+    log_error "Regular file exists at $PLIST_DEST. Remove it first."
+    exit 1
+  fi
+
+  ln -s "$PLIST_SOURCE" "$PLIST_DEST"
+  log_info "Created symlink: $PLIST_DEST -> $PLIST_SOURCE"
+
+  if launchctl list | grep -q "$SERVICE_LABEL"; then
+    log_warn "Agent already loaded, reloading…"
+    launchctl unload "$PLIST_DEST" 2>/dev/null || true
+  fi
+
+  launchctl load "$PLIST_DEST"
+  log_success "LaunchAgent installed and loaded"
+  [[ -n "${SCHEDULE_DESC:-}" ]] && log_info "Runs ${SCHEDULE_DESC}"
+  log_info "Use '$(basename "$0") run' to test the worker now"
+}
+
+cmd_uninstall() {
+  log_info "Uninstalling ${SERVICE_LABEL} LaunchAgent…"
+
+  if launchctl list | grep -q "$SERVICE_LABEL"; then
+    launchctl unload "$PLIST_DEST" 2>/dev/null || true
+    log_info "Agent unloaded"
+  fi
+
+  if [[ -L "$PLIST_DEST" || -f "$PLIST_DEST" ]]; then
+    rm "$PLIST_DEST"
+    log_info "Removed: $PLIST_DEST"
+  fi
+
+  log_success "LaunchAgent uninstalled"
+}
+
+cmd_start() {
+  log_info "Triggering ${SERVICE_LABEL} run…"
+
+  if ! launchctl list | grep -q "$SERVICE_LABEL"; then
+    log_error "Agent not loaded. Run 'install' first."
+    exit 1
+  fi
+
+  launchctl start "$SERVICE_LABEL"
+  log_success "Run started"
+  log_info "Use '$(basename "$0") logs' to watch progress"
+}
+
+cmd_stop() {
+  log_info "Stopping LaunchAgent…"
+
+  if launchctl list | grep -q "$SERVICE_LABEL"; then
+    launchctl unload "$PLIST_DEST" 2>/dev/null || true
+    log_success "Agent stopped (unloaded)"
+  else
+    log_warn "Agent was not loaded"
+  fi
+}
+
+cmd_status() {
+  echo "LaunchAgent Status:"
+  echo "==================="
+
+  if [[ -L "$PLIST_DEST" ]]; then
+    echo -e "Symlink:  ${GREEN}installed${NC}"
+  elif [[ -f "$PLIST_DEST" ]]; then
+    echo -e "Symlink:  ${YELLOW}regular file (not symlink)${NC}"
+  else
+    echo -e "Symlink:  ${RED}not installed${NC}"
+  fi
+
+  local agent_line
+  agent_line=$(launchctl list | grep "$SERVICE_LABEL" || true)
+  if [[ -n "$agent_line" ]]; then
+    echo -e "Agent:    ${GREEN}loaded${NC}"
+    local status
+    status=$(awk '{print $1}' <<<"$agent_line")
+    if [[ "$status" == "-" ]]; then
+      echo "Last run: never (or currently running)"
+    elif [[ "$status" == "0" ]]; then
+      echo -e "Last run: ${GREEN}success (exit 0)${NC}"
+    else
+      echo -e "Last run: ${RED}failed (exit $status)${NC}"
+    fi
+  else
+    echo -e "Agent:    ${RED}not loaded${NC}"
+  fi
+
+  if [[ -f "$LOG_FILE" ]]; then
+    local log_size log_lines
+    log_size=$(du -h "$LOG_FILE" | cut -f1)
+    log_lines=$(wc -l < "$LOG_FILE" | tr -d ' ')
+    echo "Log file: $LOG_FILE ($log_size, $log_lines lines)"
+  else
+    echo "Log file: not created yet"
+  fi
+
+  if [[ -f "$LAST_SESSION_FILE" ]]; then
+    local last_session
+    last_session=$(cat "$LAST_SESSION_FILE")
+    echo "Last session: $last_session"
+    echo "  Resume with: cd ${REPO_ROOT} && claude --resume $last_session"
+  else
+    echo "Last session: none recorded"
+  fi
+
+  if declare -F service_status_extra >/dev/null; then
+    service_status_extra
+  fi
+}
+
+cmd_logs() {
+  if [[ ! -f "$LOG_FILE" ]]; then
+    log_warn "Log file does not exist yet: $LOG_FILE"
+    log_info "Run 'start' or 'run' to generate output"
+    exit 0
+  fi
+
+  log_info "Tailing log file (Ctrl+C to stop)…"
+  tail -f "$LOG_FILE"
+}
+
+cmd_run() {
+  if [[ ! -x "$WORKER" ]]; then
+    log_error "Worker not found or not executable: $WORKER"
+    exit 1
+  fi
+  log_info "Running worker in foreground…"
+  exec "$WORKER" ${WORKER_ARGS[@]+"${WORKER_ARGS[@]}"} "$@"
+}
+
+cmd_resume() {
+  if [[ ! -f "$LAST_SESSION_FILE" ]]; then
+    log_error "No recorded session yet. Run '$(basename "$0") run' first."
+    exit 1
+  fi
+  local last_session
+  last_session=$(cat "$LAST_SESSION_FILE")
+  log_info "Resuming session $last_session from $REPO_ROOT"
+  cd "$REPO_ROOT"
+  exec claude --resume "$last_session"
+}
+
+launchd_service_main() {
+  _svc_init
+
+  if [[ $# -eq 0 || -z "${1:-}" ]]; then
+    usage
+  fi
+
+  local command="$1"
+  shift
+  case "$command" in
+    install) cmd_install ;;
+    uninstall) cmd_uninstall ;;
+    start) cmd_start ;;
+    stop) cmd_stop ;;
+    status) cmd_status ;;
+    logs) cmd_logs ;;
+    run) cmd_run "$@" ;;
+    resume) cmd_resume ;;
+    -h|--help|help) usage ;;
+    *)
+      log_error "Unknown command: $command"
+      usage
+      ;;
+  esac
+}

--- a/bin/ops-report-service.sh
+++ b/bin/ops-report-service.sh
@@ -5,28 +5,13 @@
 #   ops-report-service.sh <command> [daily|weekly]
 #
 # The optional second argument selects which agent to act on (default: daily).
-#
-# Commands:
-#   install    Create symlink, log directory, and load the agent
-#   uninstall  Unload the agent and remove symlink
-#   start      Manually trigger the run now (via launchctl)
-#   stop       Unload the agent (disable scheduled runs)
-#   status     Show agent status and the last session ID
-#   logs       Tail the launchd log file
-#   run        Run the worker script directly in this terminal (for testing)
-#   resume     Resume the most recent session (claude --resume <last-session-id>)
+# Commands are provided by lib/launchd-service.sh.
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/lib/logging.sh"
-
-# Auto-detect the worktree/install root from this script's location, so `run`
-# and `resume` work both from ~/.dotfiles (installed) and from a worktree.
-# install/uninstall still pin to ~/.dotfiles since that's where the merged
-# code lives and where the LaunchAgent symlink should point.
-REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
-WORKER="${REPO_ROOT}/bin/ops-report-run"
+source "${SCRIPT_DIR}/lib/launchd-service.sh"
 
 # The report kind (daily|weekly) is the optional second positional argument and
 # selects the agent, state dir, and worker window. One worker serves both.
@@ -40,211 +25,19 @@ case "$KIND" in
     ;;
 esac
 
-PLIST_NAME="com.haacked.ops-report-${KIND}.plist"
-PLIST_SOURCE="${HOME}/.dotfiles/macos/LaunchAgents/${PLIST_NAME}"
-PLIST_DEST="${HOME}/Library/LaunchAgents/${PLIST_NAME}"
-STATE_DIR="${HOME}/.local/state/ops-report-${KIND}"
-LOG_FILE="${STATE_DIR}/launchd.log"
-LAST_SESSION_FILE="${STATE_DIR}/last-session-id"
-LABEL="com.haacked.ops-report-${KIND}"
+SERVICE_NAME="ops-report-${KIND}"
+WORKER="${SCRIPT_DIR}/ops-report-run"
+WORKER_ARGS=("$WINDOW")
 
-usage() {
-  cat <<EOF
-Usage: $(basename "$0") <command> [daily|weekly]
-
-Manage the ops-report LaunchAgents. The optional second argument selects the
+USAGE_ARGS="[daily|weekly]"
+USAGE_DESC="Manage the ops-report LaunchAgents. The optional second argument selects the
 agent (default: daily). The daily agent runs Tue–Fri; the weekly digest runs
-Monday.
-
-Commands:
-  install    Create symlink and load the agent
-  uninstall  Unload the agent and remove symlink
-  start      Trigger the run now (via launchctl)
-  stop       Unload the agent (disable scheduled runs)
-  status     Show agent status and the last session ID
-  logs       Tail the launchd log file
-  run        Run the worker script directly (for testing)
-  resume     Resume the most recent session in an interactive terminal
-
-Examples:
+Monday."
+USAGE_EXTRA="Examples:
   $(basename "$0") install          # Install the daily agent (Tue–Fri 9am)
   $(basename "$0") install weekly   # Install the weekly digest (Monday 9am)
   $(basename "$0") run weekly       # Generate this week's digest now, foreground
   $(basename "$0") resume           # Open the most recent daily session to iterate
-  $(basename "$0") logs weekly      # Watch what the weekly agent did
-EOF
-  exit 0
-}
+  $(basename "$0") logs weekly      # Watch what the weekly agent did"
 
-cmd_install() {
-  log_info "Installing ops-report-${KIND} LaunchAgent…"
-
-  mkdir -p "$STATE_DIR"
-  log_info "Created state directory: $STATE_DIR"
-
-  if [[ ! -f "$PLIST_SOURCE" ]]; then
-    log_error "Source plist not found: $PLIST_SOURCE"
-    exit 1
-  fi
-
-  if [[ -L "$PLIST_DEST" ]]; then
-    log_warn "Symlink already exists, recreating…"
-    rm "$PLIST_DEST"
-  elif [[ -f "$PLIST_DEST" ]]; then
-    log_error "Regular file exists at $PLIST_DEST. Remove it first."
-    exit 1
-  fi
-
-  ln -s "$PLIST_SOURCE" "$PLIST_DEST"
-  log_info "Created symlink: $PLIST_DEST -> $PLIST_SOURCE"
-
-  if launchctl list | grep -q "$LABEL"; then
-    log_warn "Agent already loaded, reloading…"
-    launchctl unload "$PLIST_DEST" 2>/dev/null || true
-  fi
-
-  launchctl load "$PLIST_DEST"
-  log_success "LaunchAgent installed and loaded"
-  log_info "Runs ${SCHEDULE_DESC}"
-  log_info "Use '$(basename "$0") run ${KIND}' to test the worker now"
-}
-
-cmd_uninstall() {
-  log_info "Uninstalling ops-report-${KIND} LaunchAgent…"
-
-  if launchctl list | grep -q "$LABEL"; then
-    launchctl unload "$PLIST_DEST" 2>/dev/null || true
-    log_info "Agent unloaded"
-  fi
-
-  if [[ -L "$PLIST_DEST" || -f "$PLIST_DEST" ]]; then
-    rm "$PLIST_DEST"
-    log_info "Removed: $PLIST_DEST"
-  fi
-
-  log_success "LaunchAgent uninstalled"
-}
-
-cmd_start() {
-  log_info "Triggering ops-report-${KIND} run…"
-
-  if ! launchctl list | grep -q "$LABEL"; then
-    log_error "Agent not loaded. Run 'install' first."
-    exit 1
-  fi
-
-  launchctl start "$LABEL"
-  log_success "Run started"
-  log_info "Use '$(basename "$0") logs' to watch progress"
-}
-
-cmd_stop() {
-  log_info "Stopping LaunchAgent…"
-
-  if launchctl list | grep -q "$LABEL"; then
-    launchctl unload "$PLIST_DEST" 2>/dev/null || true
-    log_success "Agent stopped (unloaded)"
-  else
-    log_warn "Agent was not loaded"
-  fi
-}
-
-cmd_status() {
-  echo "LaunchAgent Status:"
-  echo "==================="
-
-  if [[ -L "$PLIST_DEST" ]]; then
-    echo -e "Symlink:  ${GREEN}installed${NC}"
-  elif [[ -f "$PLIST_DEST" ]]; then
-    echo -e "Symlink:  ${YELLOW}regular file (not symlink)${NC}"
-  else
-    echo -e "Symlink:  ${RED}not installed${NC}"
-  fi
-
-  local agent_line
-  agent_line=$(launchctl list | grep "$LABEL" || true)
-  if [[ -n "$agent_line" ]]; then
-    echo -e "Agent:    ${GREEN}loaded${NC}"
-    local status
-    status=$(awk '{print $1}' <<<"$agent_line")
-    if [[ "$status" == "-" ]]; then
-      echo "Last run: never (or currently running)"
-    elif [[ "$status" == "0" ]]; then
-      echo -e "Last run: ${GREEN}success (exit 0)${NC}"
-    else
-      echo -e "Last run: ${RED}failed (exit $status)${NC}"
-    fi
-  else
-    echo -e "Agent:    ${RED}not loaded${NC}"
-  fi
-
-  if [[ -f "$LOG_FILE" ]]; then
-    local log_size log_lines
-    log_size=$(du -h "$LOG_FILE" | cut -f1)
-    log_lines=$(wc -l < "$LOG_FILE" | tr -d ' ')
-    echo "Log file: $LOG_FILE ($log_size, $log_lines lines)"
-  else
-    echo "Log file: not created yet"
-  fi
-
-  if [[ -f "$LAST_SESSION_FILE" ]]; then
-    local last_session
-    last_session=$(cat "$LAST_SESSION_FILE")
-    echo "Last session: $last_session"
-    echo "  Resume with: cd ${REPO_ROOT} && claude --resume $last_session"
-  else
-    echo "Last session: none recorded"
-  fi
-}
-
-cmd_logs() {
-  if [[ ! -f "$LOG_FILE" ]]; then
-    log_warn "Log file does not exist yet: $LOG_FILE"
-    log_info "Run 'start' or 'run' to generate output"
-    exit 0
-  fi
-
-  log_info "Tailing log file (Ctrl+C to stop)…"
-  tail -f "$LOG_FILE"
-}
-
-cmd_run() {
-  if [[ ! -x "$WORKER" ]]; then
-    log_error "Worker not found or not executable: $WORKER"
-    exit 1
-  fi
-  log_info "Running ${KIND} worker (${WINDOW} window) in foreground…"
-  exec "$WORKER" "$WINDOW"
-}
-
-cmd_resume() {
-  if [[ ! -f "$LAST_SESSION_FILE" ]]; then
-    log_error "No recorded session yet. Run '$(basename "$0") run' first."
-    exit 1
-  fi
-  local last_session
-  last_session=$(cat "$LAST_SESSION_FILE")
-  log_info "Resuming session $last_session from $REPO_ROOT"
-  cd "$REPO_ROOT"
-  exec claude --resume "$last_session"
-}
-
-if [[ $# -eq 0 ]]; then
-  usage
-fi
-
-case "${1:-}" in
-  install) cmd_install ;;
-  uninstall) cmd_uninstall ;;
-  start) cmd_start ;;
-  stop) cmd_stop ;;
-  status) cmd_status ;;
-  logs) cmd_logs ;;
-  run) cmd_run ;;
-  resume) cmd_resume ;;
-  -h|--help|help) usage ;;
-  *)
-    log_error "Unknown command: $1"
-    usage
-    ;;
-esac
+launchd_service_main "${1:-}"

--- a/bin/ops-report-service.sh
+++ b/bin/ops-report-service.sh
@@ -40,4 +40,6 @@ USAGE_EXTRA="Examples:
   $(basename "$0") resume           # Open the most recent daily session to iterate
   $(basename "$0") logs weekly      # Watch what the weekly agent did"
 
-launchd_service_main "${1:-}"
+# Pass only the command word; the kind was consumed above. ${1:+"$1"} expands
+# to nothing (not an empty string) when the script is run with no arguments.
+launchd_service_main ${1:+"$1"}

--- a/bin/review-all-prs-service.sh
+++ b/bin/review-all-prs-service.sh
@@ -4,14 +4,7 @@
 # Usage:
 #   review-all-prs-service.sh [install|uninstall|start|stop|status|logs|run]
 #
-# Commands:
-#   install    Create symlink, log directory, and load the agent
-#   uninstall  Unload the agent and remove symlink
-#   start      Manually trigger the review job now
-#   stop       Unload the agent (disable scheduled runs)
-#   status     Show agent status
-#   logs       Tail the log file
-#   run        Run the review script manually (for testing)
+# Commands are provided by lib/launchd-service.sh.
 #
 # IMPORTANT: Run 'install' before the LaunchAgent runs to create the log
 # directory. The LaunchAgent writes to ~/.local/state/review-all-prs/launchd.log
@@ -19,166 +12,23 @@
 
 set -euo pipefail
 
-# Source shared logging utilities
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/lib/logging.sh"
+source "${SCRIPT_DIR}/lib/launchd-service.sh"
 
-PLIST_NAME="com.haacked.review-all-prs.plist"
-PLIST_SOURCE="${HOME}/.dotfiles/macos/LaunchAgents/${PLIST_NAME}"
-PLIST_DEST="${HOME}/Library/LaunchAgents/${PLIST_NAME}"
-STATE_DIR="${HOME}/.local/state/review-all-prs"
-LOG_FILE="${STATE_DIR}/launchd.log"
-LABEL="com.haacked.review-all-prs"
+SERVICE_NAME="review-all-prs"
+WORKER="${SCRIPT_DIR}/run-pr-reviews.sh"
+WORKER_ARGS=(--auto)
+SCHEDULE_DESC="hourly from 6 PM to 2 AM"
 
-usage() {
-  cat <<EOF
-Usage: $(basename "$0") <command>
-
-Manage the review-all-prs LaunchAgent.
-
-Commands:
-  install    Create symlink and load the agent
-  uninstall  Unload the agent and remove symlink
-  start      Manually trigger the review job now
-  stop       Unload the agent (disable scheduled runs)
-  status     Show agent status
-  logs       Tail the log file
-  run        Run the review script manually (for testing)
-
-Examples:
-  $(basename "$0") install    # Set up scheduled reviews
-  $(basename "$0") start      # Run reviews now
-  $(basename "$0") logs       # Watch the log output
-  $(basename "$0") status     # Check if agent is loaded
-EOF
-  exit 0
-}
-
-cmd_install() {
-  log_info "Installing review-all-prs LaunchAgent..."
-
-  # Ensure state directory exists (required for log file before LaunchAgent runs)
-  mkdir -p "$STATE_DIR"
-  log_info "Created state directory: $STATE_DIR"
-
-  # Check if source plist exists
-  if [[ ! -f "$PLIST_SOURCE" ]]; then
-    log_error "Source plist not found: $PLIST_SOURCE"
-    exit 1
-  fi
-
-  # Create symlink
-  if [[ -L "$PLIST_DEST" ]]; then
-    log_warn "Symlink already exists, recreating..."
-    rm "$PLIST_DEST"
-  elif [[ -f "$PLIST_DEST" ]]; then
-    log_error "Regular file exists at $PLIST_DEST - remove it first"
-    exit 1
-  fi
-
-  ln -s "$PLIST_SOURCE" "$PLIST_DEST"
-  log_info "Created symlink: $PLIST_DEST -> $PLIST_SOURCE"
-
-  # Load the agent
-  if launchctl list | grep -q "$LABEL"; then
-    log_warn "Agent already loaded, reloading..."
-    launchctl unload "$PLIST_DEST" 2>/dev/null || true
-  fi
-
-  launchctl load "$PLIST_DEST"
-  log_success "LaunchAgent installed and loaded"
-  log_info "Reviews will run hourly from 6 PM to 2 AM"
-  log_info "Use '$(basename "$0") start' to run immediately"
-}
-
-cmd_uninstall() {
-  log_info "Uninstalling review-all-prs LaunchAgent..."
-
-  # Unload if loaded
-  if launchctl list | grep -q "$LABEL"; then
-    launchctl unload "$PLIST_DEST" 2>/dev/null || true
-    log_info "Agent unloaded"
-  fi
-
-  # Remove symlink
-  if [[ -L "$PLIST_DEST" || -f "$PLIST_DEST" ]]; then
-    rm "$PLIST_DEST"
-    log_info "Removed: $PLIST_DEST"
-  fi
-
-  log_success "LaunchAgent uninstalled"
-}
-
-cmd_start() {
-  log_info "Triggering review job..."
-
-  if ! launchctl list | grep -q "$LABEL"; then
-    log_error "Agent not loaded. Run 'install' first."
-    exit 1
-  fi
-
-  launchctl start "$LABEL"
-  log_success "Review job started"
-  log_info "Use '$(basename "$0") logs' to watch progress"
-}
-
-cmd_stop() {
-  log_info "Stopping LaunchAgent..."
-
-  if launchctl list | grep -q "$LABEL"; then
-    launchctl unload "$PLIST_DEST" 2>/dev/null || true
-    log_success "Agent stopped (unloaded)"
-  else
-    log_warn "Agent was not loaded"
-  fi
-}
-
-cmd_status() {
-  echo "LaunchAgent Status:"
-  echo "==================="
-
-  if [[ -L "$PLIST_DEST" ]]; then
-    echo -e "Symlink:  ${GREEN}installed${NC}"
-  elif [[ -f "$PLIST_DEST" ]]; then
-    echo -e "Symlink:  ${YELLOW}regular file (not symlink)${NC}"
-  else
-    echo -e "Symlink:  ${RED}not installed${NC}"
-  fi
-
-  if launchctl list | grep -q "$LABEL"; then
-    echo -e "Agent:    ${GREEN}loaded${NC}"
-    # Get last exit status
-    local status
-    status=$(launchctl list | grep "$LABEL" | awk '{print $1}')
-    if [[ "$status" == "-" ]]; then
-      echo "Last run: never (or running)"
-    elif [[ "$status" == "0" ]]; then
-      echo -e "Last run: ${GREEN}success (exit 0)${NC}"
-    else
-      echo -e "Last run: ${RED}failed (exit $status)${NC}"
-    fi
-  else
-    echo -e "Agent:    ${RED}not loaded${NC}"
-  fi
-
-  if [[ -f "$LOG_FILE" ]]; then
-    local log_size
-    log_size=$(du -h "$LOG_FILE" | cut -f1)
-    local log_lines
-    log_lines=$(wc -l < "$LOG_FILE" | tr -d ' ')
-    echo "Log file: $LOG_FILE ($log_size, $log_lines lines)"
-  else
-    echo "Log file: not created yet"
-  fi
-
-  # Show today's session if exists
-  local today
+# Today's review session counts, appended to `status`.
+service_status_extra() {
+  local today session_file
   today=$(date +%Y-%m-%d)
-  local session_file="${STATE_DIR}/session-${today}.json"
+  session_file="${STATE_DIR}/session-${today}.json"
   if [[ -f "$session_file" ]]; then
-    local reviewed
+    local reviewed failed
     reviewed=$(jq '.reviewed | length' < "$session_file")
-    local failed
     failed=$(jq '.failed | length' < "$session_file")
     echo ""
     echo "Today's session:"
@@ -187,55 +37,4 @@ cmd_status() {
   fi
 }
 
-cmd_logs() {
-  if [[ ! -f "$LOG_FILE" ]]; then
-    log_warn "Log file doesn't exist yet: $LOG_FILE"
-    log_info "Run 'start' to trigger a review and create logs"
-    exit 0
-  fi
-
-  log_info "Tailing log file (Ctrl+C to stop)..."
-  tail -f "$LOG_FILE"
-}
-
-cmd_run() {
-  log_info "Running review script manually..."
-  exec "${HOME}/.dotfiles/bin/run-pr-reviews.sh" --auto "$@"
-}
-
-# Main
-if [[ $# -eq 0 ]]; then
-  usage
-fi
-
-case "${1:-}" in
-  install)
-    cmd_install
-    ;;
-  uninstall)
-    cmd_uninstall
-    ;;
-  start)
-    cmd_start
-    ;;
-  stop)
-    cmd_stop
-    ;;
-  status)
-    cmd_status
-    ;;
-  logs)
-    cmd_logs
-    ;;
-  run)
-    shift
-    cmd_run "$@"
-    ;;
-  -h|--help|help)
-    usage
-    ;;
-  *)
-    log_error "Unknown command: $1"
-    usage
-    ;;
-esac
+launchd_service_main "$@"

--- a/bin/sprint-status-run
+++ b/bin/sprint-status-run
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# sprint-status-run - Generate the Feature Flags sprint status and DM it.
+#
+# Runs the /sprint-status skill in slack output mode (Slack markdown instead of
+# the rich-text clipboard; nobody is at the keyboard to paste) and DMs the
+# result to the recipient. The DM footer explains how to resume the session to
+# iterate.
+#
+# Intended to be invoked by launchd (com.haacked.sprint-status.plist) or by
+# hand via bin/sprint-status-service.sh.
+#
+# Usage: sprint-status-run
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/lib/logging.sh"
+source "${SCRIPT_DIR}/lib/claude-worker.sh"
+
+MAX_BUDGET_USD="${SPRINT_STATUS_MAX_BUDGET_USD:-5}"
+RUN_TIMEOUT_SECONDS="${SPRINT_STATUS_TIMEOUT_SECONDS:-900}"   # 15 min
+RUN_KILL_AFTER_SECONDS="${SPRINT_STATUS_KILL_AFTER_SECONDS:-60}"
+
+claude_worker_init "sprint-status"
+
+log_section "sprint-status"
+log_info "Session ID:   $SESSION_ID"
+log_info "Budget cap:   \$${MAX_BUDGET_USD}"
+log_info "Working dir:  $WORKING_DIR"
+
+PROMPT=$(cat <<EOF
+You are generating the mid-week sprint status for the PostHog Feature Flags
+team. This run was triggered by a launchd job. Your output goes to one Slack
+DM, not to the team channel.
+
+Your session ID for this run is: ${SESSION_ID}
+
+Do these steps in order.
+
+1. Invoke the /sprint-status skill in slack output mode for the default
+   Feature Flags team: "/sprint-status slack"
+
+$(slack_dm_instructions 2 "the rendered sprint status from step 1" "To iterate on this status:")
+
+3. After the DM is sent, print a one-line summary to stdout: sprint issue
+   number, members covered, done/total counts, and the DM channel ID.
+
+Hard constraints:
+- Do NOT post to any Slack channel. Only DM.
+- Do NOT post anything to GitHub.
+- Do NOT modify any files in the repo.
+- If a data-gathering step fails, still DM whatever partial status you have,
+  with a note about which step failed and why.
+EOF
+)
+
+claude_worker_run "Generating sprint status" "$PROMPT"

--- a/bin/sprint-status-run
+++ b/bin/sprint-status-run
@@ -21,6 +21,8 @@ MAX_BUDGET_USD="${SPRINT_STATUS_MAX_BUDGET_USD:-5}"
 RUN_TIMEOUT_SECONDS="${SPRINT_STATUS_TIMEOUT_SECONDS:-900}"   # 15 min
 RUN_KILL_AFTER_SECONDS="${SPRINT_STATUS_KILL_AFTER_SECONDS:-60}"
 
+# Must match SERVICE_NAME in sprint-status-service.sh and log_dir in the plist;
+# the service's `logs` and `resume` commands read this state dir.
 claude_worker_init "sprint-status"
 
 log_section "sprint-status"

--- a/bin/sprint-status-service.sh
+++ b/bin/sprint-status-service.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# sprint-status-service.sh - Manage the weekly sprint status LaunchAgent.
+#
+# Usage:
+#   sprint-status-service.sh [install|uninstall|start|stop|status|logs|run|resume]
+#
+# Commands are provided by lib/launchd-service.sh.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/lib/logging.sh"
+source "${SCRIPT_DIR}/lib/launchd-service.sh"
+
+SERVICE_NAME="sprint-status"
+WORKER="${SCRIPT_DIR}/sprint-status-run"
+SCHEDULE_DESC="Wednesday at 08:00 local time"
+
+launchd_service_main "$@"

--- a/bin/triage-run
+++ b/bin/triage-run
@@ -3,8 +3,9 @@
 # team and DM the digest.
 #
 # Runs the /triage-issues skill in unattended mode (auto-labels HIGH-confidence
-# candidates, digests the rest) and DMs the digest to the recipient with
-# instructions for resuming the session to act on the undecided items.
+# candidates, normalizes conventional title scopes, digests the rest) and DMs
+# the digest to the recipient with instructions for resuming the session to act
+# on the undecided items.
 #
 # Intended to be invoked by launchd (com.haacked.triage-daily.plist) or by hand
 # via bin/triage-service.sh.
@@ -23,6 +24,30 @@ MAX_BUDGET_USD="${TRIAGE_MAX_BUDGET_USD:-5}"
 RUN_TIMEOUT_SECONDS="${TRIAGE_TIMEOUT_SECONDS:-900}"   # 15 min
 RUN_KILL_AFTER_SECONDS="${TRIAGE_KILL_AFTER_SECONDS:-60}"
 
+# This run ingests untrusted text (public GitHub issue and PR bodies), so it
+# gets exactly the tools the job needs instead of bypassPermissions: the gh
+# fetches and label edits from the triage-issues skill, Skill/Task to invoke
+# the skill and its subagent, ToolSearch to load the Slack tool schema, and
+# the one Slack send tool for the DM. Everything else is denied.
+WORKER_ALLOWED_TOOLS=(
+  "Skill"
+  "Task"
+  "ToolSearch"
+  "Bash(date:*)"
+  "Bash(echo:*)"
+  "Bash(jq:*)"
+  "Bash(gh issue list:*)"
+  "Bash(gh issue view:*)"
+  "Bash(gh search:*)"
+  "Bash(gh pr view:*)"
+  "Bash(gh issue edit:*)"
+  "Bash(gh pr edit:*)"
+  "mcp__claude_ai_Slack__slack_send_message"
+  "mcp__plugin_slack_slack__slack_send_message"
+)
+
+# Must match SERVICE_NAME in triage-service.sh and log_dir in the plist; the
+# service's `logs` and `resume` commands read this state dir.
 claude_worker_init "triage-daily"
 
 log_section "triage-daily"
@@ -42,12 +67,13 @@ Your session ID for this run is: ${SESSION_ID}
 Do these steps in order.
 
 1. Invoke the /triage-issues skill in unattended mode:
-   "/triage-issues ${LOOKBACK_DAYS} ${TEAM} unattended"
+   "/triage-issues ${LOOKBACK_DAYS} for ${TEAM} unattended"
 
 $(slack_dm_instructions 2 "the digest from step 1" "To label the undecided items or dig into any of them:")
 
 3. After the DM is sent, print a one-line summary to stdout: items scanned,
-   items auto-labeled, items needing a decision, and the DM channel ID.
+   items auto-labeled, titles renamed, items needing a decision, and the DM
+   channel ID.
 
 Hard constraints:
 - Do NOT post to any Slack channel. Only DM.

--- a/bin/triage-run
+++ b/bin/triage-run
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# triage-run - Triage new PostHog issues and external PRs for the Feature Flags
+# team and DM the digest.
+#
+# Runs the /triage-issues skill in unattended mode (auto-labels HIGH-confidence
+# candidates, digests the rest) and DMs the digest to the recipient with
+# instructions for resuming the session to act on the undecided items.
+#
+# Intended to be invoked by launchd (com.haacked.triage-daily.plist) or by hand
+# via bin/triage-service.sh.
+#
+# Usage: triage-run
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/lib/logging.sh"
+source "${SCRIPT_DIR}/lib/claude-worker.sh"
+
+TEAM="feature-flags"
+LOOKBACK_DAYS="${TRIAGE_LOOKBACK_DAYS:-7}"
+MAX_BUDGET_USD="${TRIAGE_MAX_BUDGET_USD:-5}"
+RUN_TIMEOUT_SECONDS="${TRIAGE_TIMEOUT_SECONDS:-900}"   # 15 min
+RUN_KILL_AFTER_SECONDS="${TRIAGE_KILL_AFTER_SECONDS:-60}"
+
+claude_worker_init "triage-daily"
+
+log_section "triage-daily"
+log_info "Team:         $TEAM"
+log_info "Lookback:     ${LOOKBACK_DAYS} days"
+log_info "Session ID:   $SESSION_ID"
+log_info "Budget cap:   \$${MAX_BUDGET_USD}"
+log_info "Working dir:  $WORKING_DIR"
+
+PROMPT=$(cat <<EOF
+You are running the daily issue and external-PR triage for the PostHog
+${TEAM} team. This run was triggered by a launchd job. Your output goes to
+one Slack DM, not to any channel.
+
+Your session ID for this run is: ${SESSION_ID}
+
+Do these steps in order.
+
+1. Invoke the /triage-issues skill in unattended mode:
+   "/triage-issues ${LOOKBACK_DAYS} ${TEAM} unattended"
+
+$(slack_dm_instructions 2 "the digest from step 1" "To label the undecided items or dig into any of them:")
+
+3. After the DM is sent, print a one-line summary to stdout: items scanned,
+   items auto-labeled, items needing a decision, and the DM channel ID.
+
+Hard constraints:
+- Do NOT post to any Slack channel. Only DM.
+- Do NOT modify any files in the repo.
+- If a step fails partway, still DM whatever digest you have, with a note
+  about what failed and why.
+EOF
+)
+
+claude_worker_run "Triaging ${TEAM} issues and PRs" "$PROMPT"

--- a/bin/triage-service.sh
+++ b/bin/triage-service.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# triage-service.sh - Manage the daily Feature Flags triage LaunchAgent.
+#
+# Usage:
+#   triage-service.sh [install|uninstall|start|stop|status|logs|run|resume]
+#
+# Commands are provided by lib/launchd-service.sh.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/lib/logging.sh"
+source "${SCRIPT_DIR}/lib/launchd-service.sh"
+
+SERVICE_NAME="triage-daily"
+WORKER="${SCRIPT_DIR}/triage-run"
+SCHEDULE_DESC="Mon–Fri at 08:30 local time"
+
+launchd_service_main "$@"

--- a/macos/LaunchAgents/com.haacked.sprint-status.plist
+++ b/macos/LaunchAgents/com.haacked.sprint-status.plist
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.haacked.sprint-status</string>
+
+    <!--
+        Use zsh login shell so .zshenv provides PATH (Homebrew, ~/.local/bin,
+        Cargo) and path_helper picks up entries from /etc/paths.d.
+    -->
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/zsh</string>
+        <string>-lc</string>
+        <string><![CDATA[
+log_dir="$HOME/.local/state/sprint-status"
+mkdir -p "$log_dir"
+exec "$HOME/.dotfiles/bin/sprint-status-run" >> "$log_dir/launchd.log" 2>&1
+]]></string>
+    </array>
+
+    <!--
+        Fire Wednesday at 08:00 local time: mid-sprint for the two-week
+        sprints, and clear of the 08:30 triage and 09:00 ops-report agents.
+        StartCalendarInterval uses the system's local time zone; Weekday
+        3=Wednesday.
+    -->
+    <key>StartCalendarInterval</key>
+    <array>
+        <dict>
+            <key>Weekday</key>
+            <integer>3</integer>
+            <key>Hour</key>
+            <integer>8</integer>
+            <key>Minute</key>
+            <integer>0</integer>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/macos/LaunchAgents/com.haacked.triage-daily.plist
+++ b/macos/LaunchAgents/com.haacked.triage-daily.plist
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.haacked.triage-daily</string>
+
+    <!--
+        Use zsh login shell so .zshenv provides PATH (Homebrew, ~/.local/bin,
+        Cargo) and path_helper picks up entries from /etc/paths.d.
+    -->
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/zsh</string>
+        <string>-lc</string>
+        <string><![CDATA[
+log_dir="$HOME/.local/state/triage-daily"
+mkdir -p "$log_dir"
+exec "$HOME/.dotfiles/bin/triage-run" >> "$log_dir/launchd.log" 2>&1
+]]></string>
+    </array>
+
+    <!--
+        Fire Mon-Fri at 08:30 local time, before the ops-report agents at
+        09:00 so the morning runs never overlap. StartCalendarInterval uses
+        the system's local time zone; Weekday 1=Monday … 5=Friday.
+    -->
+    <key>StartCalendarInterval</key>
+    <array>
+        <dict>
+            <key>Weekday</key>
+            <integer>1</integer>
+            <key>Hour</key>
+            <integer>8</integer>
+            <key>Minute</key>
+            <integer>30</integer>
+        </dict>
+        <dict>
+            <key>Weekday</key>
+            <integer>2</integer>
+            <key>Hour</key>
+            <integer>8</integer>
+            <key>Minute</key>
+            <integer>30</integer>
+        </dict>
+        <dict>
+            <key>Weekday</key>
+            <integer>3</integer>
+            <key>Hour</key>
+            <integer>8</integer>
+            <key>Minute</key>
+            <integer>30</integer>
+        </dict>
+        <dict>
+            <key>Weekday</key>
+            <integer>4</integer>
+            <key>Hour</key>
+            <integer>8</integer>
+            <key>Minute</key>
+            <integer>30</integer>
+        </dict>
+        <dict>
+            <key>Weekday</key>
+            <integer>5</integer>
+            <key>Hour</key>
+            <integer>8</integer>
+            <key>Minute</key>
+            <integer>30</integer>
+        </dict>
+    </array>
+</dict>
+</plist>


### PR DESCRIPTION
- Extracts the duplicated LaunchAgent command logic (install/uninstall/start/stop/status/logs/run/resume) from `ops-report-service.sh` and `review-all-prs-service.sh` into `bin/lib/launchd-service.sh`. Service scripts are now ~20-line configs, and worker plumbing (session id, DM footer, timeout/budget guards) lives in `bin/lib/claude-worker.sh`.
- Adds two scheduled agents: sprint-status (Wednesday 08:00, DMs the sprint checklist via `/sprint-status slack`) and triage-daily (Mon-Fri 08:30, runs `/triage-issues` unattended: auto-labels HIGH-confidence issues and external PRs for the Feature Flags team, renames conventional title scopes `feature-flags` to `flags`, and DMs a digest).
- The triage worker runs with a minimal tool allowlist under `--permission-mode default` instead of `bypassPermissions`, since it ingests public GitHub issue and PR text; anything outside the gh fetches, label and title edits, and the Slack DM send is denied.
- Adds the `babysit-prs` skill: one sweep over my open PRs (CI health, new review comments) dispatching `ci-monitor` and `copilot-review`, with a state file so reruns skip quiet PRs. Designed to be driven by `/loop`.

## Test plan

- `bin/triage-service.sh run` does a foreground triage run: verify the tool allowlist is logged, labels and renames apply, and the digest arrives as a DM.
- `bin/sprint-status-service.sh run` DMs the sprint checklist.
- `bin/ops-report-service.sh status` and `bin/review-all-prs-service.sh status` confirm the refactored scripts still drive the already-installed agents.
- `bin/triage-service.sh install` / `bin/sprint-status-service.sh install` load the new agents; `status` and `logs` show the scheduled runs.