### PR TITLE
Add review-prs.sh to review specific PRs

### DIFF
--- a/bin/lib/git-worktree.sh
+++ b/bin/lib/git-worktree.sh
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
-# git-worktree.sh - Helpers for parsing `git worktree` output
+# git-worktree.sh - Helpers for parsing and creating git worktrees
 #
 # Source this file:
 #   source "${SCRIPT_DIR}/lib/git-worktree.sh"
 #
-# Uses the documented porcelain format and literal (not regex) matching, so
-# branch names with metacharacters and paths with spaces are handled safely.
+# Parsing uses the documented porcelain format and literal (not regex)
+# matching, so branch names with metacharacters and paths with spaces are
+# handled safely.
 
 # Print the path of the worktree for the given branch, or nothing if none.
 worktree_path_for() {
@@ -32,4 +33,35 @@ list_worktrees_excluding_main() {
     /^branch refs\/heads\// { branch = substr($0, 19) }
     END { flush() }
   '
+}
+
+# Create a worktree at <path> on branch <branch>, starting at <committish>.
+# Prints the worktree's path on stdout; git's own output goes to stderr so the
+# stdout capture stays clean for the caller.
+#
+# Idempotent across the common re-run cases:
+#   - branch already has a worktree -> print its existing path, touch nothing
+#   - branch exists without a worktree -> attach a worktree to it (ignores
+#     <committish>, since the branch already points somewhere)
+#   - neither exists -> create the branch at <committish> and its worktree
+#
+# Runs `git` in the current directory, so call it from inside the target repo
+# (any of its worktrees works). Returns non-zero if `git worktree add` fails.
+worktree_create() {
+  local path="$1" branch="$2" committish="$3"
+
+  local existing
+  existing=$(worktree_path_for "$branch")
+  if [[ -n "$existing" ]]; then
+    echo "$existing"
+    return 0
+  fi
+
+  if git show-ref --verify --quiet "refs/heads/${branch}"; then
+    git worktree add "$path" "$branch" >&2 || return 1
+  else
+    git worktree add -b "$branch" "$path" "$committish" >&2 || return 1
+  fi
+
+  echo "$path"
 }

--- a/bin/lib/test-git-worktree.sh
+++ b/bin/lib/test-git-worktree.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+# Tests for worktree_create in git-worktree.sh.
+#
+# Usage: test-git-worktree.sh
+#
+# Builds a throwaway git repo in a temp dir, exercises worktree_create against
+# it, and cleans up on exit.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# shellcheck source=bin/lib/test-helpers.sh
+source "$SCRIPT_DIR/test-helpers.sh"
+# shellcheck source=bin/lib/git-worktree.sh
+source "$SCRIPT_DIR/git-worktree.sh"
+
+# ── Fixture: a small repo with two commits ─────────────────────────────────
+
+# Resolve through symlinks (macOS /var -> /private/var) so the literal paths
+# we build match the canonical paths `git worktree list` reports.
+REPO_DIR=$(cd "$(mktemp -d)" && pwd -P)
+WT_BASE=$(cd "$(mktemp -d)" && pwd -P)
+trap 'rm -rf "$REPO_DIR" "$WT_BASE"' EXIT
+
+git -C "$REPO_DIR" init -q
+git -C "$REPO_DIR" config user.email test@example.com
+git -C "$REPO_DIR" config user.name "Test"
+# A stable default branch name regardless of the host's init.defaultBranch.
+git -C "$REPO_DIR" checkout -q -b main
+echo one > "$REPO_DIR/file"
+git -C "$REPO_DIR" add file
+git -C "$REPO_DIR" commit -qm "one"
+echo two > "$REPO_DIR/file"
+git -C "$REPO_DIR" commit -qam "two"
+HEAD_SHA=$(git -C "$REPO_DIR" rev-parse HEAD)
+PREV_SHA=$(git -C "$REPO_DIR" rev-parse HEAD~1)
+
+# worktree_create runs git in the current directory, so operate from the repo.
+cd "$REPO_DIR"
+
+# ── Test: creates a worktree on a new branch at the given commit ───────────
+
+path="${WT_BASE}/review-repo-1"
+out=$(worktree_create "$path" "review-repo-1" "$PREV_SHA")
+assert "prints the worktree path it created" test "$out" = "$path"
+assert "worktree directory exists" test -d "$path"
+assert "worktree HEAD is the requested commit" \
+  test "$(git -C "$path" rev-parse HEAD)" = "$PREV_SHA"
+assert "new branch was created for the worktree" \
+  test "$(git -C "$path" rev-parse --abbrev-ref HEAD)" = "review-repo-1"
+
+# ── Test: idempotent when the branch already has a worktree ────────────────
+
+out=$(worktree_create "${WT_BASE}/somewhere-else" "review-repo-1" "$HEAD_SHA")
+assert "re-run returns the existing worktree path, ignoring the new path arg" \
+  test "$out" = "$path"
+assert "re-run does not create the alternate path" \
+  test ! -d "${WT_BASE}/somewhere-else"
+assert "re-run leaves the worktree at its original commit" \
+  test "$(git -C "$path" rev-parse HEAD)" = "$PREV_SHA"
+
+# ── Test: attaches a worktree to a pre-existing branch ─────────────────────
+
+git branch review-repo-2 "$HEAD_SHA"
+path2="${WT_BASE}/review-repo-2"
+out=$(worktree_create "$path2" "review-repo-2" "$PREV_SHA")
+assert "attaches to an existing branch and prints its path" test "$out" = "$path2"
+assert "existing-branch worktree stays at the branch tip, not <committish>" \
+  test "$(git -C "$path2" rev-parse HEAD)" = "$HEAD_SHA"
+
+# ── Test: returns non-zero and prints nothing when `git worktree add` fails ──
+# prepare_run_dir captures stdout into a path and branches on the exit code, so
+# a failure must both return non-zero and emit no path.
+
+mkdir -p "${WT_BASE}/occupied"
+echo blocker > "${WT_BASE}/occupied/file"
+rc=0
+out=$(worktree_create "${WT_BASE}/occupied" "review-repo-3" "$HEAD_SHA" 2>/dev/null) || rc=$?
+assert "returns non-zero when git worktree add fails" test "$rc" -ne 0
+assert "prints nothing on failure so the caller captures no path" test -z "$out"
+
+# ── Results ────────────────────────────────────────────────────────────────
+
+print_results

--- a/bin/review-prs.sh
+++ b/bin/review-prs.sh
@@ -1,0 +1,353 @@
+#!/usr/bin/env bash
+# review-prs.sh - Review specific PRs of the current repo
+#
+# For each PR you name, this runs `/review-code <pr-url> --force --draft`,
+# leaving a pending (unsubmitted) GitHub review with inline comments. Reviewing
+# by URL needs no local checkout, so by default the review runs in the current
+# directory.
+#
+# Pass --worktree to instead create a git worktree off the current repo at each
+# PR's head commit and run the review inside it. Worktrees are left in place so
+# you can open one and act on the review (apply fixes, push).
+#
+# Usage:
+#   review-prs.sh PR [PR...] [--repo OWNER/NAME]
+#
+# PR is a PR number or a full PR URL. Bare numbers resolve against --repo if
+# given, otherwise against the repo of the current directory. You can therefore
+# run it from anywhere as long as you pass --repo.
+#
+# Options:
+#   --repo OWNER/NAME  Target repo for bare PR numbers (default: current repo)
+#   --worktree         Create a worktree per PR and review inside it
+#   --remote NAME      Git remote to fetch PR heads from with --worktree
+#                      (default: origin)
+#   --dry-run          Show what would happen without making changes
+#   -h, --help         Show this help message
+#
+# --worktree builds each worktree from the git repo you are standing in, so it
+# requires the current directory to be a checkout of the target repo. Combining
+# --worktree with a --repo that differs from the current repo is an error.
+#
+# With --worktree, each worktree is created at
+#   ~/dev/worktrees/<repo>/review-<repo>-<pr>
+# on a branch of the same name (review-<repo>-<pr>).
+#
+# Reviews run sequentially. A stuck review is bounded by a wall-clock timeout
+# so it can't hang forever.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/lib/logging.sh"
+source "${SCRIPT_DIR}/lib/github.sh"
+source "${SCRIPT_DIR}/lib/git-worktree.sh"
+
+# Where per-repo worktrees live, matching the ~/dev/worktrees/<repo>/<branch>
+# convention. Overridable for tests.
+WORKTREES_DIR="${REVIEW_PRS_WORKTREES_DIR:-${HOME}/dev/worktrees}"
+REMOTE="origin"
+REPO_FLAG=""
+WORKTREE=false
+DRY_RUN=false
+# Generous enough for a full multi-agent review; bounds a stuck run so it can't
+# hang the terminal indefinitely.
+REVIEW_TIMEOUT_SECONDS=1800
+# SIGKILL this many seconds after SIGTERM if claude ignores the timeout.
+REVIEW_KILL_AFTER_SECONDS=60
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") PR [PR...] [OPTIONS]
+
+Review specific PRs by number or URL.
+
+PR is a PR number or a full PR URL. Bare numbers resolve against --repo if
+given, otherwise against the current directory's repo.
+
+Options:
+  --repo OWNER/NAME  Target repo for bare PR numbers (default: current repo)
+  --worktree         Create a worktree per PR and review inside it
+  --remote NAME      Git remote to fetch PR heads from with --worktree
+                     (default: origin)
+  --dry-run          Show what would happen without making changes
+  -h, --help         Show this help message
+
+By default the review runs in the current directory (reviewing by URL needs no
+checkout). With --worktree, each worktree is created at
+~/dev/worktrees/<repo>/review-<repo>-<pr> and left in place after the review;
+--worktree requires the current directory to be a checkout of the target repo.
+
+Examples:
+  $(basename "$0") 123                          # PR #123 of the current repo
+  $(basename "$0") 123 456 789                  # Three PRs in sequence
+  $(basename "$0") 123 456 --repo posthog/posthog  # PRs of another repo
+  $(basename "$0") --worktree 123               # Review inside a new worktree
+  $(basename "$0") --dry-run 123                # Show what would happen
+EOF
+  exit 0
+}
+
+PR_ARGS=()
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --repo)
+      if [[ -z "${2:-}" || "${2:-}" == --* ]]; then
+        log_error "--repo requires a repo as OWNER/NAME"
+        exit 1
+      fi
+      if [[ ! "$2" =~ ^[^/]+/[^/]+$ ]]; then
+        log_error "--repo must be in OWNER/NAME form (got: $2)"
+        exit 1
+      fi
+      REPO_FLAG="$2"
+      shift 2
+      ;;
+    --worktree)
+      WORKTREE=true
+      shift
+      ;;
+    --remote)
+      if [[ -z "${2:-}" || "${2:-}" == --* ]]; then
+        log_error "--remote requires a remote name"
+        exit 1
+      fi
+      REMOTE="$2"
+      shift 2
+      ;;
+    --dry-run)
+      DRY_RUN=true
+      shift
+      ;;
+    -h|--help)
+      usage
+      ;;
+    -*)
+      log_error "Unknown option: $1"
+      usage
+      ;;
+    *)
+      PR_ARGS+=("$1")
+      shift
+      ;;
+  esac
+done
+
+if [[ "${#PR_ARGS[@]}" -eq 0 ]]; then
+  log_error "No PRs specified."
+  usage
+fi
+
+check_prerequisites() {
+  local required=(claude gh timeout caffeinate)
+  # git is only used to fetch heads and build worktrees.
+  [[ "$WORKTREE" == "true" ]] && required+=(git)
+
+  local missing=false
+  for cmd in "${required[@]}"; do
+    if ! command -v "$cmd" &>/dev/null; then
+      log_error "Required command not found: ${cmd}"
+      missing=true
+    fi
+  done
+  [[ "$missing" == "true" ]] && exit 1
+
+  if ! gh auth status &>/dev/null; then
+    log_error "Not authenticated with GitHub. Run 'gh auth login' first."
+    exit 1
+  fi
+}
+
+# True if any positional PR argument is a bare number (needs a default repo).
+args_have_bare_number() {
+  local a
+  for a in "${PR_ARGS[@]}"; do
+    [[ "$a" =~ ^[0-9]+$ ]] && return 0
+  done
+  return 1
+}
+
+# Resolve a PR argument (number or URL). Sets the globals PR_NUMBER, PR_URL,
+# and PR_REPO (owner/name). A bare number resolves against <default_repo>; a
+# URL carries its own repo. Returns non-zero if the argument is malformed or a
+# bare number is given with no default repo available.
+resolve_pr() {
+  local arg="$1" default_repo="$2"
+
+  if [[ "$arg" =~ ^[0-9]+$ ]]; then
+    if [[ -z "$default_repo" ]]; then
+      log_error "PR ${arg} is a bare number but no repo is set."
+      log_error "Pass --repo OWNER/NAME, run from inside the repo, or use a full PR URL."
+      return 1
+    fi
+    PR_NUMBER="$arg"
+    PR_REPO="$default_repo"
+    PR_URL="https://github.com/${default_repo}/pull/${arg}"
+    return 0
+  fi
+
+  if parse_pr_url "$arg"; then
+    # parse_pr_url sets PR_NUMBER and REPO.
+    PR_REPO="$REPO"
+    PR_URL="$arg"
+    return 0
+  fi
+
+  log_error "Invalid PR argument: ${arg} (expected a number or a PR URL)."
+  return 1
+}
+
+# Prepare the worktree for a PR and print the directory the review should run
+# in. With --worktree, fetches the PR head and creates the worktree. Returns
+# non-zero on failure.
+prepare_run_dir() {
+  local pr_number="$1" repo_name="$2"
+
+  local name="review-${repo_name}-${pr_number}"
+  local path="${WORKTREES_DIR}/${repo_name}/${name}"
+  log_info "Worktree: ${path}" >&2
+
+  # Worktrees are left in place, so a re-run reuses an existing one as-is: it is
+  # not advanced to a newer head if the PR gained commits. Short-circuit before
+  # fetching so re-runs skip the network round trip. Remove it with
+  # `git worktree remove <path>` for a fresh checkout.
+  local existing
+  existing=$(worktree_path_for "$name")
+  if [[ -n "$existing" ]]; then
+    log_success "Worktree ready (reused): ${existing}" >&2
+    echo "$existing"
+    return 0
+  fi
+
+  # Bring the PR head into the local repo so the new worktree can start at it.
+  log_info "Fetching PR head from ${REMOTE}…" >&2
+  if ! git fetch "$REMOTE" "pull/${pr_number}/head" >&2; then
+    log_error "Failed to fetch pull/${pr_number}/head from ${REMOTE}."
+    return 1
+  fi
+  local head
+  head=$(git rev-parse FETCH_HEAD)
+
+  mkdir -p "${WORKTREES_DIR}/${repo_name}"
+
+  local wt
+  if ! wt=$(worktree_create "$path" "$name" "$head"); then
+    log_error "Failed to create worktree for PR #${pr_number}."
+    return 1
+  fi
+  log_success "Worktree ready: ${wt}" >&2
+  echo "$wt"
+}
+
+# Review one PR. Returns the run's exit code.
+review_one() {
+  local pr_url="$1" pr_number="$2" repo_name="$3"
+
+  log_section "PR #${pr_number}"
+  log_info "URL: ${pr_url}"
+
+  if [[ "$DRY_RUN" == "true" ]]; then
+    if [[ "$WORKTREE" == "true" ]]; then
+      log_info "[DRY RUN] Would fetch ${REMOTE} pull/${pr_number}/head and create worktree review-${repo_name}-${pr_number}"
+    fi
+    log_info "[DRY RUN] Would run: claude -p \"/review-code ${pr_url} --force --draft\""
+    return 0
+  fi
+
+  # Default to the current directory; reviewing by URL needs no checkout.
+  local run_dir="."
+  if [[ "$WORKTREE" == "true" ]]; then
+    if ! run_dir=$(prepare_run_dir "$pr_number" "$repo_name"); then
+      return 1
+    fi
+  fi
+
+  # Run the review in a subshell so the parent stays in the repo root for the
+  # next PR. The heartbeat must start from the main shell.
+  #
+  # --force skips the skill's interactive pre-flight prompt, which a headless
+  # `claude -p` run cannot answer. --draft posts a pending GitHub review with
+  # inline comments (left unsubmitted for you to review and submit).
+  local exit_code=0
+  start_heartbeat 30 "Claude reviewing PR #${pr_number}"
+  (
+    cd "$run_dir" || exit 1
+    caffeinate -i timeout --kill-after="$REVIEW_KILL_AFTER_SECONDS" \
+      "$REVIEW_TIMEOUT_SECONDS" \
+      claude -p "/review-code ${pr_url} --force --draft"
+  ) || exit_code=$?
+  stop_heartbeat
+
+  if [[ "$exit_code" -eq 0 ]]; then
+    log_success "Review complete for PR #${pr_number}"
+  elif [[ "$exit_code" -eq 124 || "$exit_code" -eq 137 ]]; then
+    log_error "Review for PR #${pr_number} timed out after ${REVIEW_TIMEOUT_SECONDS}s"
+  else
+    log_error "Review for PR #${pr_number} failed (exit code: ${exit_code})"
+  fi
+  if [[ "$WORKTREE" == "true" ]]; then
+    log_info "Worktree left in place: ${run_dir}"
+  fi
+  return "$exit_code"
+}
+
+main() {
+  trap 'stop_heartbeat' EXIT
+
+  check_prerequisites
+
+  # --worktree builds the worktree from the repo of the current directory, so
+  # that repo must be the one we're reviewing. Resolve it and reject a --repo
+  # that points elsewhere.
+  local cwd_repo=""
+  if [[ "$WORKTREE" == "true" ]]; then
+    cwd_repo=$(get_current_repo)
+    if [[ -n "$REPO_FLAG" && "$REPO_FLAG" != "$cwd_repo" ]]; then
+      log_error "--worktree builds from the current repo (${cwd_repo}); --repo ${REPO_FLAG} differs."
+      log_error "Run from inside ${REPO_FLAG}, or drop --worktree."
+      exit 1
+    fi
+  fi
+
+  # The repo that bare PR numbers resolve against: --repo if given, else the
+  # current directory's repo. Inferred from cwd only when a bare number needs
+  # it, so an all-URL invocation works from anywhere without --repo.
+  local default_repo="$REPO_FLAG"
+  if [[ -z "$default_repo" ]]; then
+    default_repo="$cwd_repo"  # set above only under --worktree
+  fi
+  if [[ -z "$default_repo" ]] && args_have_bare_number; then
+    default_repo=$(get_current_repo)
+  fi
+  [[ -n "$default_repo" ]] && log_info "Default repo: ${default_repo}"
+
+  local failed=0
+  for arg in "${PR_ARGS[@]}"; do
+    if ! resolve_pr "$arg" "$default_repo"; then
+      ((failed++)) || true
+      continue
+    fi
+
+    # A full URL can name a foreign repo even under --worktree (bare numbers
+    # always resolve to cwd_repo, so they never reach here). Skip those rather
+    # than abort the whole batch; the up-front --repo guard covers bare numbers.
+    if [[ "$WORKTREE" == "true" && "$PR_REPO" != "$cwd_repo" ]]; then
+      log_error "Skipping ${arg}: it is in ${PR_REPO}, but --worktree builds from ${cwd_repo}."
+      ((failed++)) || true
+      continue
+    fi
+
+    if ! review_one "$PR_URL" "$PR_NUMBER" "${PR_REPO##*/}"; then
+      ((failed++)) || true
+    fi
+  done
+
+  log_section "Done"
+  if [[ "$failed" -gt 0 ]]; then
+    log_warn "${failed} PR(s) did not complete cleanly."
+    exit 1
+  fi
+  log_success "All requested reviews finished."
+}
+
+main "$@"


### PR DESCRIPTION
- Adds `bin/review-prs.sh`, a script that runs `/review-code <pr-url> --force --draft` for each named PR, leaving a pending GitHub review with inline comments.
- Adds `worktree_create()` to `bin/lib/git-worktree.sh`: idempotent worktree creation that handles three cases (branch and worktree already exist, branch exists without a worktree, neither exists).
- Adds `bin/lib/test-git-worktree.sh` with four tests covering the new function.

With `--worktree`, each PR gets its own worktree at `~/dev/worktrees/<repo>/review-<repo>-<pr>` so you can open the checkout and act on the review. Reviews run sequentially with a 30-minute wall-clock timeout bounded by `caffeinate` and `timeout`.

## Test plan

- Run `bin/lib/test-git-worktree.sh` to verify the four worktree_create cases pass.
- Run `bin/review-prs.sh --dry-run 123` from inside a repo to confirm it prints the expected actions without touching anything.
- Run `bin/review-prs.sh --help` to confirm usage output is correct.