### PR TITLE
Fix sprint-status runner to call /sprint-planning --status

### DIFF
--- a/bin/sprint-status-run
+++ b/bin/sprint-status-run
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # sprint-status-run - Generate the Feature Flags sprint status and DM it.
 #
-# Runs the /sprint-status skill in slack output mode (Slack markdown instead of
+# Runs /sprint-planning --status in slack output mode (Slack markdown instead of
 # the rich-text clipboard; nobody is at the keyboard to paste) and DMs the
 # result to the recipient. The DM footer explains how to resume the session to
 # iterate.
@@ -39,8 +39,8 @@ Your session ID for this run is: ${SESSION_ID}
 
 Do these steps in order.
 
-1. Invoke the /sprint-status skill in slack output mode for the default
-   Feature Flags team: "/sprint-status slack"
+1. Invoke the /sprint-planning skill in status + slack output mode for the
+   default Feature Flags team: "/sprint-planning --status slack"
 
 $(slack_dm_instructions 2 "the rendered sprint status from step 1" "To iterate on this status:")
 


### PR DESCRIPTION
The weekly Feature Flags sprint-status launchd job has been failing before it renders anything.

#103 folded the standalone `/sprint-status` skill into `/sprint-planning` as a `--status` argument and deleted `ai/skills/sprint-status/SKILL.md`. But `bin/sprint-status-run` still told the worker to invoke `/sprint-status slack`, which no longer exists, so every Wednesday 07:00 run died at step 1 with no status produced.

This points the runner at the live form, `/sprint-planning --status slack`, and updates the header comment to match. The launchd label, service name, log dir, and worker filename keep the `sprint-status` identity, so nothing about install/state changes.

## Test plan

- [ ] `bash -n bin/sprint-status-run` passes
- [ ] `bin/sprint-status-service.sh run` produces a sprint status and DMs it (no GitHub or channel posts)
- [ ] Repo-wide `grep -rn '/sprint-status ' .` finds no remaining references to the dead command