### PR TITLE
Never auto-post PR review replies to humans

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ These orchestrate Claude Code reviews of pull requests. They power the `review-a
 | [`review-all-prs-service.sh`](bin/review-all-prs-service.sh) | Manage the `review-all-prs` macOS LaunchAgent (install, start, stop, logs, run). |
 | [`recent-reviews.sh`](bin/recent-reviews.sh) | Show recent PR review activity from session state files. |
 | [`seed-pr-failures.sh`](bin/seed-pr-failures.sh) | Rebuild the persistent PR-failure ledger from session history. |
-| [`copilot-review-loop.sh`](bin/copilot-review-loop.sh) | Request Copilot reviews, fix legitimate issues, reply to others, push, repeat. |
+| [`copilot-review-loop.sh`](bin/copilot-review-loop.sh) | Request Copilot reviews, fix legitimate issues, reply to and resolve Copilot threads, gather drafted replies to human reviewers for you to post, push, repeat. |
 | [`review-fix-loop.sh`](bin/review-fix-loop.sh) | Run the `/review-fix-cycle` skill in a loop with fresh Claude context per iteration. |
 
 #### Disk and system

--- a/ai/skills/address-pr-reviews/SKILL.md
+++ b/ai/skills/address-pr-reviews/SKILL.md
@@ -117,20 +117,27 @@ With user confirmation:
 - Edit the file to address the issue
 - Stage the changed file with `git add <file>`
 
-**For not-legit comments:**
+**For not-legit comments, branch on who authored the comment:**
 
-- Draft a concise, professional reply explaining why the code is correct
-- Show the draft to the user
-- Post via: `gh api "repos/<repo>/pulls/<pr_number>/comments/<comment_id>/replies" --method POST -f body='<reply>'`
-- Resolve the thread **only when `is_copilot` is true**: `~/.dotfiles/bin/gh-resolve-threads "https://github.com/<repo>/pull/<pr_number>" --comment-id <comment_id>`. For human reviewers (`is_copilot` false), reply but leave the thread unresolved so the reviewer gets the last word.
+- **Copilot (`is_copilot` true):** Draft a concise, professional reply explaining why the code is correct, show the draft to the user, then post it: `gh api "repos/<repo>/pulls/<pr_number>/comments/<comment_id>/replies" --method POST -f body='<reply>'`. Resolve the thread: `~/.dotfiles/bin/gh-resolve-threads "https://github.com/<repo>/pull/<pr_number>" --comment-id <comment_id>`.
+- **Human reviewers (`is_copilot` false):** Do **not** post anything. Draft the reply and hold it for the user to review and post themselves (see Step 6). Leave the thread unresolved so the reviewer gets the last word.
+
+Never auto-post a reply to a human reviewer. The user reviews and posts those replies.
 
 ### Step 6: Finalize
 
 1. Show a summary: N comments fixed, M comments dismissed
-2. If any files were changed, ask the user if they want to commit and push:
+2. **Present drafted replies to human reviewers for the user to post.** For each not-legit comment from a human reviewer, show the file:line, the comment quote, and your drafted reply. Write each reply to a file so it survives quotes and newlines, then give the user the exact command to post it:
+
+   ```bash
+   gh api "repos/<repo>/pulls/<pr_number>/comments/<comment_id>/replies" --method POST -F body=@<reply-file>
+   ```
+
+   The user reviews each reply and posts the ones they approve. Do not post them yourself.
+3. If any files were changed, ask the user if they want to commit and push:
    - Commit message: "Address Copilot review feedback"
    - Push to the current branch
-3. Update the shared state file with newly dismissed comment hashes:
+4. Update the shared state file with newly dismissed comment hashes:
 
 ```bash
 STATE_DIR="$HOME/.local/state/copilot-review-loop"

