### PR TITLE
Pin skills and commands to explicit models

### DIFF
--- a/ai/commands/security-audit.md
+++ b/ai/commands/security-audit.md
@@ -4,6 +4,7 @@ description: Focused security audit of code, calibrated to surface real exploita
 argument-hint: <file | dir | PR ref | "branch" | leave empty for current diff>
 user-invocable: true
 allowed-tools: Read, Grep, Glob, Bash, Agent
+model: fable
 ---
 
 # Security Audit

--- a/ai/skills/analyze-permissions/SKILL.md
+++ b/ai/skills/analyze-permissions/SKILL.md
@@ -3,6 +3,7 @@ name: analyze-permissions
 description: Analyze accumulated permissions and suggest smart wildcard patterns
 argument-hint: [analyze|apply|cleanup]
 disable-model-invocation: true
+model: sonnet
 ---
 
 # Analyze Claude Code Permissions

--- a/ai/skills/babysit-prs/SKILL.md
+++ b/ai/skills/babysit-prs/SKILL.md
@@ -3,6 +3,7 @@ name: babysit-prs
 description: One sweep over all of my open PRs — check CI, handle new review comments, fix and push — tracking state so reruns skip already-handled work. Designed to be driven by /loop.
 argument-hint: "[--owner <org>] [--limit <n>] [--dry-run]"
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep, Skill
+model: sonnet
 ---
 
 # Babysit PRs

