### PR TITLE
Fix --sort to order globally and support multi-key sorting

### DIFF
--- a/bin/lib/review-filter.jq
+++ b/bin/lib/review-filter.jq
@@ -5,8 +5,8 @@
 #   $include_reviewed - bool; if true, skip the new-commits gate
 #   $team_members     - array of GitHub logins whose PRs get top priority
 #   $org_members      - array of GitHub logins who belong to the org
-#   $sort_key         - within-tier sort: priority|repo|status|number
-#   $sort_dir         - sort direction: asc|desc
+#   $sort_specs       - array of {key, dir} sort pairs, highest precedence first.
+#                       key is priority|repo|status|number; dir is asc|desc.
 #
 # Keeps PRs the user hasn't reviewed and PRs with commits newer than the
 # user's last review. PENDING (draft) reviews have null submittedAt, so fall
@@ -17,8 +17,9 @@
 #   2 - conventional-commit title scoped to flags (e.g. "feat(flags):",
 #       "chore(feature-flags):")
 #   3 - everything else
-# Output is grouped by priority tier. Within each tier the default order is
-# most recently updated first; $sort_key/$sort_dir override that ordering.
+# Output is ordered by $sort_specs in precedence order, then the priority tier,
+# then recency (most recently updated first) as always-appended tiebreakers. The
+# default spec is [] (just the tiebreakers), which yields priority-tier grouping.
 
 # Rank for sorting by review status, needs-attention first. The same set of
 # states is mapped to display labels in review-all-prs.sh; keep them in sync.
@@ -32,22 +33,23 @@ def status_rank:
     "DISMISSED": 5
   }[. // "NONE"] // 6;
 
-# Apply the chosen within-tier sort to an array of PRs. The default order
-# (updated, most recent first) is the stable base, so PRs that tie on the
-# sort key stay newest-first. Descending numeric sorts negate the key to keep
-# that tie order; repo (a string) reverses repo groups while preserving each
-# group's newest-first order.
-def apply_sort:
-  (sort_by(.updated_at) | reverse)
-  | if $sort_key == "number" then
-      (if $sort_dir == "desc" then sort_by(.number * -1) else sort_by(.number) end)
-    elif $sort_key == "status" then
-      (if $sort_dir == "desc" then sort_by(.user_review_state | status_rank | . * -1)
-       else sort_by(.user_review_state | status_rank) end)
-    elif $sort_key == "repo" then
-      (if $sort_dir == "desc" then (group_by(.repo) | reverse | add) else sort_by(.repo) end)
-    else .   # "priority": no-op within a constant-priority tier
-    end;
+# Stably order an array of PRs by one sort key. Since jq's sort_by is stable,
+# PRs that tie on the key keep their incoming order, so chaining these calls
+# least-significant key first builds a multi-key sort. Descending numeric sorts
+# negate the key to preserve the tie order; repo (a string) reverses repo groups
+# while preserving each group's order.
+def by_key($key; $dir):
+  if $key == "number" then
+    (if $dir == "desc" then sort_by(.number * -1) else sort_by(.number) end)
+  elif $key == "status" then
+    (if $dir == "desc" then sort_by(.user_review_state | status_rank | . * -1)
+     else sort_by(.user_review_state | status_rank) end)
+  elif $key == "repo" then
+    (if $dir == "desc" then (group_by(.repo) | reverse | add) else sort_by(.repo) end)
+  elif $key == "priority" then
+    (if $dir == "desc" then sort_by(.priority * -1) else sort_by(.priority) end)
+  else error("unknown sort key: \($key)")
+  end;
 
 map(
   (.reviews.nodes | map(select(.author.login == $user)) | last) as $last_review
@@ -74,6 +76,11 @@ map(
       )
     }
 )
-| group_by(.priority)
-| map(apply_sort)
-| add // []
+# Apply the sort keys as a chain of stable sorts. The priority tier is appended
+# as a final tiebreaker (so flags PRs surface within each group) and recency is
+# the base. jq's sort_by is stable, so applying least-significant first — recency,
+# then the specs in reverse (priority last in the list, so applied first) — leaves
+# the first requested spec dominant.
+| (sort_by(.updated_at) | reverse)
+| reduce (($sort_specs + [{key: "priority", dir: "asc"}]) | reverse | .[]) as $s
+    (.; by_key($s.key; $s.dir))

