### PR TITLE
Reduce skill token spend with cheaper model pins and capped output

### DIFF
--- a/ai/agents/triage-feature-flags.md
+++ b/ai/agents/triage-feature-flags.md
@@ -7,6 +7,8 @@ color: orange
 
 You are a triage specialist for the **Feature Flags team** at PostHog. Your job is to analyze GitHub issues and external pull requests and identify which ones belong to this team's domain.
 
+Classify each item from its title, labels, and (for PRs) changed file paths. Body text is not always provided. When a title and labels are ambiguous and you need the body to make a confident call, set confidence to MEDIUM or LOW and note that the body would help. The orchestrator will fetch the body for those items and pass it back for a second pass.
+
 ## Team Domain
 
 The Feature Flags team owns:

--- a/ai/commands/squash.md
+++ b/ai/commands/squash.md
@@ -2,7 +2,7 @@
 name: squash
 description: Squash all developer commits on the current branch into one. CI snapshot commits (authored by bots) are preserved in place and reported.
 argument-hint: "[<message hint>]"
-model: sonnet
+model: haiku
 ---
 
 # Squash

--- a/ai/skills/babysit-prs/SKILL.md
+++ b/ai/skills/babysit-prs/SKILL.md
@@ -56,14 +56,15 @@ If `--owner` was given, add `--owner <org>` to the search. Sort by `updatedAt` d
 If a PR's `updatedAt` from Step 1 matches the state file's `updated_at` AND its stored `ci_conclusion` is terminal-good (`success` or `skipped`), mark it quiet without any further calls; on an all-quiet sweep, the search query is the only API call made. PRs recorded as pending or failing always get the per-PR fetch until CI concludes green. For the remaining PRs, fetch the facts needed to compare against state:
 
 ```bash
-gh pr view <url> --json headRefOid,statusCheckRollup,reviewDecision,isDraft
+gh pr view <url> --json headRefOid,statusCheckRollup,reviewDecision,isDraft \
+  --jq '{headRefOid, reviewDecision, isDraft, conclusions: ([.statusCheckRollup[].conclusion] | unique), failing: [.statusCheckRollup[] | select(.conclusion == "FAILURE") | {name, detailsUrl}]}'
 gh api 'repos/<owner>/<repo>/pulls/<number>/comments?sort=created&direction=desc&per_page=20' --jq '[.[] | {id, user: .user.login, created_at}]'
 ```
 
 Classify:
 
 - **Quiet**: matches the state file as defined above. Skip; no per-PR output beyond the summary table.
-- **CI failing or pending-after-push**: head SHA differs from state, or rollup contains failures.
+- **CI failing or pending-after-push**: head SHA differs from state, or `conclusions` contains `"FAILURE"` or does not yet contain a terminal value.
 - **New comments**: review comments newer than `last_comment_at` from anyone other than me.
 
 ### Step 3: Locate a Checkout (only for PRs needing fixes)

--- a/ai/skills/ci-monitor/SKILL.md
+++ b/ai/skills/ci-monitor/SKILL.md
@@ -82,6 +82,8 @@ Checks are still running. Report progress:
 
 "CI checks in progress: $PASSED/$TOTAL passed, $PENDING pending. Checking again in 30 seconds…"
 
+Retain only the summary scalars from `CHECK_DATA` (status, total, passed, failed, pending). Discard the full JSON until status is `"completed"`.
+
 Wait 30 seconds:
 
 ```bash
@@ -149,15 +151,14 @@ Then go back to **Step 2** to monitor the re-run (this does NOT count against `R
 
 **Uncertain classifications:** Present your own analysis of the log excerpt alongside the automated classification. Use your judgment to refine the classification before proceeding. Treat uncertain failures you judge to be legit the same as legit failures when building `LEGIT_FAILURES`.
 
-**Building `LEGIT_FAILURES`:** Before entering Step 5, construct an enriched array containing one entry per legit or uncertain failure. Each entry must include:
+**Building `LEGIT_FAILURES`:** Before entering Step 5, construct an array containing one entry per legit or uncertain failure. Each entry carries only compact identifiers:
 - `check_name` — the check's name
 - `check_link` — the check's URL
 - `run_id` — the run ID (may be null for non-Actions checks)
 - `workflow` — the workflow name
-- `log_data` — the `LOG_DATA` object fetched in step 4a
-- `classification` — the full `CLASSIFICATION` object from step 4b
+- `classification` — the full `CLASSIFICATION` object from step 4b (scores and reasoning, no log text)
 
-This array is what the fix handler refers to as `failed_checks`.
+Do not embed `log_data` in this array. The fix handler re-fetches the log excerpt for each failure it is actively fixing. This array is what the fix handler refers to as `failed_checks`.
 
 ### Step 5: Fix Cycle
 