--- a/ai/skills/ci-monitor/SKILL.md
+++ b/ai/skills/ci-monitor/SKILL.md
@@ -3,6 +3,7 @@ name: ci-monitor
 description: Monitor CI checks after pushing, detect flaky vs legit failures, and auto-fix
 argument-hint: "[<pr-number>|<pr-url>|--no-fix|--timeout <min>]"
 allowed-tools: Bash(~/.claude/skills/ci-monitor/scripts/*:*, ~/.dotfiles/bin/detect-pr.sh:*, sleep:*, gh:*, git:*), Read(~/.claude/skills/ci-monitor/**), Write, Edit
+model: sonnet
 ---
 
 Monitor GitHub CI checks for the current PR, wait for completion, classify failures as flaky or legit, and guide fixes for legit failures.

--- a/ai/skills/copilot-review/SKILL.md
+++ b/ai/skills/copilot-review/SKILL.md
@@ -2,6 +2,7 @@
 name: copilot-review
 description: Evaluate unresolved PR review comments (Copilot and human reviewers), fix legitimate issues, and reply to dismissed ones. Only Copilot reviews are requested.
 argument-hint: "[<pr-url>|<pr-number>]"
+model: opus
 ---
 
 # Copilot Review

--- a/ai/skills/create-pr/SKILL.md
+++ b/ai/skills/create-pr/SKILL.md
@@ -2,6 +2,7 @@
 name: create-pr
 description: Create or update a GitHub PR with automatic template detection and filling
 argument-hint: "[--draft] [--force] [<title>]"
+model: sonnet
 ---
 
 # Create PR

--- a/ai/skills/go/SKILL.md
+++ b/ai/skills/go/SKILL.md
@@ -2,6 +2,7 @@
 name: go
 description: Plan, implement, and iteratively review a task end-to-end using Claude + Copilot reviewers in a linear flow.
 argument-hint: "<task description> [--skip-planner] [--skip-copilot]"
+model: fable
 ---
 
 # /go

--- a/ai/skills/handoff/SKILL.md
+++ b/ai/skills/handoff/SKILL.md
@@ -2,6 +2,7 @@
 name: handoff
 description: Write or resume a handoff document so the next Claude session can pick up the current work. Use when context is filling up, when ending a session mid-task, or at the start of a new session that should continue prior work.
 argument-hint: [resume|show|path]
+model: sonnet
 ---
 
 # Session Handoff

--- a/ai/skills/note/SKILL.md
+++ b/ai/skills/note/SKILL.md
@@ -2,6 +2,7 @@
 name: note
 description: Capture complex technical discoveries into structured, reusable notes. Use when explaining system behaviors, documenting debugging insights, or preserving knowledge.
 argument-hint: [find|<slug>]
+model: sonnet
 ---
 
 # Technical Discovery Note

--- a/ai/skills/postmortem/SKILL.md
+++ b/ai/skills/postmortem/SKILL.md
@@ -2,6 +2,7 @@
 name: postmortem
 description: Write incident postmortems using the DERP model (Detection, Escalation, Recovery, Prevention). Integrates with incident.io.
 argument-hint: [find|list|from <path>|<incident-id-or-slug>]
+model: sonnet
 ---
 
 # Postmortem Skill

--- a/ai/skills/quarterly-planning/SKILL.md
+++ b/ai/skills/quarterly-planning/SKILL.md
@@ -3,6 +3,7 @@ name: quarterly-planning
 description: Draft quarterly goals for a PostHog team (defaults to Feature Flags). Gathers supporting docs (RFCs, strategy docs, Slack threads), mines open issues by label, clusters them into themes, walks the HOGS framework, and produces goals in PostHog's format. Use when planning a new quarter's objectives.
 color: purple
 argument-hint: [themes]
+model: fable
 ---
 
 # Quarterly Planning

--- a/ai/skills/resolve-conflicts/SKILL.md
+++ b/ai/skills/resolve-conflicts/SKILL.md
@@ -2,6 +2,7 @@
 name: resolve-conflicts
 description: Resolve git conflicts with AI-powered analysis, including mergiraf structural merging, lock file handling, and stacked PR duplicate detection.
 argument-hint: [--abort|--continue]
+model: fable
 ---
 
 # Resolve Git Conflicts

--- a/ai/skills/review-fix-cycle/SKILL.md
+++ b/ai/skills/review-fix-cycle/SKILL.md
@@ -2,6 +2,7 @@
 name: review-fix-cycle
 description: Run one review-fix iteration — review code, fix findings, simplify, and commit.
 argument-hint: "[<review-target>] [--iteration N]"
+model: opus
 ---
 
 # Review-Fix Cycle

--- a/ai/skills/sprint-status/SKILL.md
+++ b/ai/skills/sprint-status/SKILL.md
@@ -3,6 +3,7 @@ name: sprint-status
 description: Produce a per-team-member sprint status checklist for the current sprint (each member's planned goals with a done / in-progress / not-started marker) and copy it to the clipboard as Slack-ready rich text, or emit Slack markdown with the `slack` argument. Defaults to the Feature Flags team; pass `platform` for Feature Flags Platform.
 allowed-tools: Bash, Read
 argument-hint: "[platform] [slack]"
+model: sonnet
 ---
 
 # Sprint Status

--- a/ai/skills/standup/SKILL.md
+++ b/ai/skills/standup/SKILL.md
@@ -2,6 +2,7 @@
 name: standup
 description: Generate standup notes from GitHub PR activity
 disable-model-invocation: true
+model: haiku
 ---
 
 # Standup Notes Generator

--- a/ai/skills/support/SKILL.md
+++ b/ai/skills/support/SKILL.md
@@ -3,6 +3,7 @@ name: support
 description: Support hero workflow — start a ticket investigation with auto-organized notes, find existing notes, or generate the weekly highlights log
 argument-hint: "[find|log|zendesk|github] <number-or-date>"
 disable-model-invocation: true
+model: inherit
 ---
 
 # Support Hero Workflow

--- a/ai/skills/test-plan/SKILL.md
+++ b/ai/skills/test-plan/SKILL.md
@@ -2,6 +2,7 @@
 name: test-plan
 description: Generate a GitHub Flavored Markdown manual test plan checklist that focuses on scenarios not covered by existing unit/integration tests. Use when the user wants to create a test plan for a PR or an implementation plan.
 argument-hint: "[--force] [--save <path>] [--plan <file>]"
+model: opus
 ---
 
 # Test Plan Generator

--- a/ai/skills/triage-issues/SKILL.md
+++ b/ai/skills/triage-issues/SKILL.md
@@ -3,6 +3,7 @@ name: triage-issues
 description: Identify unlabeled GitHub issues and external PRs that may belong to a specific team, and normalize conventional title scopes to the team's canonical short form
 argument-hint: "[days] [limit] [team] [unattended]"
 disable-model-invocation: true
+model: sonnet
 ---
 
 # Triage GitHub Issues and External PRs


### PR DESCRIPTION
Adds a `model:` frontmatter pin to every skill in `ai/skills/` and command in `ai/commands/` (18 files, one line each) so skills no longer inherit the session model by default.

- haiku for mechanical workflows (`commit` already had it, `standup` joins it); sonnet for scripted orchestration and structured writing (`babysit-prs`, `ci-monitor`, `create-pr`, `handoff`, `note`, `postmortem`, `sprint-status`, `triage-issues`, `analyze-permissions`)
- opus where judging code findings is the core task (`copilot-review`, `review-fix-cycle`, `test-plan`); since sub-skill pins apply for the rest of the turn, the cheap orchestrators escalate when they dispatch these
- fable for implementation and high-stakes reasoning (`go`, `resolve-conflicts`, `quarterly-planning`, `security-audit`)
- `support` is pinned `inherit` on purpose: ticket investigations continue in-session after the scaffolding steps, so it should follow the session model

**Test plan:** run `/commit`, `/standup`, or any pinned skill and confirm the status line shows the pinned model for the turn, then reverts on the next prompt.