### PR TITLE
Generalize bot reviewer handling from Copilot-only to all GitHub Apps

### DIFF
--- a/ai/skills/address-pr-reviews/SKILL.md
+++ b/ai/skills/address-pr-reviews/SKILL.md
@@ -68,7 +68,7 @@ Run the fetch script:
 ~/.claude/skills/address-pr-reviews/scripts/fetch-unaddressed-comments.sh <repo> <pr_number>
 ```
 
-This returns a JSON array of every **unresolved** inline review comment on the PR — from any reviewer — minus ones you've previously dismissed. Each comment has `id`, `path`, `line`, `body`, `diff_hunk`, `author` (the reviewer's login), and `is_copilot` (true when Copilot authored it).
+This returns a JSON array of every **unresolved** inline review comment on the PR — from any reviewer — minus ones you've previously dismissed. Each comment has `id`, `path`, `line`, `body`, `diff_hunk`, `author` (the reviewer's login), and `is_bot` (true when a bot authored it — Copilot, Greptile, Graphite, or any other GitHub App; false for human reviewers).
 
 If the array is empty, report "No unaddressed review comments to process" and stop.
 
@@ -119,8 +119,8 @@ With user confirmation:
 
 **For not-legit comments, branch on who authored the comment:**
 
-- **Copilot (`is_copilot` true):** Draft a concise, professional reply explaining why the code is correct, show the draft to the user, then post it: `gh api "repos/<repo>/pulls/<pr_number>/comments/<comment_id>/replies" --method POST -f body='<reply>'`. Resolve the thread: `~/.dotfiles/bin/gh-resolve-threads "https://github.com/<repo>/pull/<pr_number>" --comment-id <comment_id>`.
-- **Human reviewers (`is_copilot` false):** Do **not** post anything. Draft the reply and hold it for the user to review and post themselves (see Step 6). Leave the thread unresolved so the reviewer gets the last word.
+- **Bots (`is_bot` true — Copilot, Greptile, Graphite, or any other GitHub App):** Draft a concise, professional reply explaining why the code is correct, show the draft to the user, then post it: `gh api "repos/<repo>/pulls/<pr_number>/comments/<comment_id>/replies" --method POST -f body='<reply>'`. Resolve the thread: `~/.dotfiles/bin/gh-resolve-threads "https://github.com/<repo>/pull/<pr_number>" --comment-id <comment_id>`.
+- **Human reviewers (`is_bot` false):** Do **not** post anything. Draft the reply and hold it for the user to review and post themselves (see Step 6). Leave the thread unresolved so the reviewer gets the last word.
 
 Never auto-post a reply to a human reviewer. The user reviews and posts those replies.
 

--- a/ai/skills/address-pr-reviews/scripts/fetch-unaddressed-comments.sh
+++ b/ai/skills/address-pr-reviews/scripts/fetch-unaddressed-comments.sh
@@ -5,7 +5,7 @@
 #
 # Output: JSON array of unresolved inline review comments from any reviewer
 # (Copilot, humans, other bots) that have NOT been previously dismissed.
-# Each comment has: {id, path, line, body, diff_hunk, author, is_copilot}
+# Each comment has: {id, path, line, body, diff_hunk, author, is_bot}
 #
 # Reads dismissed-comment hashes from the shared state file at:
 #   ~/.local/state/copilot-review-loop/{owner}-{repo_name}-{pr_number}.json

--- a/bin/copilot-review-loop.sh
+++ b/bin/copilot-review-loop.sh
@@ -112,20 +112,21 @@ add_dismissed() {
 }
 
 # True (exit 0) when the comment with this id in the given JSON array was
-# authored by Copilot. Gates auto-resolution: we resolve Copilot threads but
-# leave human reviewers' threads open so they get the last word.
-is_copilot_comment() {
+# authored by a bot (Copilot, Greptile, Graphite, …). Gates auto-resolution: we
+# reply to and resolve bot threads but leave human reviewers' threads open so they
+# get the last word.
+is_bot_comment() {
   local comments_json="$1" comment_id="$2"
   [[ "$(echo "$comments_json" | jq -r --argjson id "$comment_id" \
-    '.[] | select(.id == $id) | .is_copilot')" == "true" ]]
+    '.[] | select(.id == $id) | .is_bot')" == "true" ]]
 }
 
 # Process the comments Claude classified as not-legit (dismissed). Claude drafted
 # a reply for each but posted nothing, so the routing happens here: post the reply
-# to Copilot threads (and queue them for resolution via RESOLVE_ARGS), record every
-# dismissed comment in state so it's filtered next round, and gather replies to
-# human reviewers into $human_replies_file for the user to post manually. Human
-# replies are never posted automatically.
+# to bot threads (Copilot, Greptile, Graphite, …) and queue them for resolution via
+# RESOLVE_ARGS, record every dismissed comment in state so it's filtered next round,
+# and gather replies to human reviewers into $human_replies_file for the user to
+# post manually. Human replies are never posted automatically.
 #
 # Args:    summary_json  new_comments_json  round
 # Reads:   REPO PR_NUMBER OWNER REPO_NAME STATE_DIR human_replies_file
@@ -146,17 +147,17 @@ process_dismissed_comments() {
     reply=$(echo "$summary" | jq -r --argjson id "$dismissed_id" \
       '.dismissed // [] | .[] | select(.id == $id) | .reply // ""')
 
-    if is_copilot_comment "$new_comments" "$dismissed_id"; then
+    if is_bot_comment "$new_comments" "$dismissed_id"; then
       # Post Claude's drafted reply, and resolve the thread only once it posts.
       # Resolving a thread with no reply on it would swallow the dismissal
       # rationale, so an empty draft or a failed post leaves the thread open.
       if [[ -z "$reply" ]]; then
-        log_warn "No reply drafted for Copilot comment ${dismissed_id}; leaving thread open"
+        log_warn "No reply drafted for bot comment ${dismissed_id}; leaving thread open"
       elif gh api "repos/${REPO}/pulls/${PR_NUMBER}/comments/${dismissed_id}/replies" \
         --method POST -f body="$reply" --silent 2>/dev/null; then
         RESOLVE_ARGS+=(--comment-id "$dismissed_id")
       else
-        log_warn "Failed to post reply to Copilot comment ${dismissed_id}; leaving thread open"
+        log_warn "Failed to post reply to bot comment ${dismissed_id}; leaving thread open"
       fi
     else
       # Human reviewer: gather the reply for the user to post manually. Persist
@@ -245,7 +246,7 @@ build_prompt() {
   cat <<PROMPT_EOF
 You are triaging unresolved inline PR review comments on ${REPO}#${PR_NUMBER}, round ${round}.
 The comments come from any reviewer — Copilot, humans, and other bots. Each comment's
-JSON includes an "author" login and an "is_copilot" flag.
+JSON includes an "author" login and an "is_bot" flag.
 
 Your job is to classify each comment and act on it.
 
@@ -270,12 +271,13 @@ or reflects a misunderstanding of the language/framework.
 - Do NOT post anything to GitHub. Do not call gh, the API, or resolve any thread.
 - Instead, draft a concise, respectful explanation of why the code is correct and return
   it in the "reply" field of this comment's summary entry (see output format below).
-- The wrapper script handles posting: it posts your reply to Copilot threads and resolves
-  them, and it gathers replies to human reviewers for the user to post manually. Your only
-  job for not-legit comments is to write the reply text.
-- If Copilot is likely to flag the same pattern again (e.g., a modern language feature
-  that resembles a bug to static analysis, an intentional design choice), add a brief
-  clarifying source comment so future reviewers, human or automated, understand the
+- The wrapper script handles posting: it posts your reply to bot threads (Copilot,
+  Greptile, Graphite, …) and resolves them, and it gathers replies to human reviewers
+  for the user to post manually. Your only job for not-legit comments is to write the
+  reply text.
+- If a bot reviewer is likely to flag the same pattern again (e.g., a modern language
+  feature that resembles a bug to static analysis, an intentional design choice), add a
+  brief clarifying source comment so future reviewers, human or automated, understand the
   intent. This prevents the same comment from being raised every round.
 
 **needs-human**: you are genuinely uncertain, or the comment raises a concern outside
@@ -597,10 +599,10 @@ main() {
         local i
         for ((i = 0; i < ${#skipped_ids[@]}; i++)); do
           local cid="${skipped_ids[$i]}"
-          # Only re-ack Copilot threads. Human reviewers already got a reply when
+          # Only re-ack bot threads. Human reviewers already got a reply when
           # their comment was first dismissed and we leave their threads open, so
           # re-acking every run would spam them with duplicate replies.
-          if ! is_copilot_comment "$comments" "$cid"; then
+          if ! is_bot_comment "$comments" "$cid"; then
             continue
           fi
           local orig_round="${skipped_orig_rounds[$i]:-?}"

--- a/bin/lib/copilot.sh
+++ b/bin/lib/copilot.sh
@@ -38,8 +38,16 @@ COPILOT_LOGIN_JQ='(ascii_downcase | . == "copilot" or . == "copilot-pull-request
 
 # jq transform: GraphQL reviewThread nodes -> the inline-comment shape the rest of
 # the toolchain consumes. Keeps only unresolved threads, takes each thread's root
-# comment, and tags it with the author login and an is_copilot flag so callers can
-# decide whether to auto-resolve (Copilot) or only reply (human reviewers).
+# comment, and tags it with the author login and an is_bot flag so callers can
+# decide whether to auto-resolve (any bot: Copilot, Greptile, Graphite, …) or only
+# draft a reply for the user to post (human reviewers).
+#
+# is_bot keys off the GraphQL author type, which resolves every GitHub App identity
+# to "Bot" — the authoritative signal, since the login is unreliable (Copilot's
+# review login is "copilot-pull-request-reviewer", with no "[bot]" suffix to match
+# on). OR'd with the Copilot login check so Copilot always counts as a bot even if
+# its author type ever changes. A human whose handle merely contains "copilot" is a
+# "User", so they stay on the human path.
 # Exposed as a constant so the unit test exercises the exact same program.
 UNRESOLVED_COMMENTS_JQ='
   [ .[]
@@ -53,7 +61,7 @@ UNRESOLVED_COMMENTS_JQ='
         body: $c.body,
         diff_hunk: $c.diffHunk,
         author: ($c.author.login // "unknown"),
-        is_copilot: (($c.author.login // "") | '"$COPILOT_LOGIN_JQ"')
+        is_bot: ((($c.author.__typename // "") == "Bot") or (($c.author.login // "") | '"$COPILOT_LOGIN_JQ"'))
       }
   ]
 '
@@ -184,7 +192,7 @@ fetch_review_comments() {
 
 # Fetch every unresolved inline review comment on the PR, regardless of author
 # (Copilot, humans, other bots). Returns a JSON array of the root comment of each
-# unresolved thread: {id, path, line, body, diff_hunk, author, is_copilot}.
+# unresolved thread: {id, path, line, body, diff_hunk, author, is_bot}.
 # Walks reviewThreads via GraphQL with pagination. Only the thread's first comment
 # is emitted; replies are context, not separate action items.
 fetch_unresolved_review_comments() {
@@ -205,7 +213,7 @@ fetch_unresolved_review_comments() {
                   line
                   body
                   diffHunk
-                  author { login }
+                  author { login __typename }
                 }
               }
             }

--- a/bin/lib/test-dismissed-replies.sh
+++ b/bin/lib/test-dismissed-replies.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 # Tests for process_dismissed_comments routing in copilot-review-loop.sh.
 #
-# The routing is safety-critical: Copilot dismissed comments get their drafted
-# reply POSTED and queued for resolution, while human dismissed comments are
-# only GATHERED to files for the user to post manually, never posted here.
+# The routing is safety-critical: bot dismissed comments (Copilot, Greptile,
+# Graphite, …) get their drafted reply POSTED and queued for resolution, while
+# human dismissed comments are only GATHERED to files for the user to post
+# manually, never posted here.
 #
 # Usage: test-dismissed-replies.sh
 
@@ -37,20 +38,23 @@ REPO_NAME="widgets"
 PR_NUMBER=123
 
 COPILOT_REPLY="This is valid in Python 3.10+, our minimum version."
+GREPTILE_REPLY="The null case is handled by the guard clause above."
 HUMAN_REPLY="Good question; it's intentional, see the comment I added."
 HUMAN_REPLY_2="Already covered by the validation above."
 
 new_comments=$(cat <<JSON
 [
-  {"id": 1, "path": "src/a.py", "line": 10, "body": "copilot says fix this", "author": "Copilot", "is_copilot": true},
-  {"id": 2, "path": "src/b.py", "line": 20, "body": "alice asks about this", "author": "alice", "is_copilot": false},
-  {"id": 3, "path": "src/c.py", "line": 30, "body": "bob asks about this", "author": "bob", "is_copilot": false}
+  {"id": 1, "path": "src/a.py", "line": 10, "body": "copilot says fix this", "author": "Copilot", "is_bot": true},
+  {"id": 2, "path": "src/b.py", "line": 20, "body": "alice asks about this", "author": "alice", "is_bot": false},
+  {"id": 3, "path": "src/c.py", "line": 30, "body": "bob asks about this", "author": "bob", "is_bot": false},
+  {"id": 4, "path": "src/d.py", "line": 40, "body": "greptile flags this", "author": "greptile-apps", "is_bot": true}
 ]
 JSON
 )
 
 summary=$(jq -nc \
   --arg cr "$COPILOT_REPLY" \
+  --arg gr "$GREPTILE_REPLY" \
   --arg hr "$HUMAN_REPLY" \
   --arg hr2 "$HUMAN_REPLY_2" \
   '{
@@ -58,13 +62,14 @@ summary=$(jq -nc \
     dismissed: [
       {id: 1, confidence: "high", reason: "false positive", path: "src/a.py", line: 10, reply: $cr},
       {id: 2, confidence: "high", reason: "intentional", path: "src/b.py", line: 20, reply: $hr},
-      {id: 3, confidence: "high", reason: "already handled", path: "src/c.py", line: 30, reply: $hr2}
+      {id: 3, confidence: "high", reason: "already handled", path: "src/c.py", line: 30, reply: $hr2},
+      {id: 4, confidence: "high", reason: "false positive", path: "src/d.py", line: 40, reply: $gr}
     ],
     needs_human: [],
     errors: []
   }')
 
-# ── Scenario: one Copilot + two human dismissed comments ────────────────────
+# ── Scenario: two bot (Copilot + Greptile) + two human dismissed comments ───
 
 STATE_DIR="$TESTTMP/state"
 mkdir -p "$STATE_DIR"
@@ -74,15 +79,21 @@ STATE='{"dismissed_comments":[],"rounds":[]}'
 
 process_dismissed_comments "$summary" "$new_comments" 1
 
-# gh is called exactly once, only for the Copilot comment.
+# gh is called exactly twice, once for each bot comment.
 gh_call_count=$(wc -l < "$GH_CALLS_FILE" | tr -d ' ')
-assert "gh called exactly once" test "$gh_call_count" -eq 1
+assert "gh called exactly twice" test "$gh_call_count" -eq 2
 
-# That one call targets the Copilot comment (id 1) and carries the Copilot reply.
+# The Copilot comment (id 1) is posted with the Copilot reply.
 assert "gh call targets Copilot comment 1" \
   grep -q 'comments/1/replies' "$GH_CALLS_FILE"
 assert "gh call carries the Copilot reply text" \
   grep -qF "$COPILOT_REPLY" "$GH_CALLS_FILE"
+
+# The non-Copilot bot comment (id 4, Greptile) is also posted with its reply.
+assert "gh call targets Greptile comment 4" \
+  grep -q 'comments/4/replies' "$GH_CALLS_FILE"
+assert "gh call carries the Greptile reply text" \
+  grep -qF "$GREPTILE_REPLY" "$GH_CALLS_FILE"
 
 # Neither human comment (id 2, id 3) is ever posted.
 assert_not "human comment 2 is never posted" \
@@ -92,10 +103,10 @@ assert_not "human comment 3 is never posted" \
 assert_not "human reply text is never posted" \
   grep -qF "$HUMAN_REPLY" "$GH_CALLS_FILE"
 
-# Only the Copilot thread is queued for resolution.
+# Both bot threads are queued for resolution; neither human thread is.
 resolve_str="${RESOLVE_ARGS[*]}"
-assert "only Copilot thread queued for resolution" \
-  test "$resolve_str" = "--comment-id 1"
+assert "both bot threads queued for resolution" \
+  test "$resolve_str" = "--comment-id 1 --comment-id 4"
 
 # Each human reply is gathered to its own persistent file with the exact body.
 assert "human reply file for comment 2 exists" \
@@ -107,9 +118,11 @@ assert "human reply file for comment 3 exists" \
 assert "human reply file 3 holds the drafted reply" \
   test "$(cat "${STATE_DIR}/acme-widgets-123-reply-3.txt")" = "$HUMAN_REPLY_2"
 
-# No reply file is written for the Copilot comment (it was posted, not gathered).
+# No reply file is written for either bot comment (they were posted, not gathered).
 assert_not "no gathered file for Copilot comment" \
   test -f "${STATE_DIR}/acme-widgets-123-reply-1.txt"
+assert_not "no gathered file for Greptile comment" \
+  test -f "${STATE_DIR}/acme-widgets-123-reply-4.txt"
 
 # The human-replies index accumulates one line per human comment (not overwritten).
 index_count=$(wc -l < "$human_replies_file" | tr -d ' ')
@@ -121,9 +134,9 @@ assert "index records the author for comment 2" test "$entry2_author" = "alice"
 entry2_reply=$(jq -r 'select(.id == 2) | .reply' "$human_replies_file")
 assert "index records the reply for comment 2" test "$entry2_reply" = "$HUMAN_REPLY"
 
-# All three dismissed comments are recorded in state so they're filtered next round.
+# All four dismissed comments are recorded in state so they're filtered next round.
 state_dismissed=$(echo "$STATE" | jq '.dismissed_comments | length')
-assert "all dismissed comments recorded in state" test "$state_dismissed" -eq 3
+assert "all dismissed comments recorded in state" test "$state_dismissed" -eq 4
 
 # ── Scenario: a Copilot comment with an empty reply is left unresolved ──────
 # Resolution requires a posted reply. An empty draft means nothing to say, so we

--- a/bin/lib/test-unresolved-comments.sh
+++ b/bin/lib/test-unresolved-comments.sh
@@ -19,37 +19,42 @@ transform() {
 }
 
 # ── Test data ─────────────────────────────────────────────────────────────
-# A mix of resolved/unresolved threads, Copilot/human/null authors, a thread
-# with no root comment, a null databaseId (a pending review comment), the
-# production Copilot bot login, a human handle that contains "copilot", and a
-# thread with a reply (only its root should be emitted).
+# A mix of resolved/unresolved threads and authors that exercise the is_bot gate:
+# a Copilot comment with no __typename (must fall back to the login check), the
+# production Copilot bot login typed as "Bot", a non-Copilot bot (Greptile) typed
+# as "Bot", a human, a human whose handle contains "copilot", and a null author.
+# Plus a thread with no root comment, a null databaseId (a pending review comment),
+# and a thread with a reply (only its root should be emitted).
 
 nodes='[
   {"isResolved": false, "comments": {"nodes": [
     {"databaseId": 1, "path": "src/a.py", "line": 10, "body": "Copilot says fix this", "diffHunk": "@@ -1 +1 @@", "author": {"login": "Copilot"}}
   ]}},
   {"isResolved": true, "comments": {"nodes": [
-    {"databaseId": 2, "path": "src/b.py", "line": 20, "body": "resolved already", "diffHunk": "@@", "author": {"login": "Copilot"}}
+    {"databaseId": 2, "path": "src/b.py", "line": 20, "body": "resolved already", "diffHunk": "@@", "author": {"login": "Copilot", "__typename": "Bot"}}
   ]}},
   {"isResolved": false, "comments": {"nodes": [
-    {"databaseId": 3, "path": "src/c.py", "line": 30, "body": "human nit", "diffHunk": "@@", "author": {"login": "octocat"}}
+    {"databaseId": 3, "path": "src/c.py", "line": 30, "body": "human nit", "diffHunk": "@@", "author": {"login": "octocat", "__typename": "User"}}
   ]}},
   {"isResolved": false, "comments": {"nodes": []}},
   {"isResolved": false, "comments": {"nodes": [
     {"databaseId": 5, "path": "src/e.py", "line": null, "body": "ghost author", "diffHunk": "@@", "author": null}
   ]}},
   {"isResolved": false, "comments": {"nodes": [
-    {"databaseId": 6, "path": "src/f.py", "line": 60, "body": "real bot login", "diffHunk": "@@", "author": {"login": "copilot-pull-request-reviewer"}}
+    {"databaseId": 6, "path": "src/f.py", "line": 60, "body": "real bot login", "diffHunk": "@@", "author": {"login": "copilot-pull-request-reviewer", "__typename": "Bot"}}
   ]}},
   {"isResolved": false, "comments": {"nodes": [
-    {"databaseId": 7, "path": "src/g.py", "line": 70, "body": "human handle contains copilot", "diffHunk": "@@", "author": {"login": "copilot-fan"}}
+    {"databaseId": 7, "path": "src/g.py", "line": 70, "body": "human handle contains copilot", "diffHunk": "@@", "author": {"login": "copilot-fan", "__typename": "User"}}
   ]}},
   {"isResolved": false, "comments": {"nodes": [
-    {"databaseId": null, "path": "src/h.py", "line": 80, "body": "pending review comment", "diffHunk": "@@", "author": {"login": "octocat"}}
+    {"databaseId": null, "path": "src/h.py", "line": 80, "body": "pending review comment", "diffHunk": "@@", "author": {"login": "octocat", "__typename": "User"}}
   ]}},
   {"isResolved": false, "comments": {"nodes": [
-    {"databaseId": 9, "path": "src/i.py", "line": 90, "body": "thread root", "diffHunk": "@@", "author": {"login": "octocat"}},
-    {"databaseId": 10, "path": "src/i.py", "line": 90, "body": "a reply", "diffHunk": "@@", "author": {"login": "Copilot"}}
+    {"databaseId": 9, "path": "src/i.py", "line": 90, "body": "thread root", "diffHunk": "@@", "author": {"login": "octocat", "__typename": "User"}},
+    {"databaseId": 10, "path": "src/i.py", "line": 90, "body": "a reply", "diffHunk": "@@", "author": {"login": "Copilot", "__typename": "Bot"}}
+  ]}},
+  {"isResolved": false, "comments": {"nodes": [
+    {"databaseId": 11, "path": "src/j.py", "line": 110, "body": "greptile nit", "diffHunk": "@@", "author": {"login": "greptile-apps", "__typename": "Bot"}}
   ]}}
 ]'
 
@@ -58,10 +63,10 @@ result=$(echo "$nodes" | transform)
 # ── Test: only unresolved threads with a non-null root comment id survive ───
 
 count=$(echo "$result" | jq 'length')
-assert "keeps 6 of 9 threads (drops resolved, empty-comment, null databaseId)" test "$count" -eq 6
+assert "keeps 7 of 10 threads (drops resolved, empty-comment, null databaseId)" test "$count" -eq 7
 
 ids=$(echo "$result" | jq -c '[.[].id] | sort')
-assert "keeps comment IDs 1, 3, 5, 6, 7, 9" test "$ids" = "[1,3,5,6,7,9]"
+assert "keeps comment IDs 1, 3, 5, 6, 7, 9, 11" test "$ids" = "[1,3,5,6,7,9,11]"
 
 # ── Test: null databaseId thread is dropped ────────────────────────────────
 # GraphQL returns a null databaseId for a pending (not-yet-submitted) review
@@ -77,35 +82,42 @@ assert "reply comments are not emitted (id 10 absent)" test "$has_reply" -eq 0
 root_body_9=$(echo "$result" | jq -r '.[] | select(.id == 9) | .body')
 assert "thread root comment is emitted (id 9 body)" test "$root_body_9" = "thread root"
 
-# ── Test: Copilot authorship detected ──────────────────────────────────────
-# is_copilot matches the Copilot reviewer's exact login (case-insensitive), not a
-# substring. The "Copilot" fixture (capital C) also pins the case-insensitivity:
-# a case-sensitive match would fail this assertion.
+# ── Test: bot authorship detected ──────────────────────────────────────────
+# is_bot keys off the "Bot" author type, OR'd with the Copilot login check so
+# Copilot counts even when its __typename is absent.
 
-is_copilot_1=$(echo "$result" | jq -r '.[] | select(.id == 1) | .is_copilot')
-assert "Copilot comment flagged is_copilot=true" test "$is_copilot_1" = "true"
+# Copilot with no __typename: the login fallback must still flag it. The "Copilot"
+# fixture (capital C) also pins case-insensitivity in COPILOT_LOGIN_JQ.
+is_bot_1=$(echo "$result" | jq -r '.[] | select(.id == 1) | .is_bot')
+assert "Copilot comment flagged is_bot=true via login fallback" test "$is_bot_1" = "true"
 
-is_copilot_6=$(echo "$result" | jq -r '.[] | select(.id == 6) | .is_copilot')
-assert "production bot login flagged is_copilot=true" test "$is_copilot_6" = "true"
+# Production Copilot login typed as "Bot".
+is_bot_6=$(echo "$result" | jq -r '.[] | select(.id == 6) | .is_bot')
+assert "production Copilot login flagged is_bot=true" test "$is_bot_6" = "true"
 
-# A human handle that merely contains "copilot" is NOT Copilot; their thread must
-# stay open like any other human reviewer's.
-is_copilot_7=$(echo "$result" | jq -r '.[] | select(.id == 7) | .is_copilot')
-assert "human handle containing 'copilot' is not treated as Copilot" test "$is_copilot_7" = "false"
+# A non-Copilot bot (Greptile) typed as "Bot" must also be flagged so its thread is
+# replied to and resolved like any other bot's.
+is_bot_11=$(echo "$result" | jq -r '.[] | select(.id == 11) | .is_bot')
+assert "non-Copilot bot (Greptile) flagged is_bot=true" test "$is_bot_11" = "true"
+
+# A human handle that merely contains "copilot" is typed "User", so it is NOT a bot;
+# their thread must stay open like any other human reviewer's.
+is_bot_7=$(echo "$result" | jq -r '.[] | select(.id == 7) | .is_bot')
+assert "human handle containing 'copilot' is not a bot" test "$is_bot_7" = "false"
 
 # ── Test: human authorship detected ────────────────────────────────────────
 
-is_copilot_3=$(echo "$result" | jq -r '.[] | select(.id == 3) | .is_copilot')
-assert "human comment flagged is_copilot=false" test "$is_copilot_3" = "false"
+is_bot_3=$(echo "$result" | jq -r '.[] | select(.id == 3) | .is_bot')
+assert "human comment flagged is_bot=false" test "$is_bot_3" = "false"
 author_3=$(echo "$result" | jq -r '.[] | select(.id == 3) | .author')
 assert "human author login preserved" test "$author_3" = "octocat"
 
-# ── Test: null author falls back to unknown, not Copilot ───────────────────
+# ── Test: null author falls back to unknown, not a bot ─────────────────────
 
 author_5=$(echo "$result" | jq -r '.[] | select(.id == 5) | .author')
 assert "null author becomes 'unknown'" test "$author_5" = "unknown"
-is_copilot_5=$(echo "$result" | jq -r '.[] | select(.id == 5) | .is_copilot')
-assert "null author is not Copilot" test "$is_copilot_5" = "false"
+is_bot_5=$(echo "$result" | jq -r '.[] | select(.id == 5) | .is_bot')
+assert "null author is not a bot" test "$is_bot_5" = "false"
 
 # ── Test: GraphQL field names mapped to the consumed shape ─────────────────
 


### PR DESCRIPTION
The `address-pr-reviews` skill and `copilot-review-loop.sh` previously hard-coded Copilot as the only reviewer whose dismissed comments get auto-replied and resolved. Any other bot (Greptile, Graphite, etc.) fell through to the human path and got held for manual posting.

The fix replaces the `is_copilot` flag with `is_bot`, computed from GraphQL `author.__typename == "Bot"`. Every GitHub App resolves to that type, so the gate now covers all bots uniformly. The Copilot login check is kept as a fallback in case `__typename` is absent, which cannot happen in production but covers the synthetic fixture that documents the intent.

The autonomous loop (`copilot-review-loop.sh`) is also updated: the re-acknowledgment path at line 605 called `is_copilot_comment`, which no longer existed after the rename; that call site was the only one missed in the initial pass and would have caused `exit 127` on every iteration, silently dropping re-raised bot threads.

## Test plan

- `bash bin/lib/test-unresolved-comments.sh` — 17 assertions, including a new Greptile (`__typename: Bot`) fixture that must produce `is_bot=true`
- `bash bin/lib/test-dismissed-replies.sh` — 27 assertions, including a second bot comment (Greptile id 4) that must be posted and queued for resolution alongside the Copilot one; neither human comment may be posted