### PR TITLE
Fix tree-me pr to push back to contributor fork branches

### DIFF
--- a/bin/README-tree-me.md
+++ b/bin/README-tree-me.md
@@ -66,7 +66,7 @@ tree-me pr 123                              # By PR number
 tree-me pr https://github.com/org/repo/pull/456  # By URL
 ```
 
-Fetches the PR and creates a worktree at `~/dev/worktrees/<repo>/pr-123`.
+Checks out the PR (via `gh pr checkout`) into a worktree at `~/dev/worktrees/<repo>/pr-123`. The local branch matches the PR's head branch (falling back to `pr-123` if that name is already taken locally), so for PRs from forks with "Allow edits from maintainers" enabled a bare `git push` goes straight back to the contributor's branch.
 
 ### List worktrees
 

--- a/bin/tree-me
+++ b/bin/tree-me
@@ -245,20 +245,39 @@ EOF
             exit 1
         fi
 
-        # Use gh to checkout PR in a worktree
-        branch="pr-$pr_number"
-        path="$WORKTREE_ROOT/$repo/$branch"
+        # The worktree directory is keyed on the PR number (stable, unique per
+        # PR), so re-runs and same-named branches from different forks never
+        # collide. The local branch matches the PR's head branch so a bare
+        # `git push` goes straight back to it.
+        path="$WORKTREE_ROOT/$repo/pr-$pr_number"
 
-        existing=$(worktree_path_for "$branch")
-        if [ -n "$existing" ]; then
-            echo "✓ Worktree already exists: $existing"
-            echo "TREE_ME_CD:$existing"
+        if [ -d "$path" ] && git -C "$path" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+            echo "✓ Worktree already exists: $path"
+            echo "TREE_ME_CD:$path"
             exit 0
         fi
 
-        # Fetch the PR and create worktree
-        git fetch origin "pull/$pr_number/head:$branch" 2>/dev/null || true
-        git worktree add "$path" "$branch"
+        # Name the branch after the PR's head ref. Fall back to pr-<number> when
+        # that name is unknown or already taken by a local branch (e.g. the head
+        # ref is "master", or another fork's PR already claimed it).
+        head_branch=$(gh pr view "$pr_number" --json headRefName -q .headRefName 2>/dev/null || true)
+        branch="${head_branch:-pr-$pr_number}"
+        if [ "$branch" != "pr-$pr_number" ] && git show-ref --verify --quiet "refs/heads/$branch"; then
+            echo "ℹ Branch '$branch' already exists locally; using 'pr-$pr_number' instead" >&2
+            branch="pr-$pr_number"
+        fi
+
+        # Create a detached worktree, then let `gh pr checkout` create the
+        # branch inside it. Delegating to gh sets up the push/tracking config so
+        # that PRs from forks with "Allow edits from maintainers" enabled push
+        # back to the contributor's branch. A plain `git fetch pull/N/head`
+        # leaves the branch disconnected from the PR.
+        git worktree add --detach "$path" >&2
+        if ! (cd "$path" && gh pr checkout "$pr_number" --branch "$branch" >&2); then
+            git worktree remove --force "$path" 2>/dev/null || true
+            echo "Error: Failed to check out PR #$pr_number" >&2
+            exit 1
+        fi
         echo "✓ PR #$pr_number checked out at: $path"
 
         # Track with Graphite if available (use --force to auto-detect parent)


### PR DESCRIPTION
`tree-me pr` was fetching PRs with `git fetch origin pull/N/head:pr-N`, which creates a disconnected local branch. When a contributor enables "Allow edits from maintainers," there's nowhere to push because git has no tracking config for where the PR came from.

The fix creates a detached worktree first, then runs `gh pr checkout` inside it. That sets `branch.<name>.remote`, `.pushremote`, and `.merge` to point at the contributor's fork, so a bare `git push` goes back to the PR branch without any extra flags.

The local branch now also matches the PR's head ref (e.g. `patch-1`) instead of always being `pr-N`. The worktree directory stays keyed on the PR number (`pr-123`) so two fork PRs sharing a head ref name don't collide. If the head ref is already taken locally, the branch falls back to `pr-<number>` with a note.

## Test plan

- Run `tree-me pr <number>` against a fork PR where the contributor has "Allow edits from maintainers" enabled.
- Confirm the local branch matches the PR's head branch name.
- Confirm `git config --get-regexp 'branch\.<name>\.'` shows `remote` and `pushremote` pointing at the fork URL.
- Confirm `git push --dry-run` resolves to the contributor's branch without extra flags.
- Re-run `tree-me pr <number>` and confirm it detects the existing worktree without recreating it.
- Run `tree-me pr <number>` when a local branch already has the same name as the PR head ref; confirm it falls back to `pr-<number>` with a note.