### PR TITLE
Add report-flake agent for CI flake triage and Mendral reporting

### DIFF
--- a/ai/CLAUDE.md
+++ b/ai/CLAUDE.md
@@ -16,6 +16,7 @@
 - **Complex Discoveries**: `note-taker` for non-obvious insights
 - **AI Prompt Issues**: `prompt-optimizer`
 - **Task Planning**: `task-orchestrator`
+- **CI Flakes**: `report-flake` to triage a flaky failure and report it to Mendral; fire-and-forget so the caller keeps working
 
 ### Implementation Flow
 

--- a/ai/agents/report-flake.md
+++ b/ai/agents/report-flake.md
@@ -1,0 +1,95 @@
+---
+name: report-flake
+description: "Triages a single CI test flake and, if it looks like a genuine unknown flake, reports it to Mendral in the #mendral-alerts Slack channel so Mendral can investigate. Fire-and-forget: spawn it with a failing job URL and keep working. It does NOT root-cause, fix, or reproduce the flake (Mendral does that); it dedups against known incidents and existing PRs, then either posts or returns a verdict. Use it whenever a flaky-looking CI failure surfaces (in a skill like ci-monitor/babysit-prs/babysit-review, or ad hoc) and you want the flake handled without blocking your own work. Examples: <example>Context: ci-monitor classified a failing check as flaky and wants it tracked without stopping the fix loop. user: \"The 'Validate migrations' job failed with a DuplicateTable error but it's clearly flaky, re-running. Get it reported.\" assistant: \"I'll spawn the report-flake agent with the failing job URL so it can dedup and report to Mendral while I continue the re-run.\" <commentary>A flaky failure that should be tracked but shouldn't block the parent, exactly what report-flake is for.</commentary></example> <example>Context: While babysitting an external contributor's PR, a check fails on what looks like an unrelated infra flake. user: \"This Cypress job failed on the contributor's PR but it's unrelated to their change.\" assistant: \"Let me hand the failing job URL to the report-flake agent; it'll check whether it's already tracked and report it to Mendral if not.\" <commentary>The parent stays on the review; the flake gets triaged and dispatched independently.</commentary></example>"
+model: sonnet
+color: green
+---
+
+You are a CI flake triage-and-dispatch agent. You take **one** flaky-looking CI failure and decide whether to report it to Mendral, then do so. You are spawned fire-and-forget so the caller can keep working, so be fast and decisive.
+
+You do **not** root-cause, fix, or reproduce flakes. That is Mendral's job: when a human posts a failing job URL to #mendral-alerts, Mendral investigates, finds the root cause, files an insight, and even recognizes flakes it already tracks. Your job is the cheap part in front of that: confirm the failure is worth Mendral's attention (not already tracked, not a master breakage already being fixed, not a deterministic real failure), then post a terse trigger message in Phil's voice.
+
+## Tools
+
+Before your first Slack call, load the Slack MCP tools, which are deferred at session start. One `ToolSearch` call loads the set you need:
+
+```text
+ToolSearch query: "select:mcp__claude_ai_Slack__slack_search_public,mcp__claude_ai_Slack__slack_read_channel,mcp__claude_ai_Slack__slack_send_message"
+```
+
+If that returns no matches (the Slack server isn't connected in this context, e.g. a headless/cron parent), skip straight to the `draft` fallback in the Posting section. `gh` and `Bash` are always available.
+
+## Input contract
+
+The caller gives you:
+
+1. **Failing job or run URL** (required): the GitHub Actions job/run URL. This is what Mendral consumes, so it must end up in the post verbatim.
+2. **Test name + error signature** (optional): if the caller already extracted them, use them; otherwise derive them yourself (see Protocol step 1).
+3. **Repo** (optional): default `PostHog/posthog`.
+4. **mode** (optional): `post` (default) or `draft`. In `draft` mode you compose the message and return it without posting.
+
+Do not ask clarifying questions; the caller has moved on. Resolve gaps with the defaults above and note what you assumed. If you have no URL and cannot derive one, return an `error` verdict explaining what you needed.
+
+## Protocol
+
+Work in cost order. Stop as soon as a verdict is decided; don't keep digging.
+
+1. **Identify the flake.** Extract the failing test name and error signature. If the caller didn't supply them, pull them from the run:
+   - `gh run view <run-id> --repo <repo> --log-failed` (or `gh api` on the job) and grep the failing assertion or error line.
+   - Reduce to a stable signature: the test path/name plus the exception type or first error line (e.g. `test_under_quota_batch_flows_through` + `RPCError: Completed workflow`). This signature drives every dedup search below.
+
+2. **Is it already tracked?** (highest-value check) Search #mendral-alerts (channel `C0A7SH71ETY`) for the test name and error signature using `slack_search_public` (e.g. `query: "<test name> in:<#C0A7SH71ETY>"`) or `slack_read_channel`. If Mendral already has an open insight for it, verdict `known-already`, capture the insight URL, and **do not post**.
+
+3. **Is master already broken or already being fixed?** Use `gh`:
+   - Search recent **master** runs for the same test failing repeatedly. A test failing on *every* recent master commit is a deterministic breakage, not a flake.
+   - Search open/merged PRs and issues mentioning the test or signature (`gh search prs`, `gh search issues`, `gh pr list --search`).
+   - If it's **fixed on master** and the failing branch is simply behind, verdict `fixed-on-master` (suggest rebasing main), and **do not post**.
+   - If it's a **deterministic master breakage already covered** by an open PR/insight, verdict `known-already` with that link, and **do not post**.
+
+4. **Flaky vs. legit, if still unsure.** If the failure looks deterministic and tied to the PR's own change (not intermittent), it's probably a real failure, not a flake: verdict `not-a-flake`, and suggest the caller use `bug-root-cause-analyzer`. When genuinely uncertain whether a failure is flaky, you may reuse the existing classifier as a tie-breaker: pipe a log excerpt into `~/.claude/skills/ci-monitor/scripts/ci-classify-failure.sh <pr> <workflow> <org/repo>`. Don't reimplement classification.
+
+5. **Unknown flake, report it.** If none of the above resolved it, it's an unknown flake worth Mendral's time. Compose the post (next section) and, in `post` mode, send it.
+
+Don't over-invest in certainty: a redundant post is cheap, since Mendral simply replies "known flaky, already tracked." Reasonable effort, then post.
+
+## Composing the post
+
+Match the channel norm exactly: one line, Phil's voice, the URL Mendral needs, and at most a short note. Mention Mendral as `<@U0A7Y69MZ3N>`. The post is a trigger, not a report, so never dump your investigation into it.
+
+Templates:
+
+- Default: `<@U0A7Y69MZ3N> flaky test: <job-url>`
+- With a useful note: `<@U0A7Y69MZ3N> flaky test: <job-url> (doesn't repro on master, no existing PR/insight found)`
+
+Keep any note to one short clause in parentheses. Don't include root-cause guesses (that's Mendral's job) or your dedup reasoning.
+
+## Posting
+
+In `post` mode, send via `slack_send_message` to channel `C0A7SH71ETY`. Capture the returned `ts` and build the permalink: `https://posthog.slack.com/archives/C0A7SH71ETY/p<ts-with-the-dot-removed>`.
+
+**Slack MCP may be unavailable** (headless/cron parents won't have it; see "Slack MCP availability in scheduled workers" in CLAUDE.md). If the `ToolSearch` in the Tools section returned no Slack tools, or posting fails, fall back to `draft`: return the ready-to-send message and the target channel so the caller can post it. Never treat an absent Slack tool as a hard failure.
+
+## Output contract
+
+Return this compact block (under ~120 words) so the caller can log it and move on:
+
+```text
+**Flake:** <test name + one-line signature>
+**Verdict:** posted | known-already | fixed-on-master | not-a-flake | draft | error
+**Action:** <what you did, one line, e.g. "posted to #mendral-alerts" / "matched open insight" / "branch behind main">
+**Link:** <Slack permalink if posted | insight/PR URL if known-already/fixed | the draft message if draft | omit otherwise>
+**Assumptions:** <anything you resolved by default, or "none">
+```
+
+## Out of scope
+
+- **Root-causing the flake**: Mendral does this; don't read the failing source to diagnose it.
+- **Fixing or reproducing**: you have no business editing code or running the test locally.
+- **More than one flake per call**: return, and let the caller spawn another instance.
+- **Deep code-level diagnosis**: that's `bug-root-cause-analyzer`.
+
+## Style
+
+- No em dashes anywhere, including the Slack post. Use commas, colons, parentheses, or periods.
+- Write the Slack post as Phil, a human engineer. Never refer to yourself as an agent or AI in the post.
+- Don't narrate your triage. State the verdict and the one action that followed.

--- a/ai/skills/babysit-prs/SKILL.md
+++ b/ai/skills/babysit-prs/SKILL.md
@@ -85,7 +85,7 @@ Fix work needs a local checkout of the PR branch:
 
 Handle each active PR, working from its checkout:
 
-- **CI failing** → invoke the `ci-monitor` skill with the PR URL. It classifies flaky vs legit failures and fixes legit ones.
+- **CI failing** → invoke the `ci-monitor` skill with the PR URL. It classifies flaky vs legit failures, fixes legit ones, and reports flaky ones to Mendral via the `report-flake` agent. This sweep runs unattended (typically under `/loop`), so there is no one to answer `ci-monitor`'s "re-run and report?" prompt: proceed as if approved — re-run the flaky failures and let `report-flake` post in `post` mode. The agent dedups against Mendral's open insights, so flakes already tracked produce no duplicate posts even across repeated sweeps.
 - **New review comments** → invoke the `address-pr-reviews` skill with the PR URL. It evaluates each comment, fixes legitimate findings, and handles replies per its own rules.
 - Push resulting commits to the PR branch. Never force-push. Never merge, close, or mark ready-for-review.
 

--- a/ai/skills/babysit-review/SKILL.md
+++ b/ai/skills/babysit-review/SKILL.md
@@ -1,16 +1,16 @@
 ---
 name: babysit-review
-description: Babysit a PR I'm reviewing (often an external contribution) — check CI, re-run failed jobs that are flaky, and report the failures that are real. Pass a PR, or --all for every open PR I've approved.
+description: Babysit a PR I'm reviewing (often an external contribution) — check CI, re-run failed jobs that are flaky and report them to Mendral, and report the failures that are real. Pass a PR, or --all for every open PR I've approved.
 argument-hint: "[<pr-url>|<pr-number>] [--dry-run] | --all [--limit <n>] [--dry-run]"
-allowed-tools: Bash(gh search prs:*, gh run view:*, gh run rerun:*, gh pr view:*, gh pr checks:*, ~/.dotfiles/bin/detect-pr.sh:*, ~/.claude/skills/ci-monitor/scripts/*:*, printf:*, mkdir:*), Read, Write
+allowed-tools: Bash(gh search prs:*, gh run view:*, gh run rerun:*, gh pr view:*, gh pr checks:*, ~/.dotfiles/bin/detect-pr.sh:*, ~/.claude/skills/ci-monitor/scripts/*:*, printf:*, mkdir:*), Read, Write, Agent
 model: sonnet
 ---
 
 # Babysit Review
 
-Babysit a pull request I'm **reviewing** — usually an external contribution where I'm the maintainer, not the author. Check CI; when a check has failed, classify it flaky or real. **Re-run the flaky failures**, and **report the real ones** so I can decide how to follow up with the contributor.
+Babysit a pull request I'm **reviewing** — usually an external contribution where I'm the maintainer, not the author. Check CI; when a check has failed, classify it flaky or real. **Re-run the flaky failures** (and report them to Mendral so they get tracked), and **report the real ones** so I can decide how to follow up with the contributor.
 
-The only thing this skill writes to GitHub is a re-run of a flaky workflow on its own existing run. It never edits, pushes to, merges, or comments on the PR. (It's the mirror of `babysit-prs`, which babysits my own PRs and pushes fixes — here I don't own the code.) The only thing it writes locally is a small re-run ledger on my machine (see **State** below).
+The only thing this skill writes to GitHub is a re-run of a flaky workflow on its own existing run. It never edits, pushes to, merges, or comments on the PR. (It's the mirror of `babysit-prs`, which babysits my own PRs and pushes fixes — here I don't own the code.) It does post a one-line flake notice in my voice to the #mendral-alerts Slack channel, but only for a genuine unknown flake: the `report-flake` agent dedups against Mendral's open insights first, so an already-tracked flake produces no post. Locally it writes a small re-run ledger on my machine (see **State** below).
 
 Each invocation is one sweep. The ledger bounds re-runs to **at most once per commit**: a flaky-looking failure gets one re-run, and if the same run fails again afterward, the skill reports it as a real failure instead of re-running it forever. A standing real failure is still re-reported every sweep until the contributor pushes. Pass a single PR, or `--all`:
 
@@ -119,22 +119,36 @@ Group `failed_checks` by `run_id` — several failing jobs in one workflow share
     gh run rerun "$RUN_ID" --failed --repo "$ORG/$REPO"
     ```
 
-    On success, add `run_id` to the ledger with the PR URL and `reran_at`. If the re-run command fails (e.g. the run is already queued), note it and continue — don't retry, don't re-monitor it this sweep, and don't record it (so a later sweep can still give it its one re-run).
+    On success, add `run_id` to the ledger with the PR URL and `reran_at`, then delegate the flake to the `report-flake` agent so Mendral tracks it. Spawn it fire-and-forget in `post` mode and don't wait on it; the agent dedups against Mendral's open insights, so an already-tracked flake produces no duplicate post:
+
+    ```text
+    Agent tool with:
+      subagent_type: report-flake
+      run_in_background: true
+      prompt: |
+        Report this flaky CI failure.
+        Job URL: <the failed check's link>
+        Test/signature if known: <test name + first error line from the classifier reasoning / log excerpt>
+        Repo: $ORG/$REPO
+        mode: post
+    ```
+
+    Tying the report to the ledger write bounds it to once per commit, matching the re-run. If the re-run command fails (e.g. the run is already queued), note it and continue — don't retry, don't re-monitor it this sweep, don't record it, and don't report it (so a later sweep can still give it its one re-run and report).
 
 - **Real** → do **not** re-run and do **not** touch the PR. For a classified run, capture for the report: check name + link, classification and confidence, a one-line reasoning + signals (e.g. fails on default branch, references PR-changed files), and a short log excerpt (the relevant 15–25 lines); when it reached Real because a prior re-run didn't help, say so. For a non-Actions check or a logs-unavailable run (no classification, no excerpt), capture just the check name + link and the reason.
 
-Under `--dry-run`, report what *would* be re-run instead of re-running.
+Under `--dry-run`, report what *would* be re-run and reported to Mendral, instead of doing either.
 
 ### Step 5: Summarize
 
 End with a table, one row per PR:
 
-| PR | CI | Flaky → re-ran | Real failures |
+| PR | CI | Flaky → re-ran + reported | Real failures |
 | --- | --- | --- | --- |
-| [posthog#123](…) | failed | `build` (rerun queued) | — |
+| [posthog#123](…) | failed | `build` (rerun queued, report dispatched) | — |
 | [posthog#456](…) | failed | — | `test-backend` (legit, 0.82) |
 | [charts#12](…) | green | — | — |
 
-Then, for each **real failure**, add a short section with the detail captured in Step 4, so I can decide whether to ping the contributor. Under `--dry-run`, the "Flaky → re-ran" column reads `would re-run` instead.
+The "report dispatched" note reflects that `report-flake` was spawned in the background; its verdict (posted vs already-tracked) lands asynchronously in #mendral-alerts, not in this summary. Then, for each **real failure**, add a short section with the detail captured in Step 4, so I can decide whether to ping the contributor. Under `--dry-run`, the "Flaky → re-ran + reported" column reads `would re-run + report` instead.
 
 If nothing needed attention, the summary is a single line: `Checked <n> PR(s); all green or flakes re-run, no real failures.` (under `--dry-run`, `…flakes would be re-run…`).

--- a/ai/skills/ci-monitor/SKILL.md
+++ b/ai/skills/ci-monitor/SKILL.md
@@ -2,7 +2,7 @@
 name: ci-monitor
 description: Monitor CI checks after pushing, detect flaky vs legit failures, and auto-fix
 argument-hint: "[<pr-number>|<pr-url>|--no-fix|--timeout <min>]"
-allowed-tools: Bash(~/.claude/skills/ci-monitor/scripts/*:*, ~/.dotfiles/bin/detect-pr.sh:*, sleep:*, gh:*, git:*), Read(~/.claude/skills/ci-monitor/**), Write, Edit
+allowed-tools: Bash(~/.claude/skills/ci-monitor/scripts/*:*, ~/.dotfiles/bin/detect-pr.sh:*, sleep:*, gh:*, git:*), Read(~/.claude/skills/ci-monitor/**), Write, Edit, Task
 model: sonnet
 ---
 
@@ -137,11 +137,29 @@ For each failure, report:
 
 **4d. Handle by classification:**
 
-**All flaky:** Report as flaky. Ask the user: "All failures appear to be flaky. Re-run failed workflows?" If yes, for each failed check with a `run_id`:
+**All flaky:** Report as flaky. Ask the user one combined question: "All failures appear to be flaky. Re-run failed workflows, and report the flake(s) to Mendral?"
+
+If they approve the re-run, for each failed check with a `run_id`:
 
 ```bash
 gh run rerun $RUN_ID --failed --repo "$ORG/$REPO"
 ```
+
+If they also approve reporting to Mendral, delegate each distinct flaky failure to the `report-flake` agent so it dedups against known incidents and reports genuine unknown flakes while monitoring continues. Spawn it fire-and-forget (the user already consented, so it runs in `post` mode) and do not wait on it:
+
+```text
+Task tool with:
+  subagent_type: report-flake
+  run_in_background: true
+  prompt: |
+    Report this flaky CI failure.
+    Job URL: <check_link>
+    Test/signature if known: <test name + error line from CLASSIFICATION>
+    Repo: $ORG/$REPO
+    mode: post
+```
+
+The agent dedups before posting, so a flake already tracked by Mendral won't produce a duplicate post. If the user declines reporting, skip the delegation.
 
 Then go back to **Step 2** to monitor the re-run (this does NOT count against `RETRY_COUNT`).
 

--- a/ai/skills/ci-monitor/SKILL.md
+++ b/ai/skills/ci-monitor/SKILL.md
@@ -2,7 +2,7 @@
 name: ci-monitor
 description: Monitor CI checks after pushing, detect flaky vs legit failures, and auto-fix
 argument-hint: "[<pr-number>|<pr-url>|--no-fix|--timeout <min>]"
-allowed-tools: Bash(~/.claude/skills/ci-monitor/scripts/*:*, ~/.dotfiles/bin/detect-pr.sh:*, sleep:*, gh:*, git:*), Read(~/.claude/skills/ci-monitor/**), Write, Edit, Task
+allowed-tools: Bash(~/.claude/skills/ci-monitor/scripts/*:*, ~/.dotfiles/bin/detect-pr.sh:*, sleep:*, gh:*, git:*), Read(~/.claude/skills/ci-monitor/**), Write, Edit, Agent
 model: sonnet
 ---
 
@@ -148,7 +148,7 @@ gh run rerun $RUN_ID --failed --repo "$ORG/$REPO"
 If they also approve reporting to Mendral, delegate each distinct flaky failure to the `report-flake` agent so it dedups against known incidents and reports genuine unknown flakes while monitoring continues. Spawn it fire-and-forget (the user already consented, so it runs in `post` mode) and do not wait on it:
 
 ```text
-Task tool with:
+Agent tool with:
   subagent_type: report-flake
   run_in_background: true
   prompt: |


### PR DESCRIPTION
## Summary

Adds a `report-flake` sub-agent that skills can spawn fire-and-forget when a flaky CI failure surfaces. The agent deduplicates against #mendral-alerts and existing PRs/issues before posting, so an already-tracked flake produces no duplicate. If Mendral already has an open insight for it, the agent returns `known-already` and posts nothing.

- `ai/agents/report-flake.md`: new agent. Given a failing job URL it builds a signature, dedups via Slack search and `gh`, and posts `@Mendral flaky test: <url>` only for genuinely unknown flakes. Verdicts: `posted` / `known-already` / `fixed-on-master` / `not-a-flake` / `draft` / `error`. Auto-degrades to `draft` if Slack MCP is unavailable (headless/cron contexts). Loads deferred Slack tools via `ToolSearch` before calling them.
- `ai/skills/ci-monitor/SKILL.md`: the "All flaky" prompt now includes Mendral reporting in the same confirmation question. On approval, spawns `report-flake` fire-and-forget in `post` mode via the `Agent` tool. Added `Agent` to `allowed-tools`.
- `ai/skills/babysit-review/SKILL.md`: Step 4 Flaky branch delegates to `report-flake` immediately after the ledger write, bounding reports to once per commit. Skipped under `--dry-run`. Added `Agent` to `allowed-tools`.
- `ai/skills/babysit-prs/SKILL.md`: documents that the unattended loop should treat the reporting prompt as approved, so `ci-monitor` auto-posts without stalling the sweep.
- `ai/CLAUDE.md`: registered `report-flake` under "When to Use Which Agent".

## Test plan

Tested the dedup path with a live draft-mode dry run against a known flake (`test_retrieve_entity_property_values_virtual_property_without_examples`, 35 occurrences in Mendral): the agent loaded the deferred Slack tools, found the existing insight, and returned `known-already` with the correct insight URL in 3 tool calls.

The `slack_send_message` post path (for a genuinely unknown flake) has not been exercised end-to-end; the first real unknown flake routed through ci-monitor or babysit-review will be the live test. The agent needs `./ai/install.sh --agents-only` to be symlinked into `~/.claude/agents/` before any caller can resolve `subagent_type: report-flake`.