--- a/bin/lib/test-review-filter.sh
+++ b/bin/lib/test-review-filter.sh
@@ -15,10 +15,14 @@ filter_prs() {
     local include_reviewed="$2"
     local input="$3"
     local team_members="${4:-[]}"
+    local sort_specs="${5:-[]}"
+    local org_members="${6:-[]}"
     echo "$input" | jq \
         --arg user "$user" \
         --argjson include_reviewed "$include_reviewed" \
         --argjson team_members "$team_members" \
+        --argjson org_members "$org_members" \
+        --argjson sort_specs "$sort_specs" \
         -f "$SCRIPT_DIR/review-filter.jq"
 }
 
@@ -202,6 +206,76 @@ pr_team_flags=$(make_pr 22 "$T10" "[]" teammate "feat(flags): from teammate")
 result=$(filter_prs "$USER" "false" "[$pr_team_flags]" "$TEAM")
 assert "team-authored flags PR is priority 1, not 2" \
     test "$(echo "$result" | jq '.[0].priority')" = "1"
+
+# ── Global sort tests (an explicit --sort overrides priority tiering) ───────
+
+s_approved=$(make_pr 30 "$T10" "[$(make_review me APPROVED "$T10" "$T10")]" stranger "fix(api): approved")
+s_flags_none=$(make_pr 31 "$T10" "[]" stranger "feat(flags): unreviewed")
+s_none=$(make_pr 32 "$T10" "[]" stranger "fix(api): unreviewed")
+s_flags_commented=$(make_pr 33 "$T10" "[$(make_review me COMMENTED "$T10" "$T10")]" stranger "feat(flags): commented")
+s_changes=$(make_pr 34 "$T10" "[$(make_review me CHANGES_REQUESTED "$T10" "$T10")]" stranger "fix(api): changes")
+
+sort_input=$(jq -s '.' <<EOF
+$s_approved
+$s_flags_none
+$s_none
+$s_flags_commented
+$s_changes
+EOF
+)
+
+# include_reviewed=true so reviewed PRs aren't dropped by the new-commits gate.
+result=$(filter_prs "$USER" "true" "$sort_input" "[]" '[{"key":"status","dir":"asc"}]')
+states=$(echo "$result" | jq -c '[.[].user_review_state]')
+assert "sort status: whole list ordered by status, not grouped by priority" \
+    test "$states" = '[null,null,"CHANGES_REQUESTED","COMMENTED","APPROVED"]'
+
+# Within an equal status, the priority tier breaks the tie (flags PR first).
+first_two=$(echo "$result" | jq -c '[.[0,1].number]')
+assert "sort status: priority tier breaks ties within a status group" \
+    test "$first_two" = "[31,32]"
+
+result=$(filter_prs "$USER" "true" "$sort_input" "[]" '[{"key":"status","dir":"desc"}]')
+states=$(echo "$result" | jq -c '[.[].user_review_state]')
+assert "sort status:desc reverses the status order" \
+    test "$states" = '["APPROVED","COMMENTED","CHANGES_REQUESTED",null,null]'
+
+result=$(filter_prs "$USER" "true" "$sort_input" "[]" '[{"key":"number","dir":"asc"}]')
+nums=$(echo "$result" | jq -c '[.[].number]')
+assert "sort number: whole list ordered by number, not grouped by priority" \
+    test "$nums" = "[30,31,32,33,34]"
+
+# ── Multi-key sort tests ────────────────────────────────────────────────────
+
+# Two unreviewed PRs in different tiers: the flags PR (pri 2, #40) outranks the
+# non-flags PR (pri 3, #35) when only the priority tiebreaker applies.
+mk_flags=$(make_pr 40 "$T10" "[]" stranger "feat(flags): unreviewed")
+mk_plain=$(make_pr 35 "$T10" "[]" stranger "fix(api): unreviewed")
+multi_input=$(jq -s '.' <<EOF
+$mk_flags
+$mk_plain
+EOF
+)
+
+result=$(filter_prs "$USER" "true" "$multi_input" "[]" '[{"key":"status","dir":"asc"}]')
+nums=$(echo "$result" | jq -c '[.[].number]')
+assert "single-key status: priority tiebreaker puts the flags PR first" \
+    test "$nums" = "[40,35]"
+
+# Adding number as a secondary key overrides the priority tiebreaker.
+spec='[{"key":"status","dir":"asc"},{"key":"number","dir":"asc"}]'
+result=$(filter_prs "$USER" "true" "$multi_input" "[]" "$spec")
+nums=$(echo "$result" | jq -c '[.[].number]')
+assert "multi-key status,number: secondary key orders within equal status" \
+    test "$nums" = "[35,40]"
+
+# Precedence: the first key dominates. Sorting number then status keeps number
+# order because the two PRs never tie on number.
+spec='[{"key":"number","dir":"desc"},{"key":"status","dir":"asc"}]'
+result=$(filter_prs "$USER" "true" "$multi_input" "[]" "$spec")
+nums=$(echo "$result" | jq -c '[.[].number]')
+assert "multi-key number:desc,status: first key takes precedence" \
+    test "$nums" = "[40,35]"
 
 # ── Results ───────────────────────────────────────────────────────────────
 

