### PR TITLE
Flag org members with hedgehog emoji in review-all-prs output

### DIFF
--- a/bin/lib/review-filter.jq
+++ b/bin/lib/review-filter.jq
@@ -4,6 +4,7 @@
 #   $user             - GitHub username
 #   $include_reviewed - bool; if true, skip the new-commits gate
 #   $team_members     - array of GitHub logins whose PRs get top priority
+#   $org_members      - array of GitHub logins who belong to the org
 #   $sort_key         - within-tier sort: priority|repo|status|number
 #   $sort_dir         - sort direction: asc|desc
 #
@@ -61,6 +62,7 @@ map(
       url: .url,
       repo: .repository.nameWithOwner,
       author: .author.login,
+      is_org_member: (.author.login as $a | ($org_members | index($a)) != null),
       updated_at: .updatedAt,
       user_review_state: $last_review.state,
       priority: (

--- a/bin/review-all-prs.sh
+++ b/bin/review-all-prs.sh
@@ -26,6 +26,9 @@
 #   2 - conventional-commit title scoped to flags (e.g. "feat(flags):")
 #   3 - everything else
 #
+# PR authors who belong to the org (--org, default PostHog) are flagged with a
+# hedgehog (🦔) after their username in the AUTHOR column.
+#
 # The STATUS column reflects your review of each PR:
 #   Not reviewed   - no review from you
 #   Draft pending  - you have an unsubmitted draft review
@@ -42,6 +45,7 @@
 #       "url": "https://github.com/org/repo/pull/123",
 #       "repo": "org/repo",
 #       "author": "username",
+#       "is_org_member": true,
 #       "updated_at": "2024-01-15T10:30:00Z",
 #       "user_review_state": null,
 #       "priority": 3
@@ -181,11 +185,19 @@ GITHUB_USER=$(get_github_user)
 # Logins whose PRs get priority 1, as a JSON array for the jq filter.
 TEAM_MEMBERS="[]"
 if [[ -n "$PRIORITY_TEAM" ]]; then
-  TEAM_MEMBERS=$(gh api "orgs/${ORG}/teams/${PRIORITY_TEAM}/members" --paginate --jq '[.[].login]' | jq -s 'add') || {
+  TEAM_MEMBERS=$(gh api "orgs/${ORG}/teams/${PRIORITY_TEAM}/members?per_page=100" --paginate --jq '[.[].login]' | jq -s 'add') || {
     echo "Could not list members of ${ORG}/${PRIORITY_TEAM}" >&2
     exit 1
   }
 fi
+
+# Org members, used to flag PR authors who belong to the org with a hedgehog
+# marker. This is a convenience: a fetch failure must never break the listing,
+# so degrade to an empty array (mark nobody) instead of exiting.
+ORG_MEMBERS=$(gh api "orgs/${ORG}/members?per_page=100" --paginate --jq '[.[].login]' | jq -s 'add') || {
+  echo "Could not list members of ${ORG}; PR authors will not be flagged as org members." >&2
+  ORG_MEMBERS="[]"
+}
 
 # shellcheck disable=SC2016 # GraphQL variables use $ syntax, not shell expansion
 QUERY='
@@ -302,6 +314,7 @@ PROCESSED=$(echo "$ALL_RESULTS" | jq \
   --arg user "$GITHUB_USER" \
   --argjson include_reviewed "$INCLUDE_REVIEWED" \
   --argjson team_members "$TEAM_MEMBERS" \
+  --argjson org_members "$ORG_MEMBERS" \
   --arg sort_key "$SORT_KEY" \
   --arg sort_dir "$SORT_DIR" \
   -f "${SCRIPT_DIR}/lib/review-filter.jq")
@@ -367,17 +380,23 @@ else
       else . end
     ) // "Not reviewed",
     .author,
+    .is_org_member,
     .url
-  ] | @tsv' | while IFS=$'\t' read -r num pri repo title status author url; do
+  ] | @tsv' | while IFS=$'\t' read -r num pri repo title status author is_member url; do
+    # Flag org members with a hedgehog so PostHog authors stand out at a glance.
+    author_display="$author"
+    if [[ "$is_member" == "true" ]]; then
+      author_display="$author 🦔"
+    fi
     if [[ "$HYPERLINK" == "true" ]]; then
       # OSC 8 hyperlink: \e]8;;URL\e\\TEXT\e]8;;\e\\
       num_display=$(printf '\e]8;;%s\e\\%s\e]8;;\e\\' "$url" "$num")
       # Pad manually since printf %-6s counts the escape bytes.
       pad=$(( 6 - ${#num} ))
       (( pad < 0 )) && pad=0
-      printf "%s%*s %-3s %-25s %-50s %-15s %s\n" "$num_display" "$pad" "" "$pri" "$repo" "$title" "$status" "$author"
+      printf "%s%*s %-3s %-25s %-50s %-15s %s\n" "$num_display" "$pad" "" "$pri" "$repo" "$title" "$status" "$author_display"
     else
-      printf "%-6s %-3s %-25s %-50s %-15s %s\n" "$num" "$pri" "$repo" "$title" "$status" "$author"
+      printf "%-6s %-3s %-25s %-50s %-15s %s\n" "$num" "$pri" "$repo" "$title" "$status" "$author_display"
     fi
   done
 


### PR DESCRIPTION
Adds a 🦔 marker after the GitHub username of any PR author who belongs to the org, so you can tell PostHog authors from external contributors at a glance.

The org member list is fetched once per run (paginated, 100/page) and passed to the shared jq filter, which adds `is_org_member` to each PR object. That boolean is also present in `--json` output. If the member fetch fails, the script warns to stderr and continues without marking anyone.

## Test plan

- Run `review-all-prs.sh` and confirm PostHog authors show `username 🦔` while external contributors show only their username.
- Run with `--json` and confirm each PR has an `is_org_member` boolean.
- Run against a nonexistent org and confirm the script prints a warning but still lists PRs.