### PR TITLE
Add --sort option to review-all-prs.sh

### DIFF
--- a/bin/lib/review-filter.jq
+++ b/bin/lib/review-filter.jq
@@ -19,7 +19,8 @@
 # Output is grouped by priority tier. Within each tier the default order is
 # most recently updated first; $sort_key/$sort_dir override that ordering.
 
-# Rank for sorting by review status, needs-attention first.
+# Rank for sorting by review status, needs-attention first. The same set of
+# states is mapped to display labels in review-all-prs.sh; keep them in sync.
 def status_rank:
   {
     "NONE": 0,            # no review from the user yet
@@ -31,19 +32,19 @@ def status_rank:
   }[. // "NONE"] // 6;
 
 # Apply the chosen within-tier sort to an array of PRs. The default order
-# (updated, most recent first) is the stable base; sorting by another key
-# preserves that order within ties. Descending numeric sorts negate the key
-# to stay tie-stable; repo (a string) uses reverse, which is fine here.
+# (updated, most recent first) is the stable base, so PRs that tie on the
+# sort key stay newest-first. Descending numeric sorts negate the key to keep
+# that tie order; repo (a string) reverses repo groups while preserving each
+# group's newest-first order.
 def apply_sort:
-  (sort_by(.updated_at) | reverse) as $base
-  | $base
+  (sort_by(.updated_at) | reverse)
   | if $sort_key == "number" then
       (if $sort_dir == "desc" then sort_by(.number * -1) else sort_by(.number) end)
     elif $sort_key == "status" then
       (if $sort_dir == "desc" then sort_by(.user_review_state | status_rank | . * -1)
        else sort_by(.user_review_state | status_rank) end)
     elif $sort_key == "repo" then
-      (if $sort_dir == "desc" then (sort_by(.repo) | reverse) else sort_by(.repo) end)
+      (if $sort_dir == "desc" then (group_by(.repo) | reverse | add) else sort_by(.repo) end)
     else .   # "priority": no-op within a constant-priority tier
     end;
 

--- a/bin/lib/review-filter.jq
+++ b/bin/lib/review-filter.jq
@@ -4,6 +4,8 @@
 #   $user             - GitHub username
 #   $include_reviewed - bool; if true, skip the new-commits gate
 #   $team_members     - array of GitHub logins whose PRs get top priority
+#   $sort_key         - within-tier sort: priority|repo|status|number
+#   $sort_dir         - sort direction: asc|desc
 #
 # Keeps PRs the user hasn't reviewed and PRs with commits newer than the
 # user's last review. PENDING (draft) reviews have null submittedAt, so fall
@@ -14,7 +16,36 @@
 #   2 - conventional-commit title scoped to flags (e.g. "feat(flags):",
 #       "chore(feature-flags):")
 #   3 - everything else
-# Output is sorted by priority, then most recently updated within each tier.
+# Output is grouped by priority tier. Within each tier the default order is
+# most recently updated first; $sort_key/$sort_dir override that ordering.
+
+# Rank for sorting by review status, needs-attention first.
+def status_rank:
+  {
+    "NONE": 0,            # no review from the user yet
+    "PENDING": 1,         # unsubmitted draft review
+    "CHANGES_REQUESTED": 2,
+    "COMMENTED": 3,
+    "APPROVED": 4,
+    "DISMISSED": 5
+  }[. // "NONE"] // 6;
+
+# Apply the chosen within-tier sort to an array of PRs. The default order
+# (updated, most recent first) is the stable base; sorting by another key
+# preserves that order within ties. Descending numeric sorts negate the key
+# to stay tie-stable; repo (a string) uses reverse, which is fine here.
+def apply_sort:
+  (sort_by(.updated_at) | reverse) as $base
+  | $base
+  | if $sort_key == "number" then
+      (if $sort_dir == "desc" then sort_by(.number * -1) else sort_by(.number) end)
+    elif $sort_key == "status" then
+      (if $sort_dir == "desc" then sort_by(.user_review_state | status_rank | . * -1)
+       else sort_by(.user_review_state | status_rank) end)
+    elif $sort_key == "repo" then
+      (if $sort_dir == "desc" then (sort_by(.repo) | reverse) else sort_by(.repo) end)
+    else .   # "priority": no-op within a constant-priority tier
+    end;
 
 map(
   (.reviews.nodes | map(select(.author.login == $user)) | last) as $last_review
@@ -41,5 +72,5 @@ map(
     }
 )
 | group_by(.priority)
-| map(sort_by(.updated_at) | reverse)
+| map(apply_sort)
 | add // []

--- a/bin/review-all-prs.sh
+++ b/bin/review-all-prs.sh
@@ -13,12 +13,15 @@
 #   --json          Output raw JSON (default: formatted table)
 #   --team TEAM     Also find PRs requested from this team (repeatable)
 #   --priority-team TEAM  PRs authored by members of this team sort first
+#   --sort KEY[:DIR]  Within-tier sort: priority|repo|status|number,
+#                     optional :asc or :desc (default: priority)
 #   --include-reviewed  Include PRs you've already reviewed
 #   --pending       Only show PRs where you have a pending (draft) review
 #   --draft         Alias for --pending
 #   -h, --help      Show this help message
 #
-# Results are sorted by priority tier, then most recently updated:
+# Results are grouped by priority tier, then most recently updated within
+# each tier (override the within-tier order with --sort):
 #   1 - authored by a member of --priority-team
 #   2 - conventional-commit title scoped to flags (e.g. "feat(flags):")
 #   3 - everything else
@@ -59,6 +62,8 @@ INCLUDE_REVIEWED=false
 PENDING_ONLY=false
 TEAMS=()
 PRIORITY_TEAM=""
+SORT_KEY="priority"
+SORT_DIR=""
 
 usage() {
   cat <<EOF
@@ -72,6 +77,9 @@ Options:
   --json              Output raw JSON (default: formatted table)
   --team TEAM         Also find PRs requested from this team (repeatable)
   --priority-team TEAM  PRs authored by members of this team sort first
+  --sort KEY[:DIR]    Within-tier sort order. KEY is one of priority, repo,
+                      status, number; DIR is asc (default) or desc.
+                      Default is priority (most recently updated within tier).
   --include-reviewed  Include PRs you've already reviewed
   --pending           List every PR where you have a pending (draft) review.
                       Uses involves:@me and paginates, so it finds drafts even
@@ -86,6 +94,8 @@ Examples:
   $(basename "$0") --limit 10         # Limit to 10 PRs
   $(basename "$0") --team my-team     # Include team review requests
   $(basename "$0") --pending          # List your pending draft reviews
+  $(basename "$0") --sort repo        # Sort each tier by repository name
+  $(basename "$0") --sort number:desc # Sort each tier by PR number, newest first
 EOF
   exit 0
 }
@@ -121,6 +131,17 @@ while [[ $# -gt 0 ]]; do
       PRIORITY_TEAM="$2"
       shift 2
       ;;
+    --sort)
+      if [[ -z "${2:-}" || "${2:-}" == --* ]]; then
+        echo "--sort requires a value (priority|repo|status|number[:asc|:desc])" >&2
+        exit 1
+      fi
+      SORT_KEY="${2%%:*}"
+      if [[ "$2" == *:* ]]; then
+        SORT_DIR="${2#*:}"
+      fi
+      shift 2
+      ;;
     --include-reviewed)
       INCLUDE_REVIEWED=true
       shift
@@ -139,6 +160,22 @@ while [[ $# -gt 0 ]]; do
       ;;
   esac
 done
+
+case "$SORT_KEY" in
+  priority|repo|status|number) ;;
+  *)
+    echo "Invalid --sort key: $SORT_KEY (valid: priority, repo, status, number)" >&2
+    exit 1
+    ;;
+esac
+SORT_DIR="${SORT_DIR:-asc}"
+case "$SORT_DIR" in
+  asc|desc) ;;
+  *)
+    echo "Invalid --sort direction: $SORT_DIR (valid: asc, desc)" >&2
+    exit 1
+    ;;
+esac
 
 GITHUB_USER=$(get_github_user)
 