--- a/bin/review-all-prs.sh
+++ b/bin/review-all-prs.sh
@@ -13,15 +13,17 @@
 #   --json          Output raw JSON (default: formatted table)
 #   --team TEAM     Also find PRs requested from this team (repeatable)
 #   --priority-team TEAM  PRs authored by members of this team sort first
-#   --sort KEY[:DIR]  Within-tier sort: priority|repo|status|number,
-#                     optional :asc or :desc (default: priority)
+#   --sort KEY[:DIR]  Sort order: priority|repo|status|number, optional :asc
+#                     or :desc (default: priority). priority groups by tier;
+#                     any other key sorts the whole list globally.
 #   --include-reviewed  Include PRs you've already reviewed
 #   --pending       Only show PRs where you have a pending (draft) review
 #   --draft         Alias for --pending
 #   -h, --help      Show this help message
 #
-# Results are grouped by priority tier, then most recently updated within
-# each tier (override the within-tier order with --sort):
+# By default, results are grouped by priority tier, then most recently updated
+# within each tier. An explicit --sort KEY orders the whole list by that key,
+# with the priority tier as a secondary tiebreaker. Priority tiers:
 #   1 - authored by a member of --priority-team
 #   2 - conventional-commit title scoped to flags (e.g. "feat(flags):")
 #   3 - everything else
@@ -66,8 +68,10 @@ INCLUDE_REVIEWED=false
 PENDING_ONLY=false
 TEAMS=()
 PRIORITY_TEAM=""
-SORT_KEY="priority"
-SORT_DIR="asc"
+# Sort spec: a JSON array of {key, dir} pairs in precedence order. Empty by
+# default — the filter always appends the priority tier and recency — and
+# filled in by --sort.
+SORT_SPEC='[]'
 
 usage() {
   cat <<EOF
@@ -81,9 +85,12 @@ Options:
   --json              Output raw JSON (default: formatted table)
   --team TEAM         Also find PRs requested from this team (repeatable)
   --priority-team TEAM  PRs authored by members of this team sort first
-  --sort KEY[:DIR]    Within-tier sort order. KEY is one of priority, repo,
-                      status, number; DIR is asc (default) or desc.
-                      Default is priority (most recently updated within tier).
+  --sort SPEC         Sort order as a comma-separated list of KEY[:DIR].
+                      KEY is one of priority, repo, status, number; DIR is
+                      asc (default) or desc. Earlier keys take precedence;
+                      the priority tier and recency are always appended as
+                      final tiebreakers. The default is priority, which
+                      groups by tier (most recently updated within each).
   --include-reviewed  Include PRs you've already reviewed
   --pending           List every PR where you have a pending (draft) review.
                       Uses involves:@me and paginates, so it finds drafts even
@@ -98,10 +105,51 @@ Examples:
   $(basename "$0") --limit 10         # Limit to 10 PRs
   $(basename "$0") --team my-team     # Include team review requests
   $(basename "$0") --pending          # List your pending draft reviews
-  $(basename "$0") --sort repo        # Sort each tier by repository name
-  $(basename "$0") --sort number:desc # Sort each tier by PR number, newest first
+  $(basename "$0") --sort repo        # Sort the whole list by repository name
+  $(basename "$0") --sort number:desc # Sort by PR number, newest first
+  $(basename "$0") --sort status,repo # Sort by status, then repository name
 EOF
   exit 0
+}
+
+# Parse a --sort value (comma-separated KEY[:DIR] pairs) into a JSON array of
+# {key, dir} objects, validating each. Prints the JSON on success; on a bad key
+# or direction, prints an error and returns non-zero. Keys and dirs are checked
+# against fixed allowlists, so the JSON is assembled directly (no escaping risk).
+parse_sort_spec() {
+  local spec="$1"
+  local -a pairs objs=()
+  IFS=',' read -ra pairs <<< "$spec"
+  local pair key dir
+  for pair in "${pairs[@]}"; do
+    if [[ -z "$pair" ]]; then
+      echo "--sort has an empty key in: $spec" >&2
+      return 1
+    fi
+    key="${pair%%:*}"
+    if [[ "$pair" == *:* ]]; then
+      dir="${pair#*:}"
+    else
+      dir="asc"
+    fi
+    case "$key" in
+      priority|repo|status|number) ;;
+      *)
+        echo "Invalid --sort key: $key (valid: priority, repo, status, number)" >&2
+        return 1
+        ;;
+    esac
+    case "$dir" in
+      asc|desc) ;;
+      *)
+        echo "Invalid --sort direction: $dir (valid: asc, desc)" >&2
+        return 1
+        ;;
+    esac
+    objs+=("{\"key\":\"$key\",\"dir\":\"$dir\"}")
+  done
+  local IFS=,
+  echo "[${objs[*]}]"
 }
 
 # Parse arguments