--- a/ai/skills/ci-monitor/handlers/fix.md
+++ b/ai/skills/ci-monitor/handlers/fix.md
@@ -9,13 +9,19 @@ Before this handler runs, the following variables should be available from SKILL
 - `ORG` - The GitHub organization or user
 - `REPO` - The repository name
 - `RETRY_COUNT` - Current fix attempt number
-- `failed_checks` - Array of legit/uncertain failures with their log data and classifications
+- `failed_checks` - Array of legit/uncertain failures with compact identifiers (check_name, check_link, run_id, workflow, classification); log data is not pre-loaded
 
 ## Instructions
 
 ### 1. Present Diagnosis
 
-For each legit or uncertain failure, show:
+For each legit or uncertain failure, fetch its logs first (if `run_id` is non-null):
+
+```bash
+~/.claude/skills/ci-monitor/scripts/ci-fetch-logs.sh "$run_id" "$ORG/$REPO" 2>&1
+```
+
+Then show:
 - Check name and URL
 - Classification and confidence
 - The most relevant portion of the log excerpt (focus on the actual error, not setup/teardown output)
@@ -44,7 +50,7 @@ Return to SKILL.md to re-monitor.
 For each failure the user approved:
 
 **3a. Understand the error:**
-- Read the full log excerpt carefully
+- Use the log excerpt fetched in step 1 (re-fetch if not yet retrieved for this failure)
 - Identify the specific error message, failing test, or build error
 - Determine which file(s) are involved
 

--- a/ai/skills/ci-monitor/scripts/ci-check-status.sh
+++ b/ai/skills/ci-monitor/scripts/ci-check-status.sh
@@ -46,7 +46,6 @@ if [[ "${total}" -eq 0 ]]; then
     passed: 0,
     failed: 0,
     pending: 0,
-    checks: [],
     failed_checks: []
   }'
     exit 0
@@ -119,7 +118,6 @@ jq -n \
     --argjson passed "${passed}" \
     --argjson failed "${failed}" \
     --argjson pending "${pending}" \
-    --argjson checks "${enriched_checks}" \
     --argjson failed_checks "${failed_checks}" \
     '{
     status: $status,
@@ -128,6 +126,5 @@ jq -n \
     passed: $passed,
     failed: $failed,
     pending: $pending,
-    checks: $checks,
     failed_checks: $failed_checks
   }'

--- a/ai/skills/ci-monitor/scripts/helpers/ci-helpers.sh
+++ b/ai/skills/ci-monitor/scripts/helpers/ci-helpers.sh
@@ -9,7 +9,7 @@
 CI_POLL_INTERVAL=30   # seconds between polls
 CI_TIMEOUT_MINUTES=30 # default overall timeout
 CI_MAX_FIX_RETRIES=3  # max fix-push-monitor cycles
-CI_LOG_TAIL_LINES=200 # lines of log to keep per failed job
+CI_LOG_TAIL_LINES=80  # lines of log to keep per failed job
 
 # ── gh CLI wrapper ───────────────────────────────────────────────────────────
 # Suppress DEBUG env var that causes gh to emit verbose output

--- a/ai/skills/commit/SKILL.md
+++ b/ai/skills/commit/SKILL.md
@@ -28,7 +28,8 @@ Run in parallel:
 
 ```bash
 git status                          # staged, unstaged, and untracked files
-git diff HEAD                       # all uncommitted changes (staged + unstaged)
+git diff HEAD --stat                # summary of all uncommitted changes
+git diff HEAD | head -n 300         # capped diff; the stat output covers the rest
 git log --oneline -10               # recent commits for message style reference
 ```
 

--- a/ai/skills/copilot-review/SKILL.md
+++ b/ai/skills/copilot-review/SKILL.md
@@ -2,7 +2,7 @@
 name: copilot-review
 description: Evaluate unresolved PR review comments (Copilot and human reviewers), fix legitimate issues, and reply to dismissed ones. Only Copilot reviews are requested.
 argument-hint: "[<pr-url>|<pr-number>]"
-model: opus
+model: sonnet
 ---
 
 # Copilot Review

--- a/ai/skills/create-pr/SKILL.md
+++ b/ai/skills/create-pr/SKILL.md
@@ -98,12 +98,17 @@ fi
 Then, using `$base`, run in parallel:
 
 ```bash
-git log origin/$base..HEAD --oneline                                                   # commits on this branch
-git diff origin/$base...HEAD                                                           # full diff vs base
-gh pr list --head "$head" --state open --json number,title,body,isDraft,url --jq '.[0]'  # existing PR, if any
+git log origin/$base..HEAD --oneline                                                    # commits on this branch
+git diff origin/$base...HEAD --stat                                                     # changed-file summary
+gh pr list --head "$head" --state open --json number,title,isDraft,url --jq '.[0]'     # existing PR, if any
 ```
 
 If a PR already exists, note its number and URL: you will **update** it rather than create a new one (see Step 9). Use `gh pr list --head` rather than `gh pr view`: it queries by branch name (reliable in worktrees and after re-clones) instead of relying on local upstream tracking.
