### PR TITLE
Prune broken skill symlinks during install

### DIFF
--- a/ai/install.sh
+++ b/ai/install.sh
@@ -35,11 +35,12 @@ uninstall_claude_config() {
     # Remove skill symlinks and contexts
     if [ "$INSTALL_SKILLS" = "true" ]; then
         if [ -d ~/.claude/skills ]; then
-            for skill in ~/.claude/skills/*/; do
-                [ -d "$skill" ] || continue
-                skill_name=$(basename "$skill")
-                if [ -L ~/.claude/skills/"$skill_name" ]; then
-                    rm -f ~/.claude/skills/"$skill_name"
+            for skill in ~/.claude/skills/*; do
+                # Remove any skill symlink, including broken ones left behind by
+                # a renamed or deleted skill. A dangling symlink fails -d/-e, so
+                # the glob must not be restricted to */ and the test must be -L.
+                if [ -L "$skill" ]; then
+                    rm -f "$skill"
                 fi
             done
             success "Removed skill symlinks"


### PR DESCRIPTION
Renaming a skill leaves a dangling symlink in `~/.claude/skills`, and `ai/install.sh` never cleaned it up. The uninstall pass globbed `~/.claude/skills/*/`, which only matches resolvable directories, so a symlink pointing at a renamed or deleted skill failed the `*/` match and lingered. We hit this with the copilot-review to address-pr-reviews rename: the old symlink had to be removed by hand.

The fix globs every entry in the directory and removes any symlink, broken or not. The install pass right after recreates the live ones, so resolvable symlinks are only briefly gone. A dangling symlink fails `-d`/`-e`, so the loop must not restrict the glob to `*/` and must test with `-L`.

## Test plan

- [ ] `sh -n ai/install.sh` passes.
- [ ] With a dangling symlink in `~/.claude/skills`, run `ai/install.sh --skills-only` and confirm the dangling entry is gone and live skills still resolve.