### PR TITLE
Add --approved flag to sprint-planning skill

### DIFF
--- a/ai/skills/sprint-planning/SKILL.md
+++ b/ai/skills/sprint-planning/SKILL.md
@@ -4,7 +4,7 @@ description: Write bi-weekly sprint planning updates for a PostHog team (default
 model: sonnet
 color: pink
 allowed-tools: Bash, Read, Grep, Glob
-argument-hint: [archive|--status [--last] [slack]]
+argument-hint: [archive|--status [--last] [slack]|--approved]
 ---
 
 # Sprint Planning
@@ -74,6 +74,8 @@ Format as `MM/DD - MM/DD` in the output.
   7. Run Step S7 (Render and Copy)
   8. Run Step S8 (Report)
   9. Exit after reporting
+
+- `/sprint-planning --approved`: List open PRs you've approved that haven't been merged yet, across all repositories under `SPRINT_ORG`. Read-only; follow the Approved Reviews Workflow and exit.
 
 ## Your Task
 
@@ -499,6 +501,32 @@ Show a plain-markdown rendering for in-terminal review, grouped by member with t
 > ✅ Copied to clipboard as rich text; paste directly into Slack.
 
 This workflow is read-only. Never post the result to GitHub or Slack; the user pastes it themselves.
+
+## Approved Reviews Workflow
+
+These steps apply when the `--approved` argument is provided. They run independently of the main sprint planning workflow and are read-only.
+
+The goal is to surface open PRs you've approved that are still waiting to merge, so nothing you've signed off on falls through the cracks. A PR qualifies when your latest _opinionated_ review on it is an approval (a later comment-only review doesn't drop it; a later "request changes" does) and the PR is still open.
+
+### Step A1: Fetch Approved PRs
+
+```bash
+~/.claude/skills/sprint-planning/scripts/fetch-approved-prs.sh
+```
+
+This sources `config.sh`, resolves the current user, searches open PRs they've reviewed under `SPRINT_ORG`, and filters to those they approved. It returns a JSON array sorted by most recently updated, each with `title`, `url`, `repository`, `number`, `isDraft`, `updatedAt`, and `author`. To scope to a different org, export `SPRINT_ORG` before invoking.
+
+### Step A2: Render
+
+If the array is empty, report that you have no approved-and-unmerged PRs and exit.
+
+Otherwise render a markdown list to the terminal, one line per PR, most recently updated first:
+
+```markdown
+- [exact PR title](url) (`repository`#number, by @author, updated N days ago)
+```
+
+Mark a line with a trailing `(draft)` when `isDraft` is true. Close with a one-line count, e.g. `13 approved PRs awaiting merge.`
 
 ## Formatting Rules
 

--- a/ai/skills/sprint-planning/scripts/fetch-approved-prs.sh
+++ b/ai/skills/sprint-planning/scripts/fetch-approved-prs.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+# List open PRs the current user has approved but that have not yet been merged,
+# across all repositories under SPRINT_ORG. A PR qualifies when the user's latest
+# opinionated review (comment-only reviews ignored) is APPROVED and the PR is
+# still open. So approve-then-comment still counts; approve-then-request-changes
+# does not. The batched GraphQL lookup is delegated to batch-item-query.sh.
+#
+# Usage: fetch-approved-prs.sh
+#
+# Output: JSON array sorted by most recently updated, each:
+#   { title, url, repository, number, isDraft, updatedAt, author }
+# Returns [] when nothing matches.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/config.sh"
+BATCH_QUERY="$SCRIPT_DIR/batch-item-query.sh"
+
+me=$(gh api user --jq .login)
+
+# Narrow to open PRs the user has reviewed in any way; the GraphQL pass below
+# keeps only those whose latest opinionated review by the user is an approval.
+prs=$(gh search prs \
+  --reviewed-by="$me" \
+  --state=open \
+  --owner="$SPRINT_ORG" \
+  --limit=100 \
+  --json number,title,url,repository,isDraft,updatedAt)
+
+if [[ "$(echo "$prs" | jq 'length')" -eq 0 ]]; then
+  echo "[]"
+  exit 0
+fi
+
+refs=$(echo "$prs" | jq '[.[] | {
+  owner: (.repository.nameWithOwner | split("/")[0]),
+  repo: .repository.name,
+  type: "PullRequest",
+  number
+}]')
+
+response=$(echo "$refs" | "$BATCH_QUERY" \
+  "author { login } latestOpinionatedReviews(first: 50) { nodes { author { login } state } }" \
+  "title")
+
+if [[ -z "$response" ]]; then
+  echo "[]"
+  exit 0
+fi
+
+# Join the GraphQL response back onto the search results by index (both are in
+# input order) and keep PRs whose latest opinionated review by the user approved.
+echo "$prs" | jq --argjson resp "$response" --arg me "$me" '
+  [to_entries[] |
+    .key as $i | .value as $it |
+    $resp.data["item_\($i)"].pullRequest as $pr |
+    select($pr.latestOpinionatedReviews.nodes
+      | any(.author.login == $me and .state == "APPROVED")) |
+    {
+      title: $it.title,
+      url: $it.url,
+      repository: $it.repository.nameWithOwner,
+      number: $it.number,
+      isDraft: $it.isDraft,
+      updatedAt: $it.updatedAt,
+      author: $pr.author.login
+    }
+  ]
+  | sort_by(.updatedAt) | reverse
+'


### PR DESCRIPTION
Adds a `--approved` flag to the `/sprint-planning` skill that lists open PRs the current user has approved but that haven't merged yet.

A new `fetch-approved-prs.sh` script uses `gh search prs --reviewed-by` to narrow to reviewed open PRs across `SPRINT_ORG`, then delegates to the shared `batch-item-query.sh` for a single batched GraphQL call that fetches each PR's `latestOpinionatedReviews`. Only PRs where the user's latest opinionated review is `APPROVED` are kept, so approve-then-comment still qualifies but approve-then-request-changes does not. Results are sorted by most recently updated and rendered as a markdown list in the terminal.

The `SKILL.md` update adds the argument hint, an Arguments entry, and a new read-only "Approved Reviews Workflow" section (Steps A1/A2) modeled on the existing `--status` workflow.

**Test plan:** Run `~/.claude/skills/sprint-planning/scripts/fetch-approved-prs.sh` and confirm it returns a JSON array of open PRs you've approved. Run `/sprint-planning --approved` in a Claude Code session and confirm the rendered list matches.