### PR TITLE
Surface internal Feature Flags PRs missing a team label in daily triage

### DIFF
--- a/ai/agents/triage-feature-flags.md
+++ b/ai/agents/triage-feature-flags.md
@@ -1,11 +1,13 @@
 ---
 name: triage-feature-flags
-description: Analyzes GitHub issues and external PRs to identify those belonging to the Feature Flags team domain (feature flags, cohorts, early access). Used by the triage-issues command.
+description: Analyzes GitHub issues and PRs (external and internal) to identify those belonging to the Feature Flags team domain (feature flags, cohorts, early access). Used by the triage-issues command.
 model: haiku
 color: orange
 ---
 
-You are a triage specialist for the **Feature Flags team** at PostHog. Your job is to analyze GitHub issues and external pull requests and identify which ones belong to this team's domain.
+You are a triage specialist for the **Feature Flags team** at PostHog. Your job is to analyze GitHub issues and pull requests (both external community PRs and internal PostHog-authored ones) and identify which ones belong to this team's domain.
+
+Internal PRs are pre-filtered to those touching flags-domain file paths, so a touched flags path is a given for them — not evidence on its own. Many are incidental: a dependency bump, a cross-cutting Django/ORM chore, a refactor, or another team's feature that happens to brush a flags file. Judge whether the PR is *about* feature flags, cohorts, or early access, not whether it merely touches one of those files.
 
 Classify each item from its title, labels, and (for PRs) changed file paths. Body text is not always provided. When a title and labels are ambiguous and you need the body to make a confident call, set confidence to MEDIUM or LOW and note that the body would help. The orchestrator will fetch the body for those items and pass it back for a second pass.
 
@@ -47,19 +49,22 @@ When you identify a relevant issue, suggest one or more of these labels:
 - "beta" (could be early access or general)
 - "toggle" (could be feature flag or UI toggle)
 
-**File-path signals** (for PRs, when changed file paths are provided; these outweigh a vague title):
+**File-path signals** (for PRs, when changed file paths are provided). A PR whose **primary** changes are in flags code is a strong signal that outweighs a vague title:
 
-- `posthog/api/feature_flag*`, `posthog/models/feature_flag/`
+- `posthog/api/feature_flag*`, `posthog/models/feature_flag/`, `products/feature_flags/`
 - `rust/feature-flags/`
 - `frontend/src/scenes/feature-flags/`
-- `posthog/models/cohort/`, `frontend/src/scenes/cohorts/`
-- early access feature code paths
+- `posthog/api/cohort.py`, `posthog/models/cohort/`, `products/cohorts/`, `frontend/src/scenes/cohorts/`
+- early access feature code paths (`products/early_access_features/`)
+
+But weigh the footprint: a PR that only **brushes** one of these files (a snapshot, a shared model, a generated schema) while its real subject is elsewhere — a dependency bump, an ORM-wide chore, another product's feature — is incidental, not a flags PR. Use the title's conventional scope and the balance of changed paths to tell "about flags" from "touches flags."
 
 ## What to Skip
 
-Do NOT suggest labeling issues that:
+Do NOT suggest labeling issues or PRs that:
 
 - Mention feature flags only in passing (e.g., "this bug happens when feature flag X is enabled")