--- a/ai/skills/go/SKILL.md
+++ b/ai/skills/go/SKILL.md
@@ -151,7 +151,7 @@ Otherwise run the Copilot loop against the current branch's PR:
 ~/.dotfiles/bin/copilot-review-loop.sh
 ```
 
-It auto-detects the PR from the current branch, fetches Copilot's review, fixes legit findings, replies to dismissed ones, pushes, and repeats until Copilot has no new comments.
+It auto-detects the PR from the current branch, fetches Copilot's review, fixes legit findings, replies to and resolves dismissed Copilot threads, pushes, and repeats until Copilot has no new comments. Replies to human reviewers are never auto-posted; the loop drafts them and prints them at the end for you to review and post.
 
 ### Step 8: Final Claude pass
 
@@ -170,5 +170,6 @@ Tell the user what happened:
 - Commits added during the run (`git log @{u}..HEAD --oneline` or the range since the initial commit from Step 4)
 - The PR URL (`gh pr view --json url -q .url`)
 - Any outstanding findings — check `.notes/review-skipped.md` for Claude's deferred items and the Copilot state file under `~/.local/state/copilot-review-loop/` for low-confidence Copilot items flagged for human review.
+- Any drafted replies to human reviewers the loop printed under "Human Reviewer Replies to Post" — these are not posted automatically; surface them so the user can review and post.
 
 If any step exited non-zero, tell the user which one and where the logs are (`.notes/` for Claude, `~/.local/state/copilot-review-loop/` for Copilot).

--- a/bin/copilot-review-loop.sh
+++ b/bin/copilot-review-loop.sh
@@ -39,8 +39,9 @@ usage() {
 Usage: $(basename "$0") [<pr-url>|<pr-number>] [OPTIONS]
 
 Automate Copilot PR review feedback cycles. Requests a Copilot review,
-evaluates comments with Claude, fixes legit issues, replies to non-legit
-ones, pushes, and repeats until Copilot has no new comments.
+evaluates comments with Claude, fixes legit issues, replies to and resolves
+Copilot threads, drafts human-reviewer replies for you to post, pushes, and
+repeats until Copilot has no new comments.
 
 Must be run from within a checkout of the PR's repository.
 When no argument is given, detects the PR from the current branch.
@@ -146,14 +147,17 @@ process_dismissed_comments() {
       '.dismissed // [] | .[] | select(.id == $id) | .reply // ""')
 
     if is_copilot_comment "$new_comments" "$dismissed_id"; then
-      # Post Claude's drafted reply to the Copilot thread, then resolve it.
-      if [[ -n "$reply" ]]; then
-        if ! gh api "repos/${REPO}/pulls/${PR_NUMBER}/comments/${dismissed_id}/replies" \
-          --method POST -f body="$reply" --silent 2>/dev/null; then
-          log_warn "Failed to post reply to Copilot comment ${dismissed_id}"
-        fi
+      # Post Claude's drafted reply, and resolve the thread only once it posts.
+      # Resolving a thread with no reply on it would swallow the dismissal
+      # rationale, so an empty draft or a failed post leaves the thread open.
+      if [[ -z "$reply" ]]; then
+        log_warn "No reply drafted for Copilot comment ${dismissed_id}; leaving thread open"
+      elif gh api "repos/${REPO}/pulls/${PR_NUMBER}/comments/${dismissed_id}/replies" \
+        --method POST -f body="$reply" --silent 2>/dev/null; then
+        RESOLVE_ARGS+=(--comment-id "$dismissed_id")
+      else
+        log_warn "Failed to post reply to Copilot comment ${dismissed_id}; leaving thread open"
       fi
-      RESOLVE_ARGS+=(--comment-id "$dismissed_id")
     else
       # Human reviewer: gather the reply for the user to post manually. Persist
       # the body to a file (survives TMPDIR cleanup) and index it for the summary.
@@ -161,12 +165,9 @@ process_dismissed_comments() {
       reply_file="${STATE_DIR}/${OWNER}-${REPO_NAME}-${PR_NUMBER}-reply-${dismissed_id}.txt"
       printf '%s' "$reply" > "$reply_file"
       chmod 600 "$reply_file"
-      path=$(echo "$new_comments" | jq -r --argjson id "$dismissed_id" \
-        '.[] | select(.id == $id) | .path')
-      line=$(echo "$new_comments" | jq -r --argjson id "$dismissed_id" \
-        '.[] | select(.id == $id) | (.line // "?")')
-      author_login=$(echo "$new_comments" | jq -r --argjson id "$dismissed_id" \
-        '.[] | select(.id == $id) | (.author // "unknown")')
+      IFS=$'\t' read -r path line author_login < <(echo "$new_comments" \
+        | jq -r --argjson id "$dismissed_id" \
+          '.[] | select(.id == $id) | [.path, (.line // "?"), (.author // "unknown")] | @tsv')
       jq -nc \
         --argjson id "$dismissed_id" \
         --arg path "$path" \
@@ -662,6 +663,8 @@ main() {
     # keeping PIPESTATUS intact for us to read timeout/claude's exit code.
     local -a claude_args=(claude -p --verbose --max-budget-usd "$MAX_BUDGET")
     if [[ "$SKIP_PERMISSIONS" == "true" ]]; then
+      # Bypasses the allowlist below, so the prompt's "do not post" instruction is
+      # the only guard against auto-replying. Use only when you trust the run.
       claude_args+=(--dangerously-skip-permissions)
     else
       # No gh/API tools: Claude drafts replies but never posts. The script posts
@@ -823,7 +826,7 @@ main() {
       echo ""
     fi
 
-    # Replies drafted for human reviewers. We never post these automatically — the
+    # Replies drafted for human reviewers. We never post these automatically; the
     # user reviews each and posts it. Reply bodies are saved to files so the post
     # command is safe regardless of quotes or newlines in the text.
     if [[ -s "$human_replies_file" ]]; then
@@ -841,7 +844,10 @@ main() {
         r_file=$(echo "$entry" | jq -r '.file')
         r_reply=$(echo "$entry" | jq -r '.reply')
         echo "  ${r_path}:${r_line}  (@${r_author}, comment ${r_id})"
-        echo "  Draft: ${r_reply}"
+        # Strip control bytes before display: the reply originates from comment
+        # text and could carry terminal escapes that spoof the Post line below it.
+        # The file used by the post command keeps the raw body untouched.
+        echo "  Draft: $(printf '%s' "$r_reply" | tr -d '\000-\010\013\014\016-\037')"
         echo "  Post:  gh api \"repos/${REPO}/pulls/${PR_NUMBER}/comments/${r_id}/replies\" --method POST -F body=@${r_file}"
         echo ""
       done < "$human_replies_file"

--- a/bin/copilot-review-loop.sh
+++ b/bin/copilot-review-loop.sh
@@ -3,7 +3,9 @@
 #
 # Requests a Copilot review (the only reviewer we spawn), then evaluates every
 # unresolved inline comment on the PR with Claude — from any reviewer, Copilot
-# or human — fixes legit issues, replies to non-legit ones, pushes, and repeats
+# or human — fixes legit issues, and pushes. Claude drafts replies but posts
+# nothing: the script posts and resolves Copilot threads, and gathers drafted
+# replies to human reviewers for the user to review and post manually. Repeats
 # until no unresolved comments remain or max rounds are reached.
 #
 # Usage:
@@ -117,6 +119,68 @@ is_copilot_comment() {
     '.[] | select(.id == $id) | .is_copilot')" == "true" ]]
 }
 
+# Process the comments Claude classified as not-legit (dismissed). Claude drafted
+# a reply for each but posted nothing, so the routing happens here: post the reply
+# to Copilot threads (and queue them for resolution via RESOLVE_ARGS), record every
+# dismissed comment in state so it's filtered next round, and gather replies to
+# human reviewers into $human_replies_file for the user to post manually. Human
+# replies are never posted automatically.
+#
+# Args:    summary_json  new_comments_json  round
+# Reads:   REPO PR_NUMBER OWNER REPO_NAME STATE_DIR human_replies_file
+# Sets:    STATE (via add_dismissed), RESOLVE_ARGS
+process_dismissed_comments() {
+  local summary="$1" new_comments="$2" round="$3"
+  RESOLVE_ARGS=()
+  local dismissed_id
+  while IFS= read -r dismissed_id; do
+    local body body_hash body_preview reply
+    body=$(echo "$new_comments" | jq -r --argjson id "$dismissed_id" \
+      '.[] | select(.id == $id) | .body')
+    [[ -z "$body" ]] && continue
+    body_hash=$(hash_comment "$body")
+    body_preview=$(echo "$body" | head -c 80)
+    add_dismissed "$body_hash" "$body_preview" "$round"
+
+    reply=$(echo "$summary" | jq -r --argjson id "$dismissed_id" \
+      '.dismissed // [] | .[] | select(.id == $id) | .reply // ""')
+
+    if is_copilot_comment "$new_comments" "$dismissed_id"; then
+      # Post Claude's drafted reply to the Copilot thread, then resolve it.
+      if [[ -n "$reply" ]]; then
+        if ! gh api "repos/${REPO}/pulls/${PR_NUMBER}/comments/${dismissed_id}/replies" \
+          --method POST -f body="$reply" --silent 2>/dev/null; then
+          log_warn "Failed to post reply to Copilot comment ${dismissed_id}"
+        fi
+      fi
+      RESOLVE_ARGS+=(--comment-id "$dismissed_id")
+    else
+      # Human reviewer: gather the reply for the user to post manually. Persist
+      # the body to a file (survives TMPDIR cleanup) and index it for the summary.
+      local reply_file path line author_login
+      reply_file="${STATE_DIR}/${OWNER}-${REPO_NAME}-${PR_NUMBER}-reply-${dismissed_id}.txt"
+      printf '%s' "$reply" > "$reply_file"
+      chmod 600 "$reply_file"
+      path=$(echo "$new_comments" | jq -r --argjson id "$dismissed_id" \
+        '.[] | select(.id == $id) | .path')
+      line=$(echo "$new_comments" | jq -r --argjson id "$dismissed_id" \
+        '.[] | select(.id == $id) | (.line // "?")')
+      author_login=$(echo "$new_comments" | jq -r --argjson id "$dismissed_id" \
+        '.[] | select(.id == $id) | (.author // "unknown")')
+      jq -nc \
+        --argjson id "$dismissed_id" \
+        --arg path "$path" \
+        --arg line "$line" \
+        --arg author "$author_login" \
+        --arg file "$reply_file" \
+        --arg reply "$reply" \
+        --argjson round "$round" \
+        '{id: $id, path: $path, line: $line, author: $author, file: $file, reply: $reply, round: $round}' \
+        >> "$human_replies_file"
+    fi
+  done < <(echo "$summary" | jq -r '.dismissed // [] | .[].id')
+}
+
 record_round() {
   local round="$1" review_id="$2" new_count="$3" fixed_count="$4" dismissed_count="$5"
   local head_sha_before="${6:-}" head_sha_after="${7:-}"
@@ -202,11 +266,12 @@ Classify each comment as exactly one of:
 
 **not-legit**: the code is correct; the comment is a false positive, style preference,
 or reflects a misunderstanding of the language/framework.
-- Reply to the comment with a concise, respectful explanation. Use exactly this command:
-  gh api "repos/${REPO}/pulls/${PR_NUMBER}/comments/{COMMENT_ID}/replies" --method POST -f body='Your reply here'
-  Replace {COMMENT_ID} with the numeric "id" field from the comment JSON.
-- Do NOT call any API to resolve the thread. The script resolves Copilot threads
-  automatically; human reviewers' threads are left open for them to resolve.
+- Do NOT post anything to GitHub. Do not call gh, the API, or resolve any thread.
+- Instead, draft a concise, respectful explanation of why the code is correct and return
+  it in the "reply" field of this comment's summary entry (see output format below).
+- The wrapper script handles posting: it posts your reply to Copilot threads and resolves
+  them, and it gathers replies to human reviewers for the user to post manually. Your only
+  job for not-legit comments is to write the reply text.
 - If Copilot is likely to flag the same pattern again (e.g., a modern language feature
   that resembles a bug to static analysis, an intentional design choice), add a brief
   clarifying source comment so future reviewers, human or automated, understand the
@@ -242,6 +307,10 @@ Rules for this line:
 Each entry in "fixed", "dismissed", and "needs_human" is an object:
 {"id": <number>, "confidence": "high"|"low", "reason": "<one-line phrase>", "path": "<file>", "line": <number|null>}
 
+Every "dismissed" entry MUST also include a "reply" field containing the full reply text
+you drafted for that comment (the script posts or gathers it; do not post it yourself):
+{"id": <number>, "confidence": "high"|"low", "reason": "<one-line phrase>", "path": "<file>", "line": <number|null>, "reply": "<reply text>"}
+
 confidence:
 - "high": you are confident the classification is correct.
 - "low": you made a call but a human should double-check (e.g., you fixed something
@@ -251,7 +320,7 @@ confidence:
 "errors" is a flat list of strings describing anything that went wrong.
 
 Example (do not copy this literally, generate from actual comments):
-COPILOT_REVIEW_SUMMARY:{"fixed":[{"id":123,"confidence":"high","reason":"Null pointer on missing key","path":"src/foo.py","line":42}],"dismissed":[{"id":456,"confidence":"low","reason":"isinstance() syntax valid in Python 3.10+, added clarifying comment","path":"src/bar.py","line":10}],"needs_human":[{"id":789,"confidence":"low","reason":"Possible SQL injection in dynamic query, needs security review","path":"src/db.py","line":88}],"errors":[]}
+COPILOT_REVIEW_SUMMARY:{"fixed":[{"id":123,"confidence":"high","reason":"Null pointer on missing key","path":"src/foo.py","line":42}],"dismissed":[{"id":456,"confidence":"low","reason":"isinstance() syntax valid in Python 3.10+, added clarifying comment","path":"src/bar.py","line":10,"reply":"This is valid in Python 3.10+, which is our minimum supported version. Added a clarifying comment."}],"needs_human":[{"id":789,"confidence":"low","reason":"Possible SQL injection in dynamic query, needs security review","path":"src/db.py","line":88}],"errors":[]}
 </output_format>
 
 <pr_diff>
@@ -281,7 +350,7 @@ parse_summary() {
       echo "$json_part" | jq '
         def normalize_items:
           [.[] | if type == "number" then
-            {"id": ., "confidence": "high", "reason": "unknown", "path": "unknown", "line": null}
+            {"id": ., "confidence": "high", "reason": "unknown", "path": "unknown", "line": null, "reply": ""}
           else . end];
         .fixed = (.fixed // [] | normalize_items) |
         .dismissed = (.dismissed // [] | normalize_items) |
@@ -402,6 +471,11 @@ main() {
   trap 'stop_heartbeat; save_state; rm -rf "$TMPDIR_LOOP"' EXIT
   local attention_file="${TMPDIR_LOOP}/needs-attention.ndjson"
   : > "$attention_file"
+  # Replies drafted for human reviewers that the user must post manually. Reply
+  # bodies are written to persistent files under STATE_DIR (they outlive this run);
+  # this ndjson just indexes them for the end-of-run summary.
+  local human_replies_file="${TMPDIR_LOOP}/human-replies.ndjson"
+  : > "$human_replies_file"
 
   log_info "Starting Copilot review loop for ${REPO}#${PR_NUMBER}"
   log_info "Max rounds: ${MAX_ROUNDS}, Budget per round: \$${MAX_BUDGET}, Timeout: ${TIMEOUT}s"
@@ -590,10 +664,12 @@ main() {
     if [[ "$SKIP_PERMISSIONS" == "true" ]]; then
       claude_args+=(--dangerously-skip-permissions)
     else
+      # No gh/API tools: Claude drafts replies but never posts. The script posts
+      # Copilot replies and gathers human ones, so a misclassification can't auto-reply.
       claude_args+=(
         --allowedTools
         'Bash(git add *)' 'Bash(git commit *)' 'Bash(git push *)'
-        'Bash(gh api *)' Edit Read Glob Grep
+        Edit Read Glob Grep
       )
     fi
 
@@ -678,28 +754,13 @@ main() {
       break
     fi
 
-    # Record newly dismissed comments in state so they're filtered in future
-    # rounds. Claude has already replied to each. We only auto-resolve Copilot
-    # threads; human reviewers' threads stay open so they get the last word.
-    local resolve_args=()
-    while IFS= read -r dismissed_id; do
-      local body body_hash body_preview
-      body=$(echo "$new_comments" | jq -r --argjson id "$dismissed_id" \
-        '.[] | select(.id == $id) | .body')
-      if [[ -n "$body" ]]; then
-        body_hash=$(hash_comment "$body")
-        body_preview=$(echo "$body" | head -c 80)
-        add_dismissed "$body_hash" "$body_preview" "$round"
-        if is_copilot_comment "$new_comments" "$dismissed_id"; then
-          resolve_args+=(--comment-id "$dismissed_id")
-        fi
-      fi
-    done < <(echo "$summary" | jq -r '.dismissed // [] | .[].id')
+    # Route dismissed comments: post+resolve Copilot threads, gather human replies.
+    process_dismissed_comments "$summary" "$new_comments" "$round"
 
     # Resolve dismissed Copilot review threads on GitHub
-    if [[ ${#resolve_args[@]} -gt 0 ]]; then
-      log_info "Resolving $(( ${#resolve_args[@]} / 2 )) dismissed thread(s)…"
-      if "${SCRIPT_DIR}/gh-resolve-threads" "$PR_NUMBER" "${resolve_args[@]}"; then
+    if [[ ${#RESOLVE_ARGS[@]} -gt 0 ]]; then
+      log_info "Resolving $(( ${#RESOLVE_ARGS[@]} / 2 )) dismissed thread(s)…"
+      if "${SCRIPT_DIR}/gh-resolve-threads" "$PR_NUMBER" "${RESOLVE_ARGS[@]}"; then
         log_success "Dismissed threads resolved"
       else
         log_warn "Failed to resolve some threads (non-fatal)"
@@ -761,7 +822,34 @@ main() {
       done < <(jq -r '[.action, (.path // "unknown"), (.line // "?"), .round, (.reason // "no details")] | @tsv' "$attention_file")
       echo ""
     fi
+
+    # Replies drafted for human reviewers. We never post these automatically — the
+    # user reviews each and posts it. Reply bodies are saved to files so the post
+    # command is safe regardless of quotes or newlines in the text.
+    if [[ -s "$human_replies_file" ]]; then
+      local replies_count
+      replies_count=$(wc -l < "$human_replies_file" | tr -d ' ')
+      log_section "Human Reviewer Replies to Post (${replies_count})"
+      log_warn "Drafted but NOT posted. Review each, then run its command to post:"
+      echo ""
+      while IFS= read -r entry; do
+        local r_id r_path r_line r_author r_file r_reply
+        r_id=$(echo "$entry" | jq -r '.id')
+        r_path=$(echo "$entry" | jq -r '.path')
+        r_line=$(echo "$entry" | jq -r '.line')
+        r_author=$(echo "$entry" | jq -r '.author')
+        r_file=$(echo "$entry" | jq -r '.file')
+        r_reply=$(echo "$entry" | jq -r '.reply')
+        echo "  ${r_path}:${r_line}  (@${r_author}, comment ${r_id})"
+        echo "  Draft: ${r_reply}"
+        echo "  Post:  gh api \"repos/${REPO}/pulls/${PR_NUMBER}/comments/${r_id}/replies\" --method POST -F body=@${r_file}"
+        echo ""
+      done < "$human_replies_file"
+    fi
   fi
 }
 
-main "$@"
+# Only run when executed directly, so tests can source this file for its functions.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main "$@"
+fi

--- a/bin/lib/test-dismissed-replies.sh
+++ b/bin/lib/test-dismissed-replies.sh
@@ -3,7 +3,7 @@
 #
 # The routing is safety-critical: Copilot dismissed comments get their drafted
 # reply POSTED and queued for resolution, while human dismissed comments are
-# only GATHERED to files for the user to post manually — never posted here.
+# only GATHERED to files for the user to post manually, never posted here.
 #
 # Usage: test-dismissed-replies.sh
 
@@ -19,9 +19,14 @@ source "$SCRIPT_DIR/test-helpers.sh"
 # shellcheck source=bin/copilot-review-loop.sh
 source "$SCRIPT_DIR/../copilot-review-loop.sh"
 
+# All temp artifacts live under one dir so a single trap cleans them up.
+TESTTMP="$(mktemp -d)"
+trap 'rm -rf "$TESTTMP"' EXIT
+
 # Stub gh so nothing hits the network. Record each call's args verbatim so we can
 # assert exactly what would have been posted. Defined after sourcing so it wins.
-GH_CALLS_FILE="$(mktemp)"
+GH_CALLS_FILE="$TESTTMP/gh-calls"
+: > "$GH_CALLS_FILE"
 gh() { printf '%s\n' "$*" >> "$GH_CALLS_FILE"; }
 
 # ── Fixture globals process_dismissed_comments reads ────────────────────────
@@ -32,12 +37,14 @@ REPO_NAME="widgets"
 PR_NUMBER=123
 
 COPILOT_REPLY="This is valid in Python 3.10+, our minimum version."
-HUMAN_REPLY="Good question — it's intentional; see the comment I added."
+HUMAN_REPLY="Good question; it's intentional, see the comment I added."
+HUMAN_REPLY_2="Already covered by the validation above."
 
 new_comments=$(cat <<JSON
 [
   {"id": 1, "path": "src/a.py", "line": 10, "body": "copilot says fix this", "author": "Copilot", "is_copilot": true},
-  {"id": 2, "path": "src/b.py", "line": 20, "body": "human asks about this", "author": "alice", "is_copilot": false}
+  {"id": 2, "path": "src/b.py", "line": 20, "body": "alice asks about this", "author": "alice", "is_copilot": false},
+  {"id": 3, "path": "src/c.py", "line": 30, "body": "bob asks about this", "author": "bob", "is_copilot": false}
 ]
 JSON
 )
@@ -45,25 +52,29 @@ JSON
 summary=$(jq -nc \
   --arg cr "$COPILOT_REPLY" \
   --arg hr "$HUMAN_REPLY" \
+  --arg hr2 "$HUMAN_REPLY_2" \
   '{
     fixed: [],
     dismissed: [
       {id: 1, confidence: "high", reason: "false positive", path: "src/a.py", line: 10, reply: $cr},
-      {id: 2, confidence: "high", reason: "intentional", path: "src/b.py", line: 20, reply: $hr}
+      {id: 2, confidence: "high", reason: "intentional", path: "src/b.py", line: 20, reply: $hr},
+      {id: 3, confidence: "high", reason: "already handled", path: "src/c.py", line: 30, reply: $hr2}
     ],
     needs_human: [],
     errors: []
   }')
 
-# ── Scenario: one Copilot + one human dismissed comment ─────────────────────
+# ── Scenario: one Copilot + two human dismissed comments ────────────────────
 
-STATE_DIR="$(mktemp -d)"
-human_replies_file="$(mktemp)"
+STATE_DIR="$TESTTMP/state"
+mkdir -p "$STATE_DIR"
+human_replies_file="$TESTTMP/human-replies"
+: > "$human_replies_file"
 STATE='{"dismissed_comments":[],"rounds":[]}'
 
 process_dismissed_comments "$summary" "$new_comments" 1
 
-# gh is called exactly once — only for the Copilot comment.
+# gh is called exactly once, only for the Copilot comment.
 gh_call_count=$(wc -l < "$GH_CALLS_FILE" | tr -d ' ')
 assert "gh called exactly once" test "$gh_call_count" -eq 1
 
@@ -73,9 +84,11 @@ assert "gh call targets Copilot comment 1" \
 assert "gh call carries the Copilot reply text" \
   grep -qF "$COPILOT_REPLY" "$GH_CALLS_FILE"
 
-# The human comment (id 2) is NEVER posted.
+# Neither human comment (id 2, id 3) is ever posted.
 assert_not "human comment 2 is never posted" \
   grep -q 'comments/2/replies' "$GH_CALLS_FILE"
+assert_not "human comment 3 is never posted" \
+  grep -q 'comments/3/replies' "$GH_CALLS_FILE"
 assert_not "human reply text is never posted" \
   grep -qF "$HUMAN_REPLY" "$GH_CALLS_FILE"
 
@@ -84,37 +97,85 @@ resolve_str="${RESOLVE_ARGS[*]}"
 assert "only Copilot thread queued for resolution" \
   test "$resolve_str" = "--comment-id 1"
 
-# The human reply is gathered to a persistent file with the exact body.
-human_file="${STATE_DIR}/acme-widgets-123-reply-2.txt"
-assert "human reply file exists" test -f "$human_file"
-assert "human reply file holds the drafted reply" \
-  test "$(cat "$human_file")" = "$HUMAN_REPLY"
+# Each human reply is gathered to its own persistent file with the exact body.
+assert "human reply file for comment 2 exists" \
+  test -f "${STATE_DIR}/acme-widgets-123-reply-2.txt"
+assert "human reply file 2 holds the drafted reply" \
+  test "$(cat "${STATE_DIR}/acme-widgets-123-reply-2.txt")" = "$HUMAN_REPLY"
+assert "human reply file for comment 3 exists" \
+  test -f "${STATE_DIR}/acme-widgets-123-reply-3.txt"
+assert "human reply file 3 holds the drafted reply" \
+  test "$(cat "${STATE_DIR}/acme-widgets-123-reply-3.txt")" = "$HUMAN_REPLY_2"
 
 # No reply file is written for the Copilot comment (it was posted, not gathered).
 assert_not "no gathered file for Copilot comment" \
   test -f "${STATE_DIR}/acme-widgets-123-reply-1.txt"
 
-# The human-replies index has exactly one entry, for comment 2.
+# The human-replies index accumulates one line per human comment (not overwritten).
 index_count=$(wc -l < "$human_replies_file" | tr -d ' ')
-assert "human-replies index has one entry" test "$index_count" -eq 1
-indexed_id=$(jq -r '.id' "$human_replies_file")
-assert "indexed entry is comment 2" test "$indexed_id" -eq 2
-indexed_author=$(jq -r '.author' "$human_replies_file")
-assert "indexed entry records author" test "$indexed_author" = "alice"
-indexed_reply=$(jq -r '.reply' "$human_replies_file")
-assert "indexed entry records the reply" test "$indexed_reply" = "$HUMAN_REPLY"
+assert "human-replies index has two entries" test "$index_count" -eq 2
+indexed_ids=$(jq -r '.id' "$human_replies_file" | sort | tr '\n' ' ')
+assert "indexed entries are comments 2 and 3" test "$indexed_ids" = "2 3 "
+entry2_author=$(jq -r 'select(.id == 2) | .author' "$human_replies_file")
+assert "index records the author for comment 2" test "$entry2_author" = "alice"
+entry2_reply=$(jq -r 'select(.id == 2) | .reply' "$human_replies_file")
+assert "index records the reply for comment 2" test "$entry2_reply" = "$HUMAN_REPLY"
 
-# Both comments are recorded in state so they're filtered in future rounds.
+# All three dismissed comments are recorded in state so they're filtered next round.
 state_dismissed=$(echo "$STATE" | jq '.dismissed_comments | length')
-assert "both dismissed comments recorded in state" test "$state_dismissed" -eq 2
+assert "all dismissed comments recorded in state" test "$state_dismissed" -eq 3
+
+# ── Scenario: a Copilot comment with an empty reply is left unresolved ──────
+# Resolution requires a posted reply. An empty draft means nothing to say, so we
+# skip the post AND leave the thread open rather than closing it silently.
+
+: > "$GH_CALLS_FILE"
+human_replies_file="$TESTTMP/human-replies-empty-reply"
+: > "$human_replies_file"
+STATE='{"dismissed_comments":[],"rounds":[]}'
+empty_reply_summary=$(jq -nc '{
+  fixed: [], needs_human: [], errors: [],
+  dismissed: [{id: 1, confidence: "high", reason: "fp", path: "src/a.py", line: 10, reply: ""}]
+}')
+
+process_dismissed_comments "$empty_reply_summary" "$new_comments" 2
+
+assert_not "no gh post when the Copilot reply is empty" \
+  grep -q 'comments/1/replies' "$GH_CALLS_FILE"
+assert "Copilot thread NOT queued when reply is empty" \
+  test "${#RESOLVE_ARGS[@]}" -eq 0
+
+# ── Scenario: a failed gh post leaves the Copilot thread unresolved ─────────
+# Resolving a thread whose reply never posted would swallow the rationale, so a
+# failed post must not queue the thread for resolution.
+
+: > "$GH_CALLS_FILE"
+human_replies_file="$TESTTMP/human-replies-post-fail"
+: > "$human_replies_file"
+STATE='{"dismissed_comments":[],"rounds":[]}'
+gh() { printf '%s\n' "$*" >> "$GH_CALLS_FILE"; return 1; }   # simulate a failed post
+copilot_only_summary=$(jq -nc --arg cr "$COPILOT_REPLY" '{
+  fixed: [], needs_human: [], errors: [],
+  dismissed: [{id: 1, confidence: "high", reason: "fp", path: "src/a.py", line: 10, reply: $cr}]
+}')
+
+process_dismissed_comments "$copilot_only_summary" "$new_comments" 3
+
+assert "post was attempted even though it failed" \
+  grep -q 'comments/1/replies' "$GH_CALLS_FILE"
+assert "Copilot thread NOT queued after a failed post" \
+  test "${#RESOLVE_ARGS[@]}" -eq 0
+
+gh() { printf '%s\n' "$*" >> "$GH_CALLS_FILE"; }   # restore the success stub
 
 # ── Scenario: empty dismissed array is a safe no-op ─────────────────────────
 
 : > "$GH_CALLS_FILE"
-human_replies_file="$(mktemp)"
+human_replies_file="$TESTTMP/human-replies-empty"
+: > "$human_replies_file"
 empty_summary='{"fixed":[],"dismissed":[],"needs_human":[],"errors":[]}'
 
-process_dismissed_comments "$empty_summary" "$new_comments" 2
+process_dismissed_comments "$empty_summary" "$new_comments" 4
 
 gh_call_count=$(wc -l < "$GH_CALLS_FILE" | tr -d ' ')
 assert "no gh calls when nothing dismissed" test "$gh_call_count" -eq 0

--- a/bin/lib/test-dismissed-replies.sh
+++ b/bin/lib/test-dismissed-replies.sh
@@ -1,0 +1,127 @@
+#!/bin/bash
+# Tests for process_dismissed_comments routing in copilot-review-loop.sh.
+#
+# The routing is safety-critical: Copilot dismissed comments get their drafted
+# reply POSTED and queued for resolution, while human dismissed comments are
+# only GATHERED to files for the user to post manually — never posted here.
+#
+# Usage: test-dismissed-replies.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# shellcheck source=bin/lib/test-helpers.sh
+source "$SCRIPT_DIR/test-helpers.sh"
+
+# Source the loop script for its functions. The source guard keeps main() from
+# running; the top-level arg parsing is a no-op with no positional parameters.
+# shellcheck source=bin/copilot-review-loop.sh
+source "$SCRIPT_DIR/../copilot-review-loop.sh"
+
+# Stub gh so nothing hits the network. Record each call's args verbatim so we can
+# assert exactly what would have been posted. Defined after sourcing so it wins.
+GH_CALLS_FILE="$(mktemp)"
+gh() { printf '%s\n' "$*" >> "$GH_CALLS_FILE"; }
+
+# ── Fixture globals process_dismissed_comments reads ────────────────────────
+
+REPO="acme/widgets"
+OWNER="acme"
+REPO_NAME="widgets"
+PR_NUMBER=123
+
+COPILOT_REPLY="This is valid in Python 3.10+, our minimum version."
+HUMAN_REPLY="Good question — it's intentional; see the comment I added."
+
+new_comments=$(cat <<JSON
+[
+  {"id": 1, "path": "src/a.py", "line": 10, "body": "copilot says fix this", "author": "Copilot", "is_copilot": true},
+  {"id": 2, "path": "src/b.py", "line": 20, "body": "human asks about this", "author": "alice", "is_copilot": false}
+]
+JSON
+)
+
+summary=$(jq -nc \
+  --arg cr "$COPILOT_REPLY" \
+  --arg hr "$HUMAN_REPLY" \
+  '{
+    fixed: [],
+    dismissed: [
+      {id: 1, confidence: "high", reason: "false positive", path: "src/a.py", line: 10, reply: $cr},
+      {id: 2, confidence: "high", reason: "intentional", path: "src/b.py", line: 20, reply: $hr}
+    ],
+    needs_human: [],
+    errors: []
+  }')
+
+# ── Scenario: one Copilot + one human dismissed comment ─────────────────────
+
+STATE_DIR="$(mktemp -d)"
+human_replies_file="$(mktemp)"
+STATE='{"dismissed_comments":[],"rounds":[]}'
+
+process_dismissed_comments "$summary" "$new_comments" 1
+
+# gh is called exactly once — only for the Copilot comment.
+gh_call_count=$(wc -l < "$GH_CALLS_FILE" | tr -d ' ')
+assert "gh called exactly once" test "$gh_call_count" -eq 1
+
+# That one call targets the Copilot comment (id 1) and carries the Copilot reply.
+assert "gh call targets Copilot comment 1" \
+  grep -q 'comments/1/replies' "$GH_CALLS_FILE"
+assert "gh call carries the Copilot reply text" \
+  grep -qF "$COPILOT_REPLY" "$GH_CALLS_FILE"
+
+# The human comment (id 2) is NEVER posted.
+assert_not "human comment 2 is never posted" \
+  grep -q 'comments/2/replies' "$GH_CALLS_FILE"
+assert_not "human reply text is never posted" \
+  grep -qF "$HUMAN_REPLY" "$GH_CALLS_FILE"
+
+# Only the Copilot thread is queued for resolution.
+resolve_str="${RESOLVE_ARGS[*]}"
+assert "only Copilot thread queued for resolution" \
+  test "$resolve_str" = "--comment-id 1"
+
+# The human reply is gathered to a persistent file with the exact body.
+human_file="${STATE_DIR}/acme-widgets-123-reply-2.txt"
+assert "human reply file exists" test -f "$human_file"
+assert "human reply file holds the drafted reply" \
+  test "$(cat "$human_file")" = "$HUMAN_REPLY"
+
+# No reply file is written for the Copilot comment (it was posted, not gathered).
+assert_not "no gathered file for Copilot comment" \
+  test -f "${STATE_DIR}/acme-widgets-123-reply-1.txt"
+
+# The human-replies index has exactly one entry, for comment 2.
+index_count=$(wc -l < "$human_replies_file" | tr -d ' ')
+assert "human-replies index has one entry" test "$index_count" -eq 1
+indexed_id=$(jq -r '.id' "$human_replies_file")
+assert "indexed entry is comment 2" test "$indexed_id" -eq 2
+indexed_author=$(jq -r '.author' "$human_replies_file")
+assert "indexed entry records author" test "$indexed_author" = "alice"
+indexed_reply=$(jq -r '.reply' "$human_replies_file")
+assert "indexed entry records the reply" test "$indexed_reply" = "$HUMAN_REPLY"
+
+# Both comments are recorded in state so they're filtered in future rounds.
+state_dismissed=$(echo "$STATE" | jq '.dismissed_comments | length')
+assert "both dismissed comments recorded in state" test "$state_dismissed" -eq 2
+
+# ── Scenario: empty dismissed array is a safe no-op ─────────────────────────
+
+: > "$GH_CALLS_FILE"
+human_replies_file="$(mktemp)"
+empty_summary='{"fixed":[],"dismissed":[],"needs_human":[],"errors":[]}'
+
+process_dismissed_comments "$empty_summary" "$new_comments" 2
+
+gh_call_count=$(wc -l < "$GH_CALLS_FILE" | tr -d ' ')
+assert "no gh calls when nothing dismissed" test "$gh_call_count" -eq 0
+assert "no resolution args when nothing dismissed" test "${#RESOLVE_ARGS[@]}" -eq 0
+empty_index_count=$(wc -l < "$human_replies_file" | tr -d ' ')
+assert "no gathered replies when nothing dismissed" test "$empty_index_count" -eq 0
+
+# ── Results ─────────────────────────────────────────────────────────────────
+
+print_results


### PR DESCRIPTION
Make `address-pr-reviews` and `copilot-review-loop` stop replying to human reviewers automatically. Copilot's auto-reply and resolve behavior is unchanged. Replies to humans are drafted and gathered so I can review and post them myself.

## Interactive skill (address-pr-reviews)

Not-legit comments now branch by author. Copilot comments get a drafted reply posted and the thread resolved, same as before. Human comments get a drafted reply only, never posted. The finalize step presents those drafts (file:line, the comment, the draft, and a `gh api … -F body=@<file>` command) for me to post.

## The loop (copilot-review-loop.sh)

Claude now posts nothing. It drafts a reply for every not-legit comment in a new `reply` field, and the script does the posting: it posts and resolves Copilot threads, and gathers human replies. Removing `Bash(gh api *)` from `--allowedTools` means a misclassification cannot auto-reply to anyone, so this is a hard guarantee rather than a prompt-only one.

Human replies are written to persistent files under `~/.local/state/copilot-review-loop/` and printed at the end under "Human Reviewer Replies to Post" with a shell-safe `-F body=@file` post command, so quotes and newlines in the reply don't break the command.

The routing is extracted into `process_dismissed_comments` with a source guard so it can be tested directly.

## Test plan

- `bin/lib/test-dismissed-replies.sh` (new, 17 assertions) exercises the real routing: gh is called exactly once for the Copilot comment and never for the human one, the human reply is gathered to a file, both comments are recorded in state, and an empty dismissed set is a no-op.
- Run the full lib suite: `for t in bin/lib/test-*.sh; do bash "$t"; done`. All green.
- `shellcheck -S error bin/copilot-review-loop.sh bin/lib/test-dismissed-replies.sh` reports no errors.

## Notes

The interactive skill is gather-and-present: it never posts to humans, I post. Switching to ask-then-post in interactive mode would be a one-line change.

A human reply is printed once, at the end of the run it's drafted in. On a later re-run, state filtering hides that comment so the draft isn't re-printed, though the file remains under `~/.local/state/copilot-review-loop/`.

https://claude.ai/code/session_01PbH59BdrLcefnDs4Yx46Vn