### PR TITLE
Prioritize automated PR reviews and review until quota runs out

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,8 +107,8 @@ These orchestrate Claude Code reviews of pull requests. They power the `review-a
 
 | Script | Purpose |
 | ------ | ------- |
-| [`review-all-prs.sh`](bin/review-all-prs.sh) | Find PRs awaiting your review in a GitHub org using the GraphQL API. Filters out PRs you've already reviewed. |
-| [`run-pr-reviews.sh`](bin/run-pr-reviews.sh) | Take a list of PRs and run `/review-code` against each one with budget and rate limits. |
+| [`review-all-prs.sh`](bin/review-all-prs.sh) | Find PRs awaiting your review in a GitHub org using the GraphQL API. Filters out PRs you've already reviewed and sorts by priority: PRs authored by `--priority-team` members, then flags-scoped titles, then the rest. |
+| [`run-pr-reviews.sh`](bin/run-pr-reviews.sh) | Take a list of PRs and run `/review-code` against each one in priority order, with budget limits and Claude usage-limit detection. |
 | [`review-all-prs-service.sh`](bin/review-all-prs-service.sh) | Manage the `review-all-prs` macOS LaunchAgent (install, start, stop, logs, run). |
 | [`recent-reviews.sh`](bin/recent-reviews.sh) | Show recent PR review activity from session state files. |
 | [`seed-pr-failures.sh`](bin/seed-pr-failures.sh) | Rebuild the persistent PR-failure ledger from session history. |

--- a/bin/lib/review-filter.jq
+++ b/bin/lib/review-filter.jq
@@ -3,10 +3,18 @@
 # Variables (pass via --arg / --argjson):
 #   $user             - GitHub username
 #   $include_reviewed - bool; if true, skip the new-commits gate
+#   $team_members     - array of GitHub logins whose PRs get top priority
 #
 # Keeps PRs the user hasn't reviewed and PRs with commits newer than the
 # user's last review. PENDING (draft) reviews have null submittedAt, so fall
 # back to createdAt for the comparison.
+#
+# Each PR gets a priority tier:
+#   1 - authored by a member of $team_members
+#   2 - conventional-commit title scoped to flags (e.g. "feat(flags):",
+#       "chore(feature-flags):")
+#   3 - everything else
+# Output is sorted by priority, then most recently updated within each tier.
 
 map(
   (.reviews.nodes | map(select(.author.login == $user)) | last) as $last_review
@@ -22,8 +30,16 @@ map(
       repo: .repository.nameWithOwner,
       author: .author.login,
       updated_at: .updatedAt,
-      user_review_state: $last_review.state
+      user_review_state: $last_review.state,
+      priority: (
+        .author.login as $pr_author
+        | if ($team_members | index($pr_author)) then 1
+          elif (.title | test("^[a-zA-Z]+\\([^)]*\\bflags\\b[^)]*\\)!?:"; "i")) then 2
+          else 3
+          end
+      )
     }
 )
-| sort_by(.updated_at)
-| reverse
+| group_by(.priority)
+| map(sort_by(.updated_at) | reverse)
+| add // []

--- a/bin/lib/test-review-filter.sh
+++ b/bin/lib/test-review-filter.sh
@@ -14,9 +14,11 @@ filter_prs() {
     local user="$1"
     local include_reviewed="$2"
     local input="$3"
+    local team_members="${4:-[]}"
     echo "$input" | jq \
         --arg user "$user" \
         --argjson include_reviewed "$include_reviewed" \
+        --argjson team_members "$team_members" \
         -f "$SCRIPT_DIR/review-filter.jq"
 }
 
@@ -31,16 +33,21 @@ make_review() {
 }
 
 make_pr() {
+    # number last_commit_at reviews_json [author] [title] [updated_at]
     local number="$1"
     local last_commit_at="$2"
     local reviews_json="$3"
-    jq -n --argjson n "$number" --arg c "$last_commit_at" --argjson r "$reviews_json" '{
+    local author="${4:-author}"
+    local title="${5:-PR $number}"
+    local updated_at="${6:-2024-01-15T10:00:00Z}"
+    jq -n --argjson n "$number" --arg c "$last_commit_at" --argjson r "$reviews_json" \
+        --arg a "$author" --arg t "$title" --arg u "$updated_at" '{
         number: $n,
-        title: ("PR " + ($n | tostring)),
+        title: $t,
         url: ("https://github.com/org/repo/pull/" + ($n | tostring)),
         repository: {nameWithOwner: "org/repo"},
-        author: {login: "author"},
-        updatedAt: "2024-01-15T10:00:00Z",
+        author: {login: $a},
+        updatedAt: $u,
         reviews: {nodes: $r},
         commits: {nodes: [{commit: {committedDate: $c}}]}
     }'
@@ -147,6 +154,54 @@ assert "empty input returns empty output" test "$count" -eq 0
 result=$(filter_prs "$USER" "false" "[$pr_unreviewed]")
 state=$(echo "$result" | jq '.[0].user_review_state')
 assert "unreviewed PR has null user_review_state in output" test "$state" = "null"
+
+# ── Priority tests ────────────────────────────────────────────────────────
+
+TEAM='["teammate"]'
+
+pr_team=$(make_pr 10 "$T10" "[]" teammate "fix: something unrelated")
+pr_flags_scope=$(make_pr 11 "$T10" "[]" stranger "feat(flags): add gating")
+pr_feature_flags_scope=$(make_pr 12 "$T10" "[]" stranger "chore(feature-flags): cleanup")
+pr_rest=$(make_pr 13 "$T10" "[]" stranger "fix(api): unrelated")
+pr_flags_word_only=$(make_pr 14 "$T10" "[]" stranger "Add flags to the CLI")
+
+priority_input=$(jq -s '.' <<EOF
+$pr_rest
+$pr_flags_scope
+$pr_team
+$pr_feature_flags_scope
+$pr_flags_word_only
+EOF
+)
+
+result=$(filter_prs "$USER" "false" "$priority_input" "$TEAM")
+
+assert "team-authored PR gets priority 1" \
+    test "$(echo "$result" | jq '.[] | select(.number == 10) | .priority')" = "1"
+assert "feat(flags) title gets priority 2" \
+    test "$(echo "$result" | jq '.[] | select(.number == 11) | .priority')" = "2"
+assert "chore(feature-flags) title gets priority 2" \
+    test "$(echo "$result" | jq '.[] | select(.number == 12) | .priority')" = "2"
+assert "unrelated PR gets priority 3" \
+    test "$(echo "$result" | jq '.[] | select(.number == 13) | .priority')" = "3"
+assert "'flags' outside a conventional scope is not priority 2" \
+    test "$(echo "$result" | jq '.[] | select(.number == 14) | .priority')" = "3"
+
+ordered=$(echo "$result" | jq -c '[.[].priority]')
+assert "output is sorted by priority ascending" test "$ordered" = "[1,2,2,3,3]"
+
+# Within a tier, most recently updated comes first.
+pr_old=$(make_pr 20 "$T10" "[]" stranger "fix(api): old" "2024-01-14T10:00:00Z")
+pr_new=$(make_pr 21 "$T10" "[]" stranger "fix(api): new" "2024-01-15T10:00:00Z")
+result=$(filter_prs "$USER" "false" "[$pr_old,$pr_new]")
+first=$(echo "$result" | jq '.[0].number')
+assert "within a tier, most recently updated sorts first" test "$first" = "21"
+
+# Team membership beats a flags scope: priority is the author's tier.
+pr_team_flags=$(make_pr 22 "$T10" "[]" teammate "feat(flags): from teammate")
+result=$(filter_prs "$USER" "false" "[$pr_team_flags]" "$TEAM")
+assert "team-authored flags PR is priority 1, not 2" \
+    test "$(echo "$result" | jq '.[0].priority')" = "1"
 
 # ── Results ───────────────────────────────────────────────────────────────
 

--- a/bin/review-all-prs-service.sh
+++ b/bin/review-all-prs-service.sh
@@ -18,7 +18,8 @@ source "${SCRIPT_DIR}/lib/launchd-service.sh"
 
 SERVICE_NAME="review-all-prs"
 WORKER="${SCRIPT_DIR}/run-pr-reviews.sh"
-WORKER_ARGS=(--auto)
+# Keep in sync with the args in macos/LaunchAgents/com.haacked.review-all-prs.plist.
+WORKER_ARGS=(--auto --team team-feature-flags --priority-team team-feature-flags)
 SCHEDULE_DESC="hourly from 6 PM to 2 AM"
 
 # Today's review session counts, appended to `status`.

--- a/bin/review-all-prs.sh
+++ b/bin/review-all-prs.sh
@@ -12,10 +12,16 @@
 #   --limit N       Maximum number of PRs to return (default: 50)
 #   --json          Output raw JSON (default: formatted table)
 #   --team TEAM     Also find PRs requested from this team (repeatable)
+#   --priority-team TEAM  PRs authored by members of this team sort first
 #   --include-reviewed  Include PRs you've already reviewed
 #   --pending       Only show PRs where you have a pending (draft) review
 #   --draft         Alias for --pending
 #   -h, --help      Show this help message
+#
+# Results are sorted by priority tier, then most recently updated:
+#   1 - authored by a member of --priority-team
+#   2 - conventional-commit title scoped to flags (e.g. "feat(flags):")
+#   3 - everything else
 #
 # Output (JSON mode):
 #   [
@@ -26,7 +32,8 @@
 #       "repo": "org/repo",
 #       "author": "username",
 #       "updated_at": "2024-01-15T10:30:00Z",
-#       "user_review_state": null
+#       "user_review_state": null,
+#       "priority": 3
 #     }
 #   ]
 
@@ -43,6 +50,7 @@ JSON_OUTPUT=false
 INCLUDE_REVIEWED=false
 PENDING_ONLY=false
 TEAMS=()
+PRIORITY_TEAM=""
 
 usage() {
   cat <<EOF
@@ -55,6 +63,7 @@ Options:
   --limit N           Maximum number of PRs to return (default: 50)
   --json              Output raw JSON (default: formatted table)
   --team TEAM         Also find PRs requested from this team (repeatable)
+  --priority-team TEAM  PRs authored by members of this team sort first
   --include-reviewed  Include PRs you've already reviewed
   --pending           List every PR where you have a pending (draft) review.
                       Uses involves:@me and paginates, so it finds drafts even
@@ -96,6 +105,14 @@ while [[ $# -gt 0 ]]; do
       TEAMS+=("$2")
       shift 2
       ;;
+    --priority-team)
+      if [[ -z "${2:-}" || "${2:-}" == --* ]]; then
+        echo "--priority-team requires a team name" >&2
+        exit 1
+      fi
+      PRIORITY_TEAM="$2"
+      shift 2
+      ;;
     --include-reviewed)
       INCLUDE_REVIEWED=true
       shift
@@ -116,6 +133,15 @@ while [[ $# -gt 0 ]]; do
 done
 
 GITHUB_USER=$(get_github_user)
+
+# Logins whose PRs get priority 1, as a JSON array for the jq filter.
+TEAM_MEMBERS="[]"
+if [[ -n "$PRIORITY_TEAM" ]]; then
+  TEAM_MEMBERS=$(gh api "orgs/${ORG}/teams/${PRIORITY_TEAM}/members" --paginate --jq '[.[].login]' | jq -s 'add') || {
+    echo "Could not list members of ${ORG}/${PRIORITY_TEAM}" >&2
+    exit 1
+  }
+fi
 
 # shellcheck disable=SC2016 # GraphQL variables use $ syntax, not shell expansion
 QUERY='
@@ -210,9 +236,11 @@ if [[ "$PENDING_ONLY" == "true" ]]; then
 else
   # GitHub search combines multiple qualifiers with AND, so we need separate
   # queries for personal and team review requests and then merge the results.
-  SEARCH_QUERIES=("is:pr is:open review-requested:@me org:${ORG}")
+  # Self-authored PRs are excluded at the source so they don't consume result
+  # slots that the --limit cap would otherwise give to reviewable PRs.
+  SEARCH_QUERIES=("is:pr is:open review-requested:@me -author:@me org:${ORG}")
   for team in "${TEAMS[@]}"; do
-    SEARCH_QUERIES+=("is:pr is:open team-review-requested:${ORG}/${team} org:${ORG}")
+    SEARCH_QUERIES+=("is:pr is:open team-review-requested:${ORG}/${team} -author:@me org:${ORG}")
   done
 fi
 
@@ -229,6 +257,7 @@ ALL_RESULTS=$(echo "$ALL_RESULTS" | jq 'unique_by(.url)')
 PROCESSED=$(echo "$ALL_RESULTS" | jq \
   --arg user "$GITHUB_USER" \
   --argjson include_reviewed "$INCLUDE_REVIEWED" \
+  --argjson team_members "$TEAM_MEMBERS" \
   -f "${SCRIPT_DIR}/lib/review-filter.jq")
 
 if [[ "$PENDING_ONLY" == "true" ]]; then
@@ -266,11 +295,12 @@ else
   fi
 
   # Print formatted table
-  printf "%-6s %-25s %-50s %-15s %s\n" "PR#" "REPO" "TITLE" "STATUS" "AUTHOR"
+  printf "%-6s %-3s %-25s %-50s %-15s %s\n" "PR#" "PRI" "REPO" "TITLE" "STATUS" "AUTHOR"
   printf "%s\n" "$(printf '%.0s-' {1..135})"
 
   echo "$PROCESSED" | jq -r '.[] | [
     .number,
+    .priority,
     (.repo | split("/")[1] | .[0:25]),
     (.title | .[0:50]),
     (.user_review_state // empty |
@@ -283,16 +313,16 @@ else
     ) // "Pending",
     .author,
     .url
-  ] | @tsv' | while IFS=$'\t' read -r num repo title status author url; do
+  ] | @tsv' | while IFS=$'\t' read -r num pri repo title status author url; do
     if [[ "$HYPERLINK" == "true" ]]; then
       # OSC 8 hyperlink: \e]8;;URL\e\\TEXT\e]8;;\e\\
       num_display=$(printf '\e]8;;%s\e\\%s\e]8;;\e\\' "$url" "$num")
       # Pad manually since printf %-6s counts the escape bytes.
       pad=$(( 6 - ${#num} ))
       (( pad < 0 )) && pad=0
-      printf "%s%*s %-25s %-50s %-15s %s\n" "$num_display" "$pad" "" "$repo" "$title" "$status" "$author"
+      printf "%s%*s %-3s %-25s %-50s %-15s %s\n" "$num_display" "$pad" "" "$pri" "$repo" "$title" "$status" "$author"
     else
-      printf "%-6s %-25s %-50s %-15s %s\n" "$num" "$repo" "$title" "$status" "$author"
+      printf "%-6s %-3s %-25s %-50s %-15s %s\n" "$num" "$pri" "$repo" "$title" "$status" "$author"
     fi
   done
 

--- a/bin/review-all-prs.sh
+++ b/bin/review-all-prs.sh
@@ -23,6 +23,14 @@
 #   2 - conventional-commit title scoped to flags (e.g. "feat(flags):")
 #   3 - everything else
 #
+# The STATUS column reflects your review of each PR:
+#   Not reviewed   - no review from you
+#   Draft pending  - you have an unsubmitted draft review
+#   Approved / Commented / Changes req / Dismissed - your last submitted
+#       review state. By default these rows appear only when the PR has new
+#       commits since that review; PRs whose draft or review is still current
+#       are hidden unless you pass --include-reviewed.
+#
 # Output (JSON mode):
 #   [
 #     {
@@ -264,8 +272,14 @@ if [[ "$PENDING_ONLY" == "true" ]]; then
   PROCESSED=$(echo "$PROCESSED" | jq '[.[] | select(.user_review_state == "PENDING")]')
 fi
 
-# Count results
+# Count results. HIDDEN counts PRs dropped by the new-commits gate: you have
+# a draft or submitted review and nothing changed since.
 COUNT=$(echo "$PROCESSED" | jq 'length')
+HIDDEN=0
+if [[ "$INCLUDE_REVIEWED" != "true" ]]; then
+  TOTAL=$(echo "$ALL_RESULTS" | jq 'length')
+  HIDDEN=$((TOTAL - COUNT))
+fi
 
 if [[ "$JSON_OUTPUT" == "true" ]]; then
   echo "$PROCESSED"
@@ -275,6 +289,9 @@ else
       echo "No pending draft reviews in ${ORG}."
     else
       echo "No PRs awaiting your review in ${ORG}."
+      if [[ "$HIDDEN" -gt 0 ]]; then
+        echo "${HIDDEN} PR(s) have your draft or review with no new commits since. Use --include-reviewed to see them."
+      fi
     fi
     exit 0
   fi
@@ -308,9 +325,9 @@ else
       elif . == "COMMENTED" then "Commented"
       elif . == "APPROVED" then "Approved"
       elif . == "DISMISSED" then "Dismissed"
-      elif . == "PENDING" then "In progress"
+      elif . == "PENDING" then "Draft pending"
       else . end
-    ) // "Pending",
+    ) // "Not reviewed",
     .author,
     .url
   ] | @tsv' | while IFS=$'\t' read -r num pri repo title status author url; do
@@ -327,5 +344,8 @@ else
   done
 
   echo ""
+  if [[ "$HIDDEN" -gt 0 ]]; then
+    echo "${HIDDEN} more PR(s) have your draft or review with no new commits since. Use --include-reviewed to see them."
+  fi
   echo "Run with --json for machine-readable output."
 fi

--- a/bin/run-pr-reviews.sh
+++ b/bin/run-pr-reviews.sh
@@ -10,13 +10,20 @@
 #
 # Options:
 #   --auto              Run in automatic mode (calls review-all-prs.sh)
-#   --max-prs N         Maximum PRs to review (default: 5)
+#   --max-prs N         Maximum PRs to review; 0 means no cap, the session
+#                       time budget and Claude usage limits govern (default: 0)
 #   --max-budget USD    Max budget per review in USD (default: 10.00)
 #   --delay SECONDS     Delay between reviews in seconds (default: 30)
 #   --dry-run           Show what would be reviewed without running
 #   --org ORG           GitHub org for --auto mode (default: PostHog)
 #   --team TEAM         Also find PRs requested from this team (repeatable)
+#   --priority-team TEAM  PRs authored by members of this team review first
 #   -h, --help          Show this help message
+#
+# PRs are reviewed in priority order (see review-all-prs.sh): team-authored
+# first, then flags-scoped titles, then the rest. If a review fails because
+# the Claude usage limit was hit, the session stops; the next scheduled tick
+# picks up where it left off once the limit window resets.
 #
 # State is tracked in ~/.local/state/review-all-prs/ to prevent
 # duplicate reviews within a session.
@@ -33,7 +40,13 @@ source "${SCRIPT_DIR}/lib/fs.sh"
 # Configuration. STATE_DIR is overridable for tests; everything else is fixed.
 STATE_DIR="${RUN_PR_REVIEWS_STATE_DIR:-${HOME}/.local/state/review-all-prs}"
 REVIEWS_DIR="${HOME}/dev/ai/reviews"
-MAX_PRS=5
+# 0 = no per-tick cap; the session time budget and Claude usage limits decide
+# when to stop.
+MAX_PRS=0
+# How many candidates to fetch from GitHub per search query during discovery.
+# Deliberately larger than any realistic per-tick throughput so that skips
+# (already reviewed, quarantined) never starve the queue.
+DISCOVERY_LIMIT=50
 MAX_BUDGET="10.00"
 DELAY_SECONDS=30
 REVIEW_TIMEOUT_SECONDS=900
@@ -54,6 +67,10 @@ DRY_RUN=false
 AUTO_MODE=false
 ORG="PostHog"
 TEAMS=()
+PRIORITY_TEAM=""
+# Set when a review fails because Claude itself is out of quota. Further
+# reviews in this session would fail the same way, so the main loop stops.
+RATE_LIMITED=false
 REVIEW_FILE_PATH_SCRIPT="${HOME}/.claude/skills/review-code/scripts/review-file-path.sh"
 FAILURES_FILE="${STATE_DIR}/pr-failures.json"
 SESSION_START_TIME=0
@@ -67,12 +84,13 @@ Orchestrate PR reviews using Claude Code's /review-code command.
 
 Options:
   --auto              Run in automatic mode (calls review-all-prs.sh)
-  --max-prs N         Maximum PRs to review (default: 5)
+  --max-prs N         Maximum PRs to review; 0 = no cap (default: 0)
   --max-budget USD    Max budget per review in USD (default: 10.00)
   --delay SECONDS     Delay between reviews in seconds (default: 30)
   --dry-run           Show what would be reviewed without running
   --org ORG           GitHub org for --auto mode (default: PostHog)
   --team TEAM         Also find PRs requested from this team (repeatable)
+  --priority-team TEAM  PRs authored by members of this team review first
   -h, --help          Show this help message
 
 Output:
@@ -97,7 +115,7 @@ while [[ $# -gt 0 ]]; do
       ;;
     --max-prs)
       if [[ ! "$2" =~ ^[0-9]+$ ]]; then
-        log_error "--max-prs must be a positive integer"
+        log_error "--max-prs must be a non-negative integer (0 = no cap)"
         exit 1
       fi
       MAX_PRS="$2"
@@ -133,6 +151,14 @@ while [[ $# -gt 0 ]]; do
         exit 1
       fi
       TEAMS+=("$2")
+      shift 2
+      ;;
+    --priority-team)
+      if [[ -z "${2:-}" || "${2:-}" == --* ]]; then
+        log_error "--priority-team requires a team name"
+        exit 1
+      fi
+      PRIORITY_TEAM="$2"
       shift 2
       ;;
     -h|--help)
@@ -338,8 +364,13 @@ get_pr_list() {
     for team in "${TEAMS[@]}"; do
       team_args+=(--team "$team")
     done
+    if [[ -n "$PRIORITY_TEAM" ]]; then
+      team_args+=(--priority-team "$PRIORITY_TEAM")
+    fi
 
-    "$DISCOVERY_SCRIPT" --org "$ORG" --limit "$MAX_PRS" --json "${team_args[@]}"
+    # Fetch a deep candidate list; the review loop applies MAX_PRS to reviews
+    # actually started, so skipped PRs don't consume review slots.
+    "$DISCOVERY_SCRIPT" --org "$ORG" --limit "$DISCOVERY_LIMIT" --json "${team_args[@]}"
   else
     # Read from stdin
     if [[ -t 0 ]]; then
@@ -481,6 +512,15 @@ run_review() {
   # Append Claude's output to review file
   cat "$output_file" >> "$review_file"
 
+  # Check whether Claude itself ran out of quota. Subscription billing prints
+  # "Claude AI usage limit reached|<reset epoch>"; API billing surfaces
+  # rate_limit_error / 429. Either way the session should stop: every further
+  # review would fail identically until the limit window resets.
+  local rate_limited=false
+  if grep -qiE "usage limit reached|rate_limit_error|overloaded_error" "$output_file"; then
+    rate_limited=true
+  fi
+
   # Check for budget exhaustion in output
   local budget_exhausted=false
   if grep -qi "budget" "$output_file" && grep -qi -E "(exhaust|limit|exceed|reach)" "$output_file"; then
@@ -498,7 +538,21 @@ run_review() {
     echo "- **Exit code:** ${exit_code}"
   } >> "$review_file"
 
-  if [[ "$budget_exhausted" == "true" ]]; then
+  if [[ "$rate_limited" == "true" ]]; then
+    {
+      echo "- **Status:** ⚠️ INCOMPLETE — Claude usage limit reached"
+      echo ""
+      echo "> **Note:** This review failed because Claude itself was rate limited, not because of the PR. It will be retried on a later run."
+    } >> "$review_file"
+    log_warn "Claude usage limit reached during PR #${pr_number}; stopping session"
+    log_info "Review saved to: ${review_file}"
+    # Not the PR's fault: record the failure in the session for visibility,
+    # but skip the persistent ledger so the PR isn't quarantined.
+    mark_failed "$pr_url" "rate_limited"
+    RATE_LIMITED=true
+    rm -f "$output_file"
+    return 1
+  elif [[ "$budget_exhausted" == "true" ]]; then
     {
       echo "- **Status:** ⚠️ INCOMPLETE — Budget exhausted (\$${MAX_BUDGET} limit reached)"
       echo ""
@@ -542,7 +596,9 @@ main() {
 
   SESSION_START_TIME=$(date +%s)
   log_info "Starting PR review session for ${TODAY}"
-  log_info "Max PRs: ${MAX_PRS}, Max budget per review: \$${MAX_BUDGET}"
+  local max_prs_desc="${MAX_PRS}"
+  [[ "$MAX_PRS" -eq 0 ]] && max_prs_desc="no cap (session budget governs)"
+  log_info "Max PRs: ${max_prs_desc}, Max budget per review: \$${MAX_BUDGET}"
 
   if [[ "$DRY_RUN" == "true" ]]; then
     log_warn "Running in DRY RUN mode - no reviews will be executed"
@@ -567,10 +623,12 @@ main() {
 
   log_info "Found ${total_prs} PR(s) to review"
 
-  # Track results
+  # Track results. `started` counts reviews actually attempted, so skipped
+  # PRs never consume --max-prs slots.
   local reviewed=0
   local failed=0
   local skipped=0
+  local started=0
 
   # Process via process substitution to keep variables in the parent shell.
   while read -r pr; do
@@ -618,13 +676,25 @@ main() {
     else
       ((failed++)) || true
     fi
+    ((started++)) || true
+
+    if [[ "$RATE_LIMITED" == "true" ]]; then
+      log_warn "Stopping session: Claude usage limit reached"
+      mark_error "claude usage limit reached"
+      break
+    fi
+
+    if [[ "$MAX_PRS" -gt 0 && "$started" -ge "$MAX_PRS" ]]; then
+      log_info "Reached --max-prs limit of ${MAX_PRS}; stopping"
+      break
+    fi
 
     # Delay between reviews (unless dry run or last PR)
     if [[ "$DRY_RUN" != "true" && "$DELAY_SECONDS" -gt 0 ]]; then
       log_info "Waiting ${DELAY_SECONDS}s before next review..."
       sleep "$DELAY_SECONDS"
     fi
-  done < <(echo "$pr_list" | jq -c '.[]' | head -n "$MAX_PRS")
+  done < <(echo "$pr_list" | jq -c '.[]')
 
   # Print summary
   log_section "Review Session Complete"

--- a/macos/LaunchAgents/com.haacked.review-all-prs.plist
+++ b/macos/LaunchAgents/com.haacked.review-all-prs.plist
@@ -18,18 +18,23 @@
 log_dir="$HOME/.local/state/review-all-prs"
 mkdir -p "$log_dir"
 
-# Run the review script with logging
-exec "$HOME/.dotfiles/bin/run-pr-reviews.sh" --auto --max-prs 5 --team team-flags-platform \
+# Run the review script with logging. No --max-prs cap: the session time
+# budget and Claude usage-limit detection decide when each tick stops.
+exec "$HOME/.dotfiles/bin/run-pr-reviews.sh" --auto \
+    --team team-feature-flags --priority-team team-feature-flags \
     >> "$log_dir/launchd.log" 2>&1
 ]]></string>
     </array>
 
     <!--
-        Run every hour from 6 PM to 2 AM (after-work to pre-workday).
-        Schedule ends at 02:00 so the last invocation completes before 03:00,
-        keeping all auto-review messages inside the 23:00-04:00 Claude
-        5-hour window. With workday start at 08:00, the user opens a fresh
-        5-hour quota bucket.
+        Run every hour from 6 PM to 2 AM. Workday ends ~18:00, so reviews
+        never compete with interactive use. Claude subscription quota comes
+        in 5-hour windows opened by the first message: the 18:00-22:00 ticks
+        share the 18:00-23:00 window (or whatever leftover workday window is
+        still open), and the 23:00-02:00 ticks share the 23:00-04:00 window,
+        which expires before the ~08:00 workday start, so morning interactive
+        quota is fresh. When a tick exhausts a window, run-pr-reviews.sh
+        detects the usage-limit error and stops; the next tick resumes.
     -->
     <key>StartCalendarInterval</key>
     <array>


### PR DESCRIPTION
- `review-all-prs.sh` now sorts results into priority tiers: PRs authored by `--priority-team` members first, then conventional-commit titles scoped to flags (e.g. `feat(flags):`), then everything else, most recently updated first within each tier. The table output gains a PRI column and clearer status labels ("Not reviewed", "Draft pending"), and reports how many PRs were hidden because your draft or review is still current.
- `run-pr-reviews.sh` drops the default per-tick cap (`--max-prs 0` means no cap) and instead stops when the session time budget runs out or Claude itself hits its usage limit. Rate-limited reviews are recorded in the session but not quarantined, so the next scheduled tick retries them. Discovery fetches a deep candidate list (50) so skipped PRs don't starve the queue.
- The LaunchAgent passes `--team team-feature-flags --priority-team team-feature-flags` and the plist comment now documents how the 18:00 to 02:00 schedule interacts with Claude's 5-hour quota windows.
- Self-authored PRs are excluded in the GitHub search itself so they don't consume `--limit` slots.

## Test plan

- `bin/lib/test-review-filter.sh` covers the new priority tiers: team-authored beats flags scope, `flags` outside a conventional scope stays priority 3, and output sorts by tier then recency.
- Run `bin/review-all-prs.sh --priority-team team-feature-flags` and verify team-authored PRs sort first and the PRI column renders.
- Run `bin/run-pr-reviews.sh --auto --dry-run --priority-team team-feature-flags` and verify the candidate list ordering and the "no cap" log line.