@@ -266,6 +303,8 @@ PROCESSED=$(echo "$ALL_RESULTS" | jq \
   --arg user "$GITHUB_USER" \
   --argjson include_reviewed "$INCLUDE_REVIEWED" \
   --argjson team_members "$TEAM_MEMBERS" \
+  --arg sort_key "$SORT_KEY" \
+  --arg sort_dir "$SORT_DIR" \
   -f "${SCRIPT_DIR}/lib/review-filter.jq")
 
 if [[ "$PENDING_ONLY" == "true" ]]; then

--- a/bin/review-all-prs.sh
+++ b/bin/review-all-prs.sh
@@ -63,7 +63,7 @@ PENDING_ONLY=false
 TEAMS=()
 PRIORITY_TEAM=""
 SORT_KEY="priority"
-SORT_DIR=""
+SORT_DIR="asc"
 
 usage() {
   cat <<EOF
@@ -168,7 +168,6 @@ case "$SORT_KEY" in
     exit 1
     ;;
 esac
-SORT_DIR="${SORT_DIR:-asc}"
 case "$SORT_DIR" in
   asc|desc) ;;
   *)


### PR DESCRIPTION
Adds a `--sort KEY[:DIR]` option to control how PRs are ordered within each priority tier. Priority tiers stay the primary grouping; this reorders the rows inside each tier.

`KEY` is one of `priority` (default), `repo`, `status`, or `number`. `DIR` is `asc` (default) or `desc`. Invalid keys or directions are rejected with a clear error.

Status sorts needs-attention first: Not reviewed, Draft pending, Changes req, Commented, Approved, Dismissed. The default ordering is unchanged: within each tier, most recently updated first.

The sort runs in `review-filter.jq` on top of the existing updated-time base sort, so updated time stays the tiebreaker. Descending numeric sorts negate the key to stay tie-stable. No GraphQL change was needed since every sort field was already in the output.

## Test plan

- [ ] `review-all-prs.sh --sort repo` groups each tier by repository name
- [ ] `review-all-prs.sh --sort number:desc` orders each tier by PR number, newest first
- [ ] `review-all-prs.sh --sort status` lists not-reviewed PRs before reviewed ones
- [ ] `review-all-prs.sh` (no flag) keeps the most-recently-updated ordering within tiers
- [ ] `review-all-prs.sh --sort bogus` and `--sort repo:up` exit with a validation error