+- Only incidentally touch a flags-domain file: dependency bumps, cross-cutting Django/ORM or test-infrastructure chores, broad refactors, or another team's feature whose changes are dominated by non-flags paths
 - Are primarily about experiments/A/B testing results analysis (that's the Experiments team)
 - Are about the feature flags UI but are clearly frontend bugs unrelated to flag logic
 - Are billing issues related to feature flag quotas (that's the Growth team)
@@ -67,7 +72,7 @@ Do NOT suggest labeling issues that:
 
 ## Output Format
 
-For each candidate item, provide (use "PR" instead of "Issue" for pull requests, and include the author for external PRs):
+For each candidate item, provide (use "PR" instead of "Issue" for pull requests, and include the author for PRs):
 
 ```markdown
 ### Issue #NUMBER - TITLE

--- a/ai/agents/triage-feature-flags.md
+++ b/ai/agents/triage-feature-flags.md
@@ -75,7 +75,7 @@ Do NOT suggest labeling issues or PRs that:
 For each candidate item, provide (use "PR" instead of "Issue" for pull requests, and include the author for PRs):
 
 ```markdown
-### Issue #NUMBER - TITLE
+### Issue|PR #NUMBER - TITLE
 
 **Current labels:** label1, label2 (or "none")
 **Suggested labels:** team/feature-flags, feature/cohorts

--- a/ai/skills/triage-issues/SKILL.md
+++ b/ai/skills/triage-issues/SKILL.md
@@ -88,7 +88,7 @@ Internal (org-member) PRs are routed to teams by reviewer assignment, not labels
 
 This step is **feature-flags only** (the helper and its path net are flags-specific). Skip it for other teams.
 
-Run the helper script, which finds internal non-bot unlabeled PRs in the window, fetches their changed files in parallel, and keeps only those touching flags-domain paths (a deliberately broad net — recall here, precision in the subagent):
+Run the helper script, which finds internal non-bot PRs missing a flags team label in the window, fetches their changed files in parallel, and keeps only those touching flags-domain paths (a deliberately broad net — recall here, precision in the subagent):
 
 ```bash
 triage-flags-pr-candidates --days {days}

--- a/ai/skills/triage-issues/SKILL.md
+++ b/ai/skills/triage-issues/SKILL.md
@@ -94,7 +94,7 @@ Run the helper script, which finds internal non-bot PRs missing a flags team lab
 triage-flags-pr-candidates --days {days}
 ```
 
-It prints a JSON array on stdout: `[{ "number", "title", "author", "paths" }]`. The `paths` are the specific flags-domain files each PR touched — carry them forward as the file-path signal for the subagent (do not re-fetch files for these). If it prints `[]`, there are no internal candidates.
+It prints a JSON array on stdout, one object per PR: `{"number": 123, "title": "…", "author": "…", "paths": ["…"]}`. The `paths` are the specific flags-domain files each PR touched — carry them forward as the file-path signal for the subagent (do not re-fetch files for these). If it prints `[]`, there are no internal candidates.
 
 ### Step 3c: Early Exit
 
@@ -141,7 +141,7 @@ Labeling, by item type:
 - **Issues and external PRs**: apply labels to HIGH-confidence candidates only; never label MEDIUM or LOW.
 - **Internal PRs (Step 3b): report only — do not apply any labels yet**, at any confidence. This is intentional while the path-net + subagent precision is validated against real digests. They appear in the digest as would-be candidates; flipping them to auto-label HIGH is a deliberate later change.
 
-Apply all Step 4 renames; the scope match is mechanical and needs no confidence gating. (Title renames are mechanical, so they apply to internal PRs too.) If a label application or rename fails, note it in the digest and continue without retrying. Then emit a Slack-friendly digest as your final output:
+Title renames (Step 4) apply in both modes without a separate prompt — the scope match is mechanical and needs no confidence gating. In interactive mode they are part of what the user approves via "all"; they apply to internal PRs too. If a label application or rename fails, note it in the digest and continue without retrying. Then emit a Slack-friendly digest as your final output:
 
 1. Header: `{team name} triage — <date>` with counts: issues scanned, external PRs scanned, internal PRs matched, auto-labeled, renamed, needing decision. Add a one-line note that this is a label queue, not project-board membership (the board is reviewer-driven).
 2. `External PRs` — every external PR matched to the domain at any confidence: link, title, author, review state (the `reviewDecision` carried from Step 3), labels applied or suggested, confidence. This section comes first; these are the items most often missed.

--- a/ai/skills/triage-issues/SKILL.md
+++ b/ai/skills/triage-issues/SKILL.md
@@ -82,9 +82,23 @@ done
 
 **Body fetching:** Issue and PR bodies are not fetched in bulk. After the subagent returns its initial classification (Step 5), fetch bodies individually only for items the subagent flags as needing more context (typically MEDIUM or LOW confidence candidates where the title and labels are ambiguous). Use `gh issue view {number} --repo PostHog/posthog --json body` or `gh pr view {number} --repo PostHog/posthog --json body`, then pass the bodies back to the subagent for a refined classification. Do not fetch bodies for HIGH-confidence candidates or items already skipped.
 
-### Step 3b: Early Exit
+### Step 3b: Fetch Internal Feature Flags PR Candidates
 
-If both the issues list and the external PRs list are empty (zero items returned), print the "nothing to triage" digest line for the team and date and stop. Do not proceed to Step 4 or spawn the subagent.
+Internal (org-member) PRs are routed to teams by reviewer assignment, not labels, so a flags-domain internal PR that never gets the team requested as a reviewer (a CODEOWNERS coverage gap, or a footprint too small to trigger assignment) lands on no board and carries no label. This step surfaces those.
+
+This step is **feature-flags only** (the helper and its path net are flags-specific). Skip it for other teams.
+
+Run the helper script, which finds internal non-bot unlabeled PRs in the window, fetches their changed files in parallel, and keeps only those touching flags-domain paths (a deliberately broad net — recall here, precision in the subagent):
+
+```bash
+triage-flags-pr-candidates --days {days}
+```
+
+It prints a JSON array on stdout: `[{ "number", "title", "author", "paths" }]`. The `paths` are the specific flags-domain files each PR touched — carry them forward as the file-path signal for the subagent (do not re-fetch files for these). If it prints `[]`, there are no internal candidates.
+
+### Step 3c: Early Exit
+
+If the issues list, the external PRs list, and the internal PR candidates are all empty (zero items returned), print the "nothing to triage" digest line for the team and date and stop. Do not proceed to Step 4 or spawn the subagent.
 
 ### Step 4: Detect Title Scope Renames
 
@@ -100,10 +114,12 @@ Use the Task tool to spawn the appropriate triage subagent:
 
 - For `feature-flags`: Use subagent `triage-feature-flags`
 
-Pass the fetched issues and external PRs (marked as such, with file paths where collected) to the subagent for analysis. The subagent will:
+Pass the fetched issues, external PRs, and internal PR candidates (Step 3b) to the subagent, each marked as such and with file paths where collected. The subagent will:
 
 1. Analyze each item against the team's domain
 2. Return candidates with confidence levels and suggested labels
+
+The internal PR candidates are pre-filtered to those touching flags-domain paths, so many are incidental (a chore, dependency bump, or other team's PR that brushes a flags file). Rely on the subagent to reject those — the path match is only a recall net, not a verdict.
 
 ### Step 6: Apply Labels and Renames, and Report
 
@@ -116,16 +132,24 @@ gh issue edit --repo PostHog/posthog {number} --title "{new title}"    # renames
 gh pr edit {number} --repo PostHog/posthog --title "{new title}"       # renames (PRs)
 ```
 
-**Interactive mode** (default): show the user a summary ("Found X issues and Y external PRs from the last Z days, N candidates for {team} team, M title renames") and the candidate list — number and title (linked), current labels, suggested labels, confidence, brief reasoning — plus the proposed renames (old title → new title). Then ask which to apply: specific numbers, "all", or "none".
+**Interactive mode** (default): show the user a summary ("Found X issues, Y external PRs, and Z internal PR candidates from the last N days, C candidates for {team} team, M title renames") and the candidate list — number and title (linked), current labels, suggested labels, confidence, brief reasoning — plus the proposed renames (old title → new title). Then ask which to apply: specific numbers, "all", or "none".
 
-**Unattended mode**: do not ask anything. Apply labels to HIGH-confidence candidates only; never label MEDIUM or LOW. Apply all Step 4 renames; the scope match is mechanical and needs no confidence gating. If a label application or rename fails, note it in the digest and continue without retrying. Then emit a Slack-friendly digest as your final output:
+**Unattended mode**: do not ask anything.
 
-1. Header: `{team name} triage — <date>` with counts: issues scanned, external PRs scanned, auto-labeled, renamed, needing decision.
+Labeling, by item type:
+
+- **Issues and external PRs**: apply labels to HIGH-confidence candidates only; never label MEDIUM or LOW.
+- **Internal PRs (Step 3b): report only — do not apply any labels yet**, at any confidence. This is intentional while the path-net + subagent precision is validated against real digests. They appear in the digest as would-be candidates; flipping them to auto-label HIGH is a deliberate later change.
+
+Apply all Step 4 renames; the scope match is mechanical and needs no confidence gating. (Title renames are mechanical, so they apply to internal PRs too.) If a label application or rename fails, note it in the digest and continue without retrying. Then emit a Slack-friendly digest as your final output:
+
+1. Header: `{team name} triage — <date>` with counts: issues scanned, external PRs scanned, internal PRs matched, auto-labeled, renamed, needing decision. Add a one-line note that this is a label queue, not project-board membership (the board is reviewer-driven).
 2. `External PRs` — every external PR matched to the domain at any confidence: link, title, author, review state (the `reviewDecision` carried from Step 3), labels applied or suggested, confidence. This section comes first; these are the items most often missed.
-3. `Auto-labeled (HIGH)`: item link, title, labels applied.
-4. `Renamed titles`: item link, old title → new title.
-5. `Needs a human decision (MEDIUM/LOW)`: item link, title, suggested labels, confidence, one-line reasoning.
-6. Any errors.
+3. `Internal PRs missing flags label (report only)` — every internal PR the subagent matched to the domain at any confidence: link, title, author, the suggested labels (not applied), confidence, one-line reasoning. Note these are not labeled automatically yet.
+4. `Auto-labeled (HIGH)`: item link, title, labels applied (issues and external PRs only).
+5. `Renamed titles`: item link, old title → new title.
+6. `Needs a human decision (MEDIUM/LOW)`: item link, title, suggested labels, confidence, one-line reasoning.
+7. Any errors.
 
 If there are no candidates and no renames, the digest is the single line: `{team name} triage — <date>: nothing to triage.`
 

--- a/bin/triage-flags-pr-candidates
+++ b/bin/triage-flags-pr-candidates
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# triage-flags-pr-candidates - Emit internal Feature Flags PR candidates that
+# lack a flags label, for the triage-issues skill to classify.
+#
+# Finds open PostHog/posthog PRs authored by org members (excluding bots) that
+# carry no feature-flags label, fetches their changed files, and keeps only
+# those touching flags-domain paths. The path net is deliberately broad: recall
+# lives here, precision lives in the triage-feature-flags subagent that judges
+# whatever this emits. Output is a JSON array on stdout:
+#   [{ "number": N, "title": "…", "author": "…", "paths": ["…"] }]
+# Progress logs go to stderr so stdout stays pure JSON.
+#
+# Read-only: it only reads PR metadata and changed filenames. It never reads PR
+# bodies or applies labels, so it stays outside the untrusted-content boundary
+# the triage-issues skill enforces with its tool allowlist.
+#
+# Usage: triage-flags-pr-candidates [--days N] [--limit N]
+
+set -euo pipefail
+
+DAYS=7
+LIMIT=1000
+REPO="PostHog/posthog"
+PARALLEL=15
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --days) DAYS="$2"; shift 2 ;;
+    --limit) LIMIT="$2"; shift 2 ;;
+    *) echo "Unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+# Broad flags-domain path net. Intentionally fuzzy: it catches feature flags,
+# cohorts, and early access wherever they live — including paths CODEOWNERS-soft
+# doesn't map to the team, which is exactly the coverage gap that lets these PRs
+# slip past reviewer auto-assignment in the first place.
+FLAGS_PATH_RE='feature_flag|cohort|early[-_]access|/flags/|rust/feature-flags'
+
+# Bots are org members, so an author-association filter alone pulls them in.
+# Exclude them explicitly, matching the bot exclusions in PostHog's CI workflows.
+BOT_RE='\[bot\]|^posthog-bot$|dependabot|github-actions'
+
+since=$(date -v-"${DAYS}"d +%Y-%m-%d 2>/dev/null || date -d "${DAYS} days ago" +%Y-%m-%d)
+echo "Searching $REPO for internal unlabeled PRs since ${since}…" >&2
+
+tmp_rows=$(mktemp)
+tmp_files=$(mktemp)
+trap 'rm -f "$tmp_rows" "$tmp_files"' EXIT
+
+# Internal (org-member) non-bot PRs lacking any flags label → number\tauthor\ttitle.
+# @tsv escapes any embedded tabs/newlines, so the columns stay parseable below.
+gh search prs --repo "$REPO" --state open --limit "$LIMIT" \
+  --json number,title,author,authorAssociation \
+  -- "created:>=$since -label:team/feature-flags -label:feature/feature-flags -label:feature/cohorts -label:feature/early-access" \
+  | jq -r --arg bots "$BOT_RE" '
+      .[]
+      | select(.authorAssociation=="MEMBER" or .authorAssociation=="OWNER" or .authorAssociation=="COLLABORATOR")
+      | select((.author.login | test($bots)) | not)
+      | [.number, .author.login, .title] | @tsv' > "$tmp_rows"
+
+nrows=$(grep -c . "$tmp_rows" || true)
+echo "Found ${nrows} internal non-bot unlabeled PRs; fetching changed files…" >&2
+
+if [[ "${nrows}" -eq 0 ]]; then
+  echo '[]'
+  exit 0
+fi
+
+# Fetch changed files for each PR in parallel → number\tpath lines. A failed
+# fetch for one PR (deleted, transient) must not abort the batch.
+cut -f1 "$tmp_rows" \
+  | xargs -P "$PARALLEL" -I{} sh -c \
+      'gh api "repos/'"$REPO"'/pulls/{}/files" --paginate --jq ".[].filename" 2>/dev/null | sed "s|^|{}\t|"' \
+  > "$tmp_files" || true
+
+nmatch=$(cut -f2- "$tmp_files" | grep -ciE "$FLAGS_PATH_RE" || true)
+echo "PRs touching flags-domain paths: keeping candidates from ${nmatch} matched file(s)…" >&2
+
+# Join matched PRs with their titles/authors and the specific flags paths they hit.
+jq -Rn \
+  --rawfile rowsRaw "$tmp_rows" \
+  --rawfile filesRaw "$tmp_files" \
+  --arg re "$FLAGS_PATH_RE" '
+    ($filesRaw | split("\n") | map(select(length > 0) | split("\t"))
+      | map(select(length >= 2 and (.[1] | test($re; "i"))))
+      | group_by(.[0])
+      | map({ key: .[0][0], value: (map(.[1]) | unique) })
+      | from_entries) as $pathsByNum
+    | ($rowsRaw | split("\n") | map(select(length > 0) | split("\t")))
+    | map(select($pathsByNum[.[0]] != null))
+    | map({ number: (.[0] | tonumber), author: .[1], title: .[2], paths: $pathsByNum[.[0]] })
+  '

--- a/bin/triage-run
+++ b/bin/triage-run
@@ -26,7 +26,8 @@ RUN_KILL_AFTER_SECONDS="${TRIAGE_KILL_AFTER_SECONDS:-60}"
 
 # This run ingests untrusted text (public GitHub issue and PR bodies), so it
 # gets exactly the tools the job needs instead of bypassPermissions: the gh
-# fetches and label edits from the triage-issues skill, Skill/Task to invoke
+# fetches and label edits from the triage-issues skill, the internal-PR
+# candidate helper (read-only gh fetches + path filtering), Skill/Task to invoke
 # the skill and its subagent, ToolSearch to load the Slack tool schema, and
 # the one Slack send tool for the DM. Everything else is denied.
 WORKER_ALLOWED_TOOLS=(
@@ -42,6 +43,7 @@ WORKER_ALLOWED_TOOLS=(
   "Bash(gh pr view:*)"
   "Bash(gh issue edit:*)"
   "Bash(gh pr edit:*)"
+  "Bash(triage-flags-pr-candidates:*)"
   "mcp__claude_ai_Slack__slack_send_message"
 )
 


### PR DESCRIPTION
## What

Adds a daily-triage step that surfaces internal PostHog-authored PRs touching feature-flags, cohort, or early-access code that carry no flags label and so never land on the team's project board.

## Why

The flags project board is populated by reviewer assignment, not labels. A flags-domain internal PR that never gets the team requested as a reviewer (a CODEOWNERS coverage gap, or a footprint too small to trigger assignment) gets no label and no board entry, and slips past the team. The existing triage scanned only external community PRs, so these internal ones were invisible.

## How

- **New `bin/triage-flags-pr-candidates`**: searches internal non-bot unlabeled PRs in the window, parallel-fetches changed files, and keeps only those hitting a broad flags-path net (`feature_flag`, `cohort`, `early[-_]access`, `/flags/`, `rust/feature-flags`). Recall lives in the net; precision lives in the subagent. About 30s for ~275 PRs. Read-only, so it stays outside the untrusted-content boundary the triage job enforces.
- **`triage-issues` skill**: new Step 3b runs the helper and feeds candidates to the `triage-feature-flags` subagent; the digest gains an "Internal PRs missing flags label" section.
- **`triage-feature-flags` agent**: now expects internal PRs and weighs footprint (a PR *about* flags vs one that merely *brushes* a flags file) to reject incidental dependency/chore/refactor/other-team touches.
- **`triage-run`**: one new allowlist entry for the helper.

The path net is intentionally broader than CODEOWNERS-soft: the PRs we miss are partly the CODEOWNERS coverage gap itself, so a filter derived from CODEOWNERS would reproduce that exact blind spot.

## Report-only for now

Internal candidates are listed in the digest but not auto-labeled, at any confidence, while the path-net plus subagent precision is validated against real digests. Flipping them to auto-label HIGH is a one-line follow-up. Issues and external PRs keep auto-labeling HIGH-confidence matches as before.

## Validation

End-to-end unattended run against PostHog/posthog:

- 276 internal non-bot unlabeled PRs → 15 touched flags paths (filtered in ~30s, no LLM)
- subagent matched 8 to the domain, rejected 7 as incidental (dependency bumps, ORM chores, dashboards/slack_app PRs brushing a flags file)
- 0 PRs labeled (report-only), digest DM delivered

This produces a label-filtered queue, not board membership (the board is reviewer-driven).

## Follow-ups (out of scope)

- Bump the external-PR fetch limit (currently 30; on busy days the 30 most-recent can all be same-day, paging out older external PRs still inside the window).
- After a few clean digests, flip internal candidates to auto-label HIGH.