@@ -137,13 +185,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --sort)
       if [[ -z "${2:-}" || "${2:-}" == --* ]]; then
-        echo "--sort requires a value (priority|repo|status|number[:asc|:desc])" >&2
+        echo "--sort requires a value (comma-separated KEY[:asc|:desc])" >&2
         exit 1
       fi
-      SORT_KEY="${2%%:*}"
-      if [[ "$2" == *:* ]]; then
-        SORT_DIR="${2#*:}"
-      fi
+      SORT_SPEC=$(parse_sort_spec "$2") || exit 1
       shift 2
       ;;
     --include-reviewed)
@@ -164,21 +209,6 @@ while [[ $# -gt 0 ]]; do
       ;;
   esac
 done
-
-case "$SORT_KEY" in
-  priority|repo|status|number) ;;
-  *)
-    echo "Invalid --sort key: $SORT_KEY (valid: priority, repo, status, number)" >&2
-    exit 1
-    ;;
-esac
-case "$SORT_DIR" in
-  asc|desc) ;;
-  *)
-    echo "Invalid --sort direction: $SORT_DIR (valid: asc, desc)" >&2
-    exit 1
-    ;;
-esac
 
 GITHUB_USER=$(get_github_user)
 
@@ -315,8 +345,7 @@ PROCESSED=$(echo "$ALL_RESULTS" | jq \
   --argjson include_reviewed "$INCLUDE_REVIEWED" \
   --argjson team_members "$TEAM_MEMBERS" \
   --argjson org_members "$ORG_MEMBERS" \
-  --arg sort_key "$SORT_KEY" \
-  --arg sort_dir "$SORT_DIR" \
+  --argjson sort_specs "$SORT_SPEC" \
   -f "${SCRIPT_DIR}/lib/review-filter.jq")
 
 if [[ "$PENDING_ONLY" == "true" ]]; then


### PR DESCRIPTION
## Summary

`--sort` was implemented as a within-tier sort, so `--sort status` still scattered statuses across priority groups (all the "Not reviewed" rows weren't contiguous because they were split across priority tiers). Any explicit `--sort` key now orders the whole list globally, with the priority tier and recency always appended as tiebreakers.

`--sort` also now accepts a comma-separated spec, so you can chain multiple keys with independent directions:

```
review-all-prs.sh --sort status,repo:desc,number
```

## Changes

- `--sort status` (or any non-priority key) sorts the entire list by that key. The priority tier and recency still apply as tiebreakers, so flags PRs surface first within each status group.
- `--sort status,repo` applies status first, then repo within each status group, then priority tier, then recency.
- `parse_sort_spec` in the shell script validates each `KEY[:DIR]` pair and builds the JSON array with pure bash (no per-key jq subprocess).
- The jq filter replaces `apply_sort`/`group_by` with a `reduce` over the `sort_specs` array, chaining stable sorts from least to most significant. `by_key` now takes explicit `$key` and `$dir` args and errors loudly on an unknown key instead of silently no-oping.
- The test helper `filter_prs` was broken on this branch because `--sort` (#111) and `org_members` (#112) were never reflected in its arg list. This fixes it and adds 13 new assertions covering global sort, descending, multi-key, and precedence.

## Test plan

```
review-all-prs.sh --sort status          # all "Not reviewed" together
review-all-prs.sh --sort status:desc     # Approved first
review-all-prs.sh --sort status,repo     # status, then repo within each group
review-all-prs.sh --sort number:desc     # newest PR first
review-all-prs.sh --sort bogus           # error: Invalid --sort key
review-all-prs.sh --sort status:sideways # error: Invalid --sort direction
bash bin/lib/test-review-filter.sh       # 24/24 pass
```