+
+When composing the PR body in Step 5, use the `--stat` output to decide how much diff to read:
+
+- If the stat shows fewer than ~200 changed lines total, fetch the full diff with `git diff origin/$base...HEAD`.
+- Otherwise, read per-file diffs only for files that are directly relevant to the PR description: `git diff origin/$base...HEAD -- <path>`. Skip generated files, lock files, and files whose names make their changes obvious (e.g. version bumps in `package.json`).
 
 ### 3. Find PR Template
 
@@ -234,7 +239,13 @@ EOF
   [--draft if draft=true]
 ```
 
-**Existing PR** (found in Step 2; note the existing body may already contain a `<details><summary>Manual test plan</summary>…</details>` block, so replace it with the new one rather than appending):
+**Existing PR** (found in Step 2; the initial check did not fetch the body to save tokens, so fetch it now if you need to inspect it before writing the update):
+
+```bash
+gh pr view <number> --json body --jq '.body'
+```
+
+Note the existing body may already contain a `<details><summary>Manual test plan</summary>…</details>` block; replace it with the new one rather than appending.
 
 ```bash
 gh pr edit <number> \

--- a/ai/skills/go/SKILL.md
+++ b/ai/skills/go/SKILL.md
@@ -2,7 +2,7 @@
 name: go
 description: Plan, implement, and iteratively review a task end-to-end using Claude + Copilot reviewers in a linear flow.
 argument-hint: "<task description> [--skip-planner] [--skip-copilot]"
-model: fable
+model: sonnet
 ---
 
 # /go
@@ -59,7 +59,7 @@ If `$plan_dir` is set, look for an existing plan in this preference order:
 2. `$plan_dir/${branch##*/}.md` (branch name minus any `owner/` prefix)
 3. If the directory contains exactly one `.md` file, use it
 
-If a plan was found, read it with the Read tool, briefly tell the user which plan you're using, and skip to Step 3.
+If a plan was found, read its first 100 lines with the Read tool (read specific later sections only when a step needs them), briefly tell the user which plan you're using, and skip to Step 3.
 
 Otherwise spawn the planner as a sub-agent so its research stays out of the main context:
 

--- a/ai/skills/handoff/SKILL.md
+++ b/ai/skills/handoff/SKILL.md
@@ -63,7 +63,8 @@ Then stop. Do not write a placeholder handoff.
 
 Do not write the handoff from memory of the conversation. Memory produces narrative; state produces handoffs. Before filling any section, gather concrete state:
 
-- Run `git diff HEAD` and `git status` to see what changed.
+- Run `git diff HEAD --stat` and `git status` to get an overview of what changed.
+- For files central to the handoff, read them directly with the Read tool (or run `git diff HEAD -- <path>` for a focused diff). Do not load the full unbounded diff.
 - Read the files you've been working in (don't trust your recall of their current contents).
 - Re-run failing tests or commands you've mentioned, so the verification section reflects reality.
 

--- a/ai/skills/metabase-prod-query/SKILL.md
+++ b/ai/skills/metabase-prod-query/SKILL.md
@@ -107,7 +107,15 @@ Default format is TSV. Pass `--format json` only when the user needs structured 
 
 ### 7. Read and summarize results
 
-Read the saved file with `Read` (or `head`/`wc -l` for size first). Report to the user:
+First, check the file size and shape:
+
+```bash
+wc -l <file> && head -5 <file>
+```
+
+If the file has 50 rows or fewer, read it in full with `Read`. Otherwise, work from targeted extracts (`head`/`awk`/`cut`) to get counts, top-N rows, or specific columns rather than loading the whole file into context.
+
+Report to the user:
 
 - Row count
 - Top N rows (or summary stats — sums, distributions — depending on the question)

--- a/ai/skills/quarterly-planning/scripts/config.sh
+++ b/ai/skills/quarterly-planning/scripts/config.sh
@@ -44,4 +44,4 @@ esac
 QPLAN_HANDBOOK_URL="${QPLAN_HANDBOOK_URL:-https://posthog.com/handbook/company/goal-setting}"
 
 # Max issues fetched per label.
-QPLAN_ISSUE_LIMIT="${QPLAN_ISSUE_LIMIT:-800}"
+QPLAN_ISSUE_LIMIT="${QPLAN_ISSUE_LIMIT:-150}"

--- a/ai/skills/review-fix-cycle/SKILL.md
+++ b/ai/skills/review-fix-cycle/SKILL.md
@@ -2,7 +2,7 @@
 name: review-fix-cycle
 description: Run one review-fix iteration — review code, fix findings, simplify, and commit.
 argument-hint: "[<review-target>] [--iteration N]"
-model: opus
+model: sonnet
 ---
 
 # Review-Fix Cycle

--- a/ai/skills/sprint-planning/SKILL.md
+++ b/ai/skills/sprint-planning/SKILL.md
@@ -96,12 +96,12 @@ If this fails (permissions, etc.), fall back to `SPRINT_FALLBACK_MEMBERS`, or as
 ### Step 3: Fetch Previous Sprint Comment
 
 ```bash
-~/.claude/skills/sprint-planning/scripts/fetch-previous-comment.sh <prev_number>
+~/.claude/skills/sprint-planning/scripts/fetch-previous-comment.sh --sections <prev_number>
 ```
 
-If the result is "NOT_FOUND" (e.g., the team's first sprint), skip the plan-first retro approach entirely. You'll build the retro purely from merged PRs and project board items instead, confirmed with the user.
+This returns only the `## Quarter goals` and `## Plan` sections, which is all that is needed here. If the result is "NOT_FOUND" (e.g., the team's first sprint), skip the plan-first retro approach entirely. You'll build the retro purely from merged PRs and project board items instead, confirmed with the user.
 
-If the result is not "NOT_FOUND", parse the comment to extract:
+If the result is not "NOT_FOUND", parse the output to extract:
 
 - The **Plan** section from the previous sprint (this becomes the retro skeleton)
 - Each team member's planned items
@@ -120,17 +120,16 @@ Store all PR data per team member.
 ### Step 5: Fetch Project Board Items
 
 ```bash
-source ~/.claude/skills/sprint-planning/scripts/config.sh
-gh project item-list "$SPRINT_PROJECT_NUMBER" --owner "$SPRINT_ORG" --format json --limit 200
+~/.claude/skills/sprint-planning/scripts/fetch-board-goals.sh --all
 ```
 
-Categorize items by status column:
+This returns a JSON array of all board items with `id`, `title`, `status`, `url`, `type`, `number`, and `assignees` fields. Categorize items by status column:
 
 - **Done** items inform the retro
 - **In Progress** and **Todo** items inform the plan
 - **In Review** and **Approved** items are treated as **In Progress** for planning purposes. These are PR-based items that may lack board assignees. For each, fetch the PR author with `gh pr view <number> --repo <owner/repo> --json author --jq .author.login` and use that as the assignee. Only include items whose author is a current team member.
 
-Each item's `content.url` field contains the issue or PR URL. Preserve these for linking in the output.
+Each item's `url` field contains the issue or PR URL. Preserve these for linking in the output.
 
 ### Step 6: First Prompt - Context
 

--- a/ai/skills/sprint-planning/scripts/fetch-board-goals.sh
+++ b/ai/skills/sprint-planning/scripts/fetch-board-goals.sh
@@ -1,10 +1,12 @@
 #!/bin/bash
-# Fetch In Progress and Todo items from the project board with assignee
-# information. Uses a single batched GraphQL query (via batch-item-query.sh)
-# to resolve assignees for all linkable items (Issues and PRs), keeping API
-# calls to a minimum.
+# Fetch project board items with assignee information. Uses a single batched
+# GraphQL query (via batch-item-query.sh) to resolve assignees for all linkable
+# items (Issues and PRs), keeping API calls to a minimum.
 #
-# Usage: fetch-board-goals.sh
+# Usage: fetch-board-goals.sh [--all]
+#
+#   --all  Return every item regardless of status. Without this flag only
+#          In Progress and Todo items are returned.
 #
 # Output: JSON array of items with fields:
 #   id, title, status, url, type, number, assignees
@@ -20,12 +22,23 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/config.sh"
 BATCH_QUERY="$SCRIPT_DIR/batch-item-query.sh"
 
-# Fetch all items and filter to active statuses.
-active_items=$(gh project item-list "$SPRINT_PROJECT_NUMBER" \
+all_statuses=false
+if [[ "${1:-}" == "--all" ]]; then
+  all_statuses=true
+fi
+
+# Fetch all items, optionally filtering to active statuses.
+raw_items=$(gh project item-list "$SPRINT_PROJECT_NUMBER" \
   --owner "$SPRINT_ORG" \
   --format json \
   --limit 200 \
-  | jq '[.items[] | select(.status == "In Progress" or .status == "Todo")]')
+  | jq '.items')
+
+if [[ "$all_statuses" == "false" ]]; then
+  active_items=$(echo "$raw_items" | jq '[.[] | select(.status == "In Progress" or .status == "Todo")]')
+else
+  active_items=$(echo "$raw_items" | jq '[.[]]')
+fi
 
 item_count=$(echo "$active_items" | jq 'length')
 

--- a/ai/skills/sprint-planning/scripts/fetch-previous-comment.sh
+++ b/ai/skills/sprint-planning/scripts/fetch-previous-comment.sh
@@ -5,16 +5,27 @@
 # SPRINT_COMMENT_HEADER (see config.sh). Returns the comment body, or
 # "NOT_FOUND" if no matching comment exists.
 #
-# Usage: fetch-previous-comment.sh <issue_number>
+# Usage: fetch-previous-comment.sh [--sections] <issue_number>
 #
-# Output: The full comment body text, or the literal string "NOT_FOUND".
+#   --sections  Extract only the ## Quarter goals and ## Plan sections
+#               instead of returning the full comment. Useful when only
+#               planning context is needed and the full comment would add
+#               unnecessary tokens to context.
+#
+# Output: The comment body text (or extracted sections), or "NOT_FOUND".
 
 set -euo pipefail
 
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/config.sh"
 
+sections_only=false
+if [[ "${1:-}" == "--sections" ]]; then
+  sections_only=true
+  shift
+fi
+
 if [[ $# -lt 1 ]]; then
-  echo "Usage: $0 <issue_number>" >&2
+  echo "Usage: $0 [--sections] <issue_number>" >&2
   exit 1
 fi
 
@@ -37,6 +48,14 @@ comment=$(gh api "repos/${SPRINT_REPO}/issues/${issue_number}/comments?per_page=
 
 if [[ -z "$comment" ]]; then
   echo "NOT_FOUND"
+elif [[ "$sections_only" == "true" ]]; then
+  # Extract ## Quarter goals and ## Plan sections (everything from each
+  # heading up to the next same-level (##) heading or end of comment).
+  echo "$comment" | awk '
+    /^## (Quarter goals|Plan)/ { printing=1 }
+    printing && /^## / && !/^## (Quarter goals|Plan)/ { printing=0 }
+    printing { print }
+  '
 else
   echo "$comment"
 fi

--- a/ai/skills/sprint-planning/scripts/fetch-previous-comment.sh
+++ b/ai/skills/sprint-planning/scripts/fetch-previous-comment.sh
@@ -51,11 +51,18 @@ if [[ -z "$comment" ]]; then
 elif [[ "$sections_only" == "true" ]]; then
   # Extract ## Quarter goals and ## Plan sections (everything from each
   # heading up to the next same-level (##) heading or end of comment).
-  echo "$comment" | awk '
+  sections=$(echo "$comment" | awk '
     /^## (Quarter goals|Plan)/ { printing=1 }
     printing && /^## / && !/^## (Quarter goals|Plan)/ { printing=0 }
     printing { print }
-  '
+  ')
+  if [[ -n "$sections" ]]; then
+    echo "$sections"
+  else
+    # The comment lacks the expected headings (older format or edited
+    # comment); return the full body so callers still get usable content.
+    echo "$comment"
+  fi
 else
   echo "$comment"
 fi

--- a/ai/skills/sprint-status/SKILL.md
+++ b/ai/skills/sprint-status/SKILL.md
@@ -3,7 +3,7 @@ name: sprint-status
 description: Produce a per-team-member sprint status checklist for the current sprint (each member's planned goals with a done / in-progress / not-started marker) and copy it to the clipboard as Slack-ready rich text, or emit Slack markdown with the `slack` argument. Defaults to the Feature Flags team; pass `platform` for Feature Flags Platform.
 allowed-tools: Bash, Read
 argument-hint: "[platform] [slack]"
-model: sonnet
+model: haiku
 ---
 
 # Sprint Status
@@ -69,19 +69,22 @@ This user's section sorts first and is marked `(you)`. If it fails, fall back to
 ### Step 4: Fetch the Current Sprint Plan
 
 ```bash
-~/.claude/skills/sprint-planning/scripts/fetch-previous-comment.sh <current_number>
+~/.claude/skills/sprint-planning/scripts/fetch-previous-comment.sh --sections <current_number>
 ```
 
-- If a comment is returned, parse the **Plan** section. Each `@member` heading is followed by their planned items; each item is a `[title](url)` link or plain text. These items are the goals. Capture, per member: the title, the URL (if any), and which member owns it.
+The `--sections` flag returns only the `## Quarter goals` and `## Plan` sections (or the literal `NOT_FOUND`), keeping the intro, retro, and other sections out of context.
+
+- If a comment is returned, parse the **Plan** section from the extracted lines. Each `@member` heading is followed by their planned items; each item is a `[title](url)` link or plain text. These items are the goals. Capture, per member: the title, the URL (if any), and which member owns it.
 - If the result is `NOT_FOUND`, there's no sprint plan yet. Fall back to board items only: run Step 5, group `In Progress` + `Todo` items by assignee, and treat every item's marker from its board status (`In Progress` → 🔄, `Todo` → ⬜). Skip the plan-based parsing.
 
 ### Step 5: Fetch Board Statuses
 
 ```bash
-~/.claude/skills/sprint-planning/scripts/fetch-board-goals.sh
+~/.claude/skills/sprint-planning/scripts/fetch-board-goals.sh \
+  | jq '[.[] | {url, status, assignees, title}]'
 ```
 
-Returns a JSON array of `In Progress` / `Todo` items with `url`, `status`, and `assignees`. Two uses:
+The jq filter retains only the four fields the steps need (`url`, `status`, `assignees`, `title`) and drops `id`, `type`, `number`, and `repo`. Returns a JSON array of `In Progress` / `Todo` items. Two uses:
 
 1. Decide 🔄 vs ⬜ for **open issues** in the plan: an open issue whose URL appears with status `In Progress` is 🔄, otherwise ⬜. (The `assignees` field is also what the Step 4 `NOT_FOUND` fallback groups by.)
 2. Surface board work that isn't in the plan. A board item whose URL or issue/PR number matches no plan item is "new": it renders under its assignee's **New (not in sprint plan)** subsection, or under a final **Unassigned** section when it has no assignee. Its marker comes from board status (`In Progress` → 🔄, `Todo` → ⬜).

--- a/ai/skills/standup/SKILL.md
+++ b/ai/skills/standup/SKILL.md
@@ -57,7 +57,7 @@ If `status` is "found":
 **Completed PRs** (merged since last standup):
 
 ```bash
-gh api search/issues --method GET -f q="author:haacked org:PostHog is:pr is:merged merged:>=${last_standup_date}" --jq '.items[] | {number, title, url: .html_url, repo: .repository_url, merged_at: .pull_request.merged_at}'
+gh api search/issues --method GET -f q="author:haacked org:PostHog is:pr is:merged merged:>=${last_standup_date}" --jq '.items[] | {number, title, url: .html_url, repo: (.repository_url | sub(".*/repos/"; "")), merged_at: .pull_request.merged_at}'
 ```
 
 Note: `gh search prs --merged` is unreliable for date filtering; it returns stale results. Always use `gh api search/issues` with the `merged:` qualifier instead, which returns accurate `merged_at` timestamps.
@@ -65,7 +65,7 @@ Note: `gh search prs --merged` is unreliable for date filtering; it returns stal
 **Active PRs** (open PRs across all PostHog repos), including draft status:
 
 ```bash
-gh api search/issues --method GET -f q="author:haacked org:PostHog is:pr is:open" --jq '.items[] | {number, title, url: .html_url, repo: .repository_url, draft: .draft, updatedAt: .updated_at}'
+gh api search/issues --method GET -f q="author:haacked org:PostHog is:pr is:open" --jq '.items[] | {number, title, url: .html_url, repo: (.repository_url | sub(".*/repos/"; "")), draft: .draft, updatedAt: .updated_at}'
 ```
 
 Note: This single query replaces per-repo `gh pr list` calls and also covers the "recently updated" signal via `updatedAt`. Filter to items updated since `last_standup_date` to identify PRs with recent activity. The search API does not return review requests; for non-draft open PRs, fetch them in one Bash call:

--- a/ai/skills/standup/SKILL.md
+++ b/ai/skills/standup/SKILL.md
@@ -62,23 +62,19 @@ gh api search/issues --method GET -f q="author:haacked org:PostHog is:pr is:merg
 
 Note: `gh search prs --merged` is unreliable for date filtering; it returns stale results. Always use `gh api search/issues` with the `merged:` qualifier instead, which returns accurate `merged_at` timestamps.
 
-**Active PRs** (open PRs with recent activity), including draft status and review requests:
+**Active PRs** (open PRs across all PostHog repos), including draft status:
 
 ```bash
-gh pr list --author "@me" --state open --json number,title,url,isDraft,reviewRequests --repo PostHog/posthog
+gh api search/issues --method GET -f q="author:haacked org:PostHog is:pr is:open" --jq '.items[] | {number, title, url: .html_url, repo: .repository_url, draft: .draft, updatedAt: .updated_at}'
 ```
 
-Also check for open PRs in other PostHog repos the user commonly works on:
-
-- `PostHog/posthog-js`
-- `PostHog/posthog-dotnet`
-- `PostHog/charts`
-- `PostHog/posthog-cloud-infra`
-
-**Recently Updated PRs** (may have changes since last standup even if not open):
+Note: This single query replaces per-repo `gh pr list` calls and also covers the "recently updated" signal via `updatedAt`. Filter to items updated since `last_standup_date` to identify PRs with recent activity. The search API does not return review requests; for non-draft open PRs, fetch them in one Bash call:
 
 ```bash
-gh api search/issues --method GET -f q="author:haacked org:PostHog is:pr is:open updated:>=${last_standup_date}" --jq '.items[] | {number, title, url: .html_url, repo: .repository_url}'
+for pr in "owner/repo#number" "owner/repo#number"; do
+  repo="${pr%%#*}"; num="${pr##*#}"
+  echo -e "$repo#$num\t$(gh pr view "$num" --repo "$repo" --json reviewRequests --jq '[.reviewRequests[].login] | join(",")')"
+done
 ```
 
 ### Step 4: Compose and Save Standup Notes
@@ -96,14 +92,24 @@ Build standup content and produce two outputs: a plain text archive file and HTM
 **Working on items:**
 
 - Include open PRs with recent activity
-- Carry over items from the previous standup's "Working on", but verify each one first:
-  - For items with a PR URL: `gh pr view <number> --repo <owner/repo> --json state,mergedAt`
-  - If **MERGED** since last standup: move to Completed (deduplicate by PR number; carry-over is the safety net for PRs the merged search may miss)
-  - If **CLOSED**: drop it entirely
-  - If **OPEN**: keep in Working on
-- Determine PR status from the `gh pr list` JSON:
-  - `isDraft: true` → link text is "draft"
-  - `reviewRequests` includes any reviewer → link text is "needs review"
+- Carry over items from the previous standup's "Working on", but verify each one first. For all carried-over PR URLs, check their state in one Bash call:
+
+```bash
+for pr in "owner/repo#number" "owner/repo#number"; do
+  repo="${pr%%#*}"; num="${pr##*#}"
+  echo -e "$repo#$num\t$(gh pr view "$num" --repo "$repo" --json state,mergedAt --jq '[.state, (.mergedAt // "")] | @tsv')"
+done
+```
+
+Then apply these rules to each row:
+
+- If **MERGED** since last standup: move to Completed (deduplicate by PR number; carry-over is the safety net for PRs the merged search may miss)
+- If **CLOSED**: drop it entirely
+- If **OPEN**: keep in Working on
+
+- Determine PR status from the Step 3 data:
+  - `draft: true` → link text is "draft"
+  - review-requests lookup returned any reviewer → link text is "needs review"
   - Otherwise → link text is "PR"
 - For non-PR work items: plain text description only
 

--- a/ai/skills/support/SKILL.md
+++ b/ai/skills/support/SKILL.md
@@ -3,7 +3,7 @@ name: support
 description: Support hero workflow — start a ticket investigation with auto-organized notes, find existing notes, or generate the weekly highlights log
 argument-hint: "[find|log|zendesk|github] <number-or-date>"
 disable-model-invocation: true
-model: inherit
+model: sonnet
 ---
 
 # Support Hero Workflow

--- a/ai/skills/test-plan/SKILL.md
+++ b/ai/skills/test-plan/SKILL.md
@@ -2,7 +2,7 @@
 name: test-plan
 description: Generate a GitHub Flavored Markdown manual test plan checklist that focuses on scenarios not covered by existing unit/integration tests. Use when the user wants to create a test plan for a PR or an implementation plan.
 argument-hint: "[--force] [--save <path>] [--plan <file>]"
-model: opus
+model: sonnet
 ---
 
 # Test Plan Generator
@@ -53,10 +53,21 @@ Then run in parallel:
 
 ```bash
 git log "$base"..HEAD --oneline
-git diff "$base"..HEAD
+git diff "$base"..HEAD --stat
 ```
 
 If there are no commits ahead of base or the diff is empty, tell the user there are no changes to generate a test plan for and stop.
+
+Check the stat output's total line count:
+
+- **Under ~200 lines changed:** fetch the full diff (`git diff "$base"..HEAD`) and proceed.
+- **200 or more lines changed:** fetch a reduced diff, excluding lock files and generated files:
+
+  ```bash
+  git diff --unified=2 "$base"..HEAD -- . ':(exclude)*.lock' ':(exclude)*-lock.*' ':(exclude)package-lock.json'
+  ```
+
+- **Reduced diff still exceeds ~4000 lines:** stop and ask the user to narrow scope (e.g., point to a specific subdirectory or file set).
 
 #### Plan mode (`--plan <file>`)
 

--- a/ai/skills/triage-issues/SKILL.md
+++ b/ai/skills/triage-issues/SKILL.md
@@ -49,7 +49,7 @@ If an unsupported team is requested, inform the user which teams are available.
 Fetch unlabeled issues from PostHog/posthog using `gh`:
 
 ```bash
-gh issue list --repo PostHog/posthog --state open --limit {limit} --json number,title,body,labels,createdAt,url --search "created:>=$(date -v-{days}d +%Y-%m-%d) {exclusion_labels}"
+gh issue list --repo PostHog/posthog --state open --limit {limit} --json number,title,labels,createdAt,url --search "created:>=$(date -v-{days}d +%Y-%m-%d) {exclusion_labels}"
 ```
 
 The `{exclusion_labels}` vary by team. For feature-flags:
@@ -65,7 +65,7 @@ The `{exclusion_labels}` vary by team. For feature-flags:
 Fetch unlabeled open PRs from the same window and keep only external contributions, which otherwise have no team routing and are easy to miss:
 
 ```bash
-gh search prs --repo PostHog/posthog --state open --limit {limit} --json number,title,body,labels,url,createdAt,isDraft,author,authorAssociation -- "created:>=$(date -v-{days}d +%Y-%m-%d) {exclusion_labels}"
+gh search prs --repo PostHog/posthog --state open --limit {limit} --json number,title,labels,url,createdAt,isDraft,author,authorAssociation -- "created:>=$(date -v-{days}d +%Y-%m-%d) {exclusion_labels}"
 ```
 
 Keep only PRs whose `authorAssociation` is NOT one of `MEMBER`, `OWNER`, `COLLABORATOR`.
@@ -79,6 +79,12 @@ for n in {external_pr_numbers}; do
   echo "PR ${n}: $(gh pr view "$n" --repo PostHog/posthog --json files,reviewDecision --jq '{files: [.files[].path], reviewDecision}')"
 done
 ```
+
+**Body fetching:** Issue and PR bodies are not fetched in bulk. After the subagent returns its initial classification (Step 5), fetch bodies individually only for items the subagent flags as needing more context (typically MEDIUM or LOW confidence candidates where the title and labels are ambiguous). Use `gh issue view {number} --repo PostHog/posthog --json body` or `gh pr view {number} --repo PostHog/posthog --json body`, then pass the bodies back to the subagent for a refined classification. Do not fetch bodies for HIGH-confidence candidates or items already skipped.
+
+### Step 3b: Early Exit
+
+If both the issues list and the external PRs list are empty (zero items returned), print the "nothing to triage" digest line for the team and date and stop. Do not proceed to Step 4 or spawn the subagent.
 
 ### Step 4: Detect Title Scope Renames
 


### PR DESCRIPTION
Skills pinned to fable/opus were spending the expensive tier on orchestration (parsing args, running bash, dispatching subagents) while the actual reasoning happens in subagents and subprocess loops. Separately, most skills let unbounded tool output (raw diffs, full GitHub JSON, untruncated logs and query results) enter context on every run.

## Model pins

| Skill | Before | After |
| --- | --- | --- |
| go | fable | sonnet |
| review-fix-cycle | opus | sonnet |
| copilot-review | opus | sonnet |
| test-plan | opus | sonnet |
| support | inherit | sonnet |
| sprint-status | sonnet | haiku |
| squash | sonnet | haiku |

The review-fix-cycle change cascades: review-code has no pin of its own, so the parallel reviewer agents it spawns now inherit sonnet instead of opus.

security-audit, resolve-conflicts, and quarterly-planning stay on fable; their savings need subagent restructures, which come separately.

## Output caps

- commit, handoff, create-pr, and test-plan use diff stats plus targeted or size-gated diffs instead of full raw diffs; test-plan stops and asks to narrow scope above ~4000 lines.
- triage-issues drops bodies from bulk fetches (they're fetched individually for MEDIUM/LOW-confidence candidates) and exits early when both queries return nothing, skipping the subagent entirely.
- babysit-prs filters statusCheckRollup down to unique conclusions plus failing check names and URLs.
- ci-monitor omits the full checks array from status output, keeps 80 log lines per failed job instead of 200, and re-fetches logs per fix instead of carrying them in LEGIT_FAILURES.
- sprint-planning calls fetch-board-goals.sh (new --all flag) instead of duplicating it inline, and fetch-previous-comment.sh gains a --sections flag that returns only the Quarter goals and Plan sections while preserving the NOT_FOUND sentinel. sprint-status uses the same flag and prefilters board JSON to the four fields it reads.
- standup replaces five per-repo PR queries with one org-wide search and batches carry-over and review-request checks into single Bash calls. The search API returns draft but not requested_reviewers (checked against the live API), so review requests come from a separate batched lookup.
- metabase-prod-query reads results in full only at 50 rows or fewer; larger files are summarized with head/awk/cut.
- quarterly-planning fetches 150 issues per label instead of 800; results are engagement-sorted, so the tail is noise.

## Test plan

- [ ] Scripts: `bash -n` passes on all edited scripts; both awk section extractors verified against synthetic sprint comments; the babysit jq verified against a sample statusCheckRollup payload.
- [ ] markdownlint output matches main (no new violations).
- [ ] Run `/commit` and `/sprint-status` once after merge to confirm the haiku pin and the capped diff produce normal output.