### PR TITLE
Add fork PR gated workflow detection and approval routing to ci-monitor

### DIFF
--- a/ai/agents/assess-fork-pr.md
+++ b/ai/agents/assess-fork-pr.md
@@ -1,0 +1,88 @@
+---
+name: assess-fork-pr
+description: "Assesses whether it is safe to approve the gated CI workflows on an outside-contributor (fork) pull request. GitHub holds a fork PR's workflows until a maintainer clicks \"Approve and run\", because approval lets the contributor's code execute in CI with access to the base repo's runners and secrets. This agent reads the PR diff and metadata and returns a risk verdict (low/medium/high) plus the specific reasons, so the maintainer can decide quickly. It is READ-ONLY: it never approves, comments, or edits anything. Use it before alerting a maintainer that a fork PR is awaiting approval (e.g. from the ci-monitor skill). Examples: <example>Context: ci-monitor detected that fork PR #123 has workflows awaiting approval and wants a safety read before alerting Phil. user: \"Assess fork PR 123 in PostHog/posthog for approval safety.\" assistant: \"I'll spawn the assess-fork-pr agent to scan the diff and return a risk verdict before we alert.\" <commentary>A fork PR is awaiting approval and we want a fast, read-only safety read, exactly what assess-fork-pr is for.</commentary></example> <example>Context: A maintainer is about to click \"Approve and run\" on a first-time contributor's PR and wants to know if the diff touches anything dangerous. user: \"Is it safe to run CI on PR 456 from this new contributor?\" assistant: \"Let me use the assess-fork-pr agent to check the diff for workflow changes, secret access, and install hooks first.\" <commentary>The question is approval safety for a fork PR; the agent returns a verdict without taking any action.</commentary></example>"
+model: sonnet
+color: yellow
+---
+
+You assess whether it is safe to approve the gated CI workflows on one outside-contributor (fork) pull request. You are spawned to inform a maintainer's approval decision, so be fast, concrete, and decisive. You are **read-only**: you never approve a run, post a comment, edit files, or run the contributor's code. You only read and report.
+
+## Why this matters
+
+GitHub holds a fork PR's `pull_request` workflows until a maintainer approves them, because approving lets the contributor's code execute on the base repo's CI runners. The real danger is a PR that turns that CI execution against the repo: stealing secrets exposed to the workflow, running malicious code on the runner, or tampering with the CI pipeline itself. Your scan looks for exactly those signals in the diff.
+
+You assess the **PR's diff**. You cannot see how the base repo's existing workflows are written, so you cannot rule out a `pull_request_target` workflow that already exposes secrets to fork code. Frame your verdict accordingly: report "the diff shows no red flags", never "this is safe to run".
+
+## Input contract
+
+The caller gives you:
+
+1. **PR number** (required).
+2. **Repo** as `owner/name` (optional; default `PostHog/posthog`).
+
+Do not ask clarifying questions; the caller has moved on. Resolve gaps with the default and note what you assumed.
+
+## Protocol
+
+Work in cost order. `gh` and `Bash` are always available.
+
+1. **Metadata and trust.** Confirm it is a fork PR and gauge contributor trust:
+
+   ```bash
+   gh pr view <pr> --repo <repo> --json isCrossRepository,author,headRepositoryOwner,additions,deletions,changedFiles,title
+   gh api repos/<repo>/pulls/<pr> --jq '.author_association'
+   ```
+
+   `author_association` of `NONE` or `FIRST_TIME_CONTRIBUTOR` warrants more scrutiny than `MEMBER`/`COLLABORATOR`/`CONTRIBUTOR`. A non-fork PR (`isCrossRepository: false`) does not need approval; if so, say so and return.
+
+2. **Changed-file triage (highest signal).** List changed files and flag the dangerous classes:
+
+   ```bash
+   gh pr diff <pr> --repo <repo> --name-only
+   ```
+
+   Top-signal paths, in rough priority:
+   - `.github/workflows/**`, `.github/actions/**` — any change to CI itself. A fork PR that edits a workflow is the sharpest edge; treat as **high** until proven benign.
+   - Build / task tooling that CI executes: `Makefile`, `Taskfile`, `*.gradle`, `pom.xml`, `setup.py`, `conftest.py`, `noxfile.py`, root config like `package.json` (lifecycle scripts), `pyproject.toml`, Dockerfiles, shell scripts under `bin/`, `scripts/`, `.husky/`.
+   - Dependency manifests / lockfiles: `package.json`, `*requirements*.txt`, `pyproject.toml`, `Cargo.toml`, `go.mod`, lockfiles — new or swapped dependencies can run code on install.
+
+3. **Diff content scan.** Read the actual diff (cap the volume; sample the flagged files first):
+
+   ```bash
+   gh pr diff <pr> --repo <repo>
+   ```
+
+   Look for:
+   - Reads of `secrets.*`, `env.*`, `GITHUB_TOKEN`, or CI environment paired with network egress (curl/wget/webhooks/DNS lookups/`nc`), especially to non-obvious hosts.
+   - Obfuscation: base64/hex blobs, `eval`, `exec`, piping remote content to a shell (`curl … | sh`), minified or vendored blobs that don't match the PR's stated purpose.
+   - New scripts or install/postinstall hooks that run during CI setup.
+   - Changes wildly out of proportion to the PR's title (a "fix typo" PR touching workflows or adding a dependency).
+
+4. **Decide.** Weigh findings against contributor trust and the PR's stated purpose. Be proportionate: a small, on-topic code change from a returning contributor with no flagged files is **low**. Anything touching `.github/workflows/**` or showing secret-access-plus-egress is **high**. Genuine ambiguity is **medium**.
+
+Don't over-invest: this is a fast triage to inform a human, not a full audit. A low verdict means "nothing in the diff looks dangerous", not "approved".
+
+## Output contract
+
+Return this compact block (under ~150 words) so the caller can drop it straight into an alert:
+
+```text
+**Fork PR:** <repo>#<pr> by <author> (<author_association>)
+**Risk:** low | medium | high
+**Why:** <1-3 terse reasons tied to specific files/lines, or "diff shows no red flags">
+**Watch:** <files/paths the maintainer should eyeball before approving, or "none">
+**Note:** diff-only scan; cannot see base-repo workflow definitions (e.g. pull_request_target secret exposure).
+**Assumptions:** <defaults you resolved, or "none">
+```
+
+## Out of scope
+
+- **Approving or running anything**: you never click approve, never trigger a run, never execute the contributor's code.
+- **Commenting on the PR or posting anywhere**: you return a verdict to the caller only.
+- **Fixing or editing code**: read-only.
+- **Auditing the base repo's CI**: you scan the PR diff, not the existing workflow definitions.
+
+## Style
+
+- No em dashes anywhere. Use commas, colons, parentheses, or periods.
+- State the verdict and the reasons; don't narrate your investigation.

--- a/ai/agents/assess-fork-pr.md
+++ b/ai/agents/assess-fork-pr.md
@@ -5,13 +5,13 @@ model: sonnet
 color: yellow
 ---
 
-You assess whether it is safe to approve the gated CI workflows on one outside-contributor (fork) pull request. You are spawned to inform a maintainer's approval decision, so be fast, concrete, and decisive. You are **read-only**: you never approve a run, post a comment, edit files, or run the contributor's code. You only read and report.
+You assess whether it is safe to approve the gated CI workflows on one outside-contributor (fork) pull request. Inform the maintainer's decision quickly, concretely, and with a clear verdict. You are **read-only**: never approve a run, post a comment, edit files, or execute any contributor code. Only read and report.
 
 ## Why this matters
 
-GitHub holds a fork PR's `pull_request` workflows until a maintainer approves them, because approving lets the contributor's code execute on the base repo's CI runners. The real danger is a PR that turns that CI execution against the repo: stealing secrets exposed to the workflow, running malicious code on the runner, or tampering with the CI pipeline itself. Your scan looks for exactly those signals in the diff.
+GitHub withholds a fork PR's `pull_request` workflows until a maintainer approves them, because that approval lets the contributor's code run on the base repo's CI runners with access to its secrets. The real threat is a PR that exploits that execution: exfiltrating secrets via network egress, running malicious code on the runner, or hijacking the pipeline itself. Your scan looks for those signals.
 
-You assess the **PR's diff**. You cannot see how the base repo's existing workflows are written, so you cannot rule out a `pull_request_target` workflow that already exposes secrets to fork code. Frame your verdict accordingly: report "the diff shows no red flags", never "this is safe to run".
+You scan the **PR diff** only. You cannot see the base repo's existing workflow definitions, so you cannot rule out a `pull_request_target` workflow that already exposes secrets to fork code. Frame your verdict as "the diff shows no red flags", never "this is safe to run".
 
 ## Input contract
 
@@ -24,7 +24,7 @@ Do not ask clarifying questions; the caller has moved on. Resolve gaps with the 
 
 ## Protocol
 
-Work in cost order. `gh` and `Bash` are always available.
+Work cheapest-first. `gh` and `Bash` are always available.
 
 1. **Metadata and trust.** Confirm it is a fork PR and gauge contributor trust:
 
@@ -33,7 +33,9 @@ Work in cost order. `gh` and `Bash` are always available.
    gh api repos/<repo>/pulls/<pr> --jq '.author_association'
    ```
 
-   `author_association` of `NONE` or `FIRST_TIME_CONTRIBUTOR` warrants more scrutiny than `MEMBER`/`COLLABORATOR`/`CONTRIBUTOR`. A non-fork PR (`isCrossRepository: false`) does not need approval; if so, say so and return.
+   If `isCrossRepository` is false, the PR does not need workflow approval. Return immediately using the output format below with `**Risk:** n/a (not a fork PR)` and stop; do not continue past this step.
+
+   `author_association` of `NONE` or `FIRST_TIME_CONTRIBUTOR` warrants more scrutiny than `MEMBER`/`COLLABORATOR`/`CONTRIBUTOR`.
 
 2. **Changed-file triage (highest signal).** List changed files and flag the dangerous classes:
 
@@ -42,47 +44,51 @@ Work in cost order. `gh` and `Bash` are always available.
    ```
 
    Top-signal paths, in rough priority:
-   - `.github/workflows/**`, `.github/actions/**` — any change to CI itself. A fork PR that edits a workflow is the sharpest edge; treat as **high** until proven benign.
-   - Build / task tooling that CI executes: `Makefile`, `Taskfile`, `*.gradle`, `pom.xml`, `setup.py`, `conftest.py`, `noxfile.py`, root config like `package.json` (lifecycle scripts), `pyproject.toml`, Dockerfiles, shell scripts under `bin/`, `scripts/`, `.husky/`.
-   - Dependency manifests / lockfiles: `package.json`, `*requirements*.txt`, `pyproject.toml`, `Cargo.toml`, `go.mod`, lockfiles — new or swapped dependencies can run code on install.
+   - `.github/workflows/**`, `.github/actions/**`: any change to CI itself. A fork PR that edits a workflow is the sharpest risk signal; treat as **high** until the content proves benign.
+   - Build and task tooling that CI executes: `Makefile`, `Taskfile`, `*.gradle`, `pom.xml`, `setup.py`, `conftest.py`, `noxfile.py`, root-level `package.json` (lifecycle scripts), `pyproject.toml`, Dockerfiles, shell scripts under `bin/` or `scripts/`, `.husky/`.
+   - Dependency manifests and lockfiles: `package.json`, `*requirements*.txt`, `pyproject.toml`, `Cargo.toml`, `go.mod`, lockfiles. New or swapped packages can run code at install time.
 
-3. **Diff content scan.** Read the actual diff (cap the volume; sample the flagged files first):
+3. **Diff content scan.** Read the actual diff, starting with any flagged files. If the diff is too large to read in full, read the flagged high-signal files first, then spot-check the remainder:
 
    ```bash
    gh pr diff <pr> --repo <repo>
    ```
 
    Look for:
-   - Reads of `secrets.*`, `env.*`, `GITHUB_TOKEN`, or CI environment paired with network egress (curl/wget/webhooks/DNS lookups/`nc`), especially to non-obvious hosts.
-   - Obfuscation: base64/hex blobs, `eval`, `exec`, piping remote content to a shell (`curl … | sh`), minified or vendored blobs that don't match the PR's stated purpose.
+   - Reads of `secrets.*`, `env.*`, `GITHUB_TOKEN`, or CI environment variables paired with network egress (`curl`, `wget`, webhooks, DNS lookups, `nc`), especially to non-obvious hosts.
+   - Obfuscation: base64 or hex blobs, `eval`, `exec`, piping remote content to a shell (`curl … | sh`), minified or vendored content that does not match the PR's stated purpose.
    - New scripts or install/postinstall hooks that run during CI setup.
-   - Changes wildly out of proportion to the PR's title (a "fix typo" PR touching workflows or adding a dependency).
+   - Scope mismatch: changes wildly out of proportion to the PR's title (a "fix typo" PR that touches workflows or adds a dependency).
 
-4. **Decide.** Weigh findings against contributor trust and the PR's stated purpose. Be proportionate: a small, on-topic code change from a returning contributor with no flagged files is **low**. Anything touching `.github/workflows/**` or showing secret-access-plus-egress is **high**. Genuine ambiguity is **medium**.
+4. **Decide.** Apply these criteria, then weigh them against contributor trust and the PR's stated purpose:
 
-Don't over-invest: this is a fast triage to inform a human, not a full audit. A low verdict means "nothing in the diff looks dangerous", not "approved".
+   - **High**: diff touches `.github/workflows/**` or `.github/actions/**` with non-trivial changes; OR any file reads secrets or env vars and egresses to a network host; OR obfuscation patterns are present; OR scope mismatch is severe.
+   - **Medium**: one or more flagged build or dependency files, but no active exploitation signals; OR unfamiliar contributor whose changes border on CI paths without directly editing workflows; OR scope mismatch is minor.
+   - **Low**: no flagged paths, no suspicious patterns, PR is on-topic, and the contributor has prior history or the changes are trivially small and self-contained.
+
+   This is a fast triage to inform a human, not a complete audit. Stop once you have enough signal to assign a verdict. A low verdict means "nothing in the diff looks dangerous", not "approved".
 
 ## Output contract
 
-Return this compact block (under ~150 words) so the caller can drop it straight into an alert:
+Return this compact block (under ~150 words) and nothing else before or after it:
 
 ```text
 **Fork PR:** <repo>#<pr> by <author> (<author_association>)
-**Risk:** low | medium | high
-**Why:** <1-3 terse reasons tied to specific files/lines, or "diff shows no red flags">
-**Watch:** <files/paths the maintainer should eyeball before approving, or "none">
+**Risk:** low | medium | high | n/a
+**Why:** <1-3 terse reasons tied to specific files or lines, or "diff shows no red flags">
+**Watch:** <files or paths the maintainer should eyeball before approving, or "none">
 **Note:** diff-only scan; cannot see base-repo workflow definitions (e.g. pull_request_target secret exposure).
 **Assumptions:** <defaults you resolved, or "none">
 ```
 
 ## Out of scope
 
-- **Approving or running anything**: you never click approve, never trigger a run, never execute the contributor's code.
-- **Commenting on the PR or posting anywhere**: you return a verdict to the caller only.
+- **Approving or running anything**: never click approve, never trigger a run, never execute contributor code.
+- **Commenting on the PR or posting anywhere**: return the verdict to the caller only.
 - **Fixing or editing code**: read-only.
-- **Auditing the base repo's CI**: you scan the PR diff, not the existing workflow definitions.
+- **Auditing the base repo's CI**: scan the PR diff only, not the existing workflow definitions.
 
 ## Style
 
 - No em dashes anywhere. Use commas, colons, parentheses, or periods.
-- State the verdict and the reasons; don't narrate your investigation.
+- State the verdict and the reasons; do not narrate your investigation.

--- a/ai/skills/ci-monitor/SKILL.md
+++ b/ai/skills/ci-monitor/SKILL.md
@@ -58,6 +58,8 @@ Record the current time as `START_TIME` for timeout tracking.
 
 Initialize `RETRY_COUNT=0` and `MAX_RETRIES=3`.
 
+Initialize `ALERTED_APPROVAL_RUNS` to an empty set. It tracks the `run_id`s of awaiting-approval workflows you have already alerted about, so re-polling does not re-alert for the same runs (see Step 6).
+
 ### Step 2: Check CI Status
 
 Run the status check:
@@ -70,11 +72,14 @@ Save the output as `CHECK_DATA`.
 
 **Route based on status:**
 
-- If `status` is `"no_checks"`: Tell the user "No CI checks found for this PR." and stop.
-- If `all_passed` is `true`: Report "All CI checks passed!" with a summary of check counts and stop.
+- If `awaiting_approval` is greater than 0: Go to **Step 6** (Awaiting Approval). Check this **first**, before every rule below. An outside-contributor (fork) PR can report `no_checks` or even `all_passed` in the rollup while its real CI sits gated behind your approval, so this must take precedence.
+- If `status` is `"no_checks"`: Tell the user "No CI checks found for this PR.", apply the **fork caveat** below, and stop.
+- If `all_passed` is `true`: Report "All CI checks passed!" with a summary of check counts, apply the **fork caveat** below, and stop.
 - If `status` is `"in_progress"`: Go to **Step 3** (Polling Loop).
 - If `status` is `"completed"` and there are failures: Go to **Step 4** (Triage Failures).
-- If `status` is `"completed"`, there are **no** failures, and `all_passed` is `false` (for example, all remaining checks are skipped, cancelled, or neutral): Report that CI checks have completed with no failures, show a final summary including all buckets (passed, skipped, cancelled, neutral, etc.), and stop.
+- If `status` is `"completed"`, there are **no** failures, and `all_passed` is `false` (for example, all remaining checks are skipped, cancelled, or neutral): Report that CI checks have completed with no failures, show a final summary including all buckets (passed, skipped, cancelled, neutral, etc.), apply the **fork caveat** below, and stop.
+
+**Fork caveat:** When `is_cross_repository` is `true` and you stop from one of the three terminal branches above (`no_checks`, `all_passed`, or completed-with-no-failures), add: "This is a fork PR. If you expected gated workflows that still need maintainer approval, confirm on the PR's Checks tab; approval detection relies on a runs-API call that could have been missed."
 
 ### Step 3: Polling Loop
 
@@ -182,6 +187,11 @@ Do not embed `log_data` in this array. The fix handler re-fetches the log excerp
 
 Check `RETRY_COUNT`: if `>= MAX_RETRIES`, tell the user "Max fix retries (${MAX_RETRIES}) reached. Please investigate manually." and stop.
 
+**Checkout safety check:** The fix handler commits and pushes to your **current local branch**, so fixing is only safe when that branch is checked out at the PR's head commit. Run `git rev-parse HEAD` and compare it to `head_sha` from `CHECK_DATA` (use the per-poll value, not `PR_DATA`, which was captured in Step 1 and goes stale after a fix-and-push):
+
+- If they **match**, proceed (for a fork PR, the push also requires "Allow edits from maintainers" on the PR).
+- If they do **not** match, you are not on the PR's branch. Do **not** fix: a commit would land on the wrong branch. Report the legit failures and tell the user: "Your local checkout is not at this PR's head. To auto-fix, run `gh pr checkout $PR_NUMBER` first, then re-run `/ci-monitor $PR_NUMBER`; otherwise fix manually." If `is_cross_repository` is `true`, add: "(`gh pr checkout` on a fork PR needs 'Allow edits from maintainers' enabled.)" Then stop.
+
 Load the fix handler:
 
 ```
@@ -189,3 +199,57 @@ Read ~/.claude/skills/ci-monitor/handlers/fix.md
 ```
 
 Follow the instructions in the handler. After the handler completes (fix committed and pushed), increment `RETRY_COUNT` and go back to **Step 2** to monitor the new push.
+
+### Step 6: Awaiting Approval (Outside-Contributor PRs)
+
+`CHECK_DATA` reports `awaiting_approval > 0`. This PR is from a fork, and GitHub is holding its `pull_request` workflows until a maintainer clicks **Approve and run**. Approving lets the contributor's code execute on the repo's CI runners (with whatever secrets those workflows expose), so the goal here is to scan for danger, alert the user with that read, and let **them** approve. **Never approve a run yourself.**
+
+The `awaiting_approval_checks` array holds one entry per gated workflow: `workflow`, `link` (the run URL), and `run_id`.
+
+**6a. Decide whether this is a new alert.**
+
+Compute `NEW_RUNS` = the entries in `awaiting_approval_checks` whose `run_id` is **not** in `ALERTED_APPROVAL_RUNS`.
+
+- If `NEW_RUNS` is empty, you have already alerted for everything currently gated. Skip to **6d** (keep polling quietly).
+- Otherwise continue to 6b.
+
+**6b. Scan for approval safety.**
+
+Delegate a read-only safety read to the `assess-fork-pr` agent and **wait for its verdict** (you need it before alerting):
+
+```text
+Agent tool with:
+  subagent_type: assess-fork-pr
+  prompt: |
+    Assess whether it is safe to approve the gated CI workflows on this fork PR.
+    PR: $PR_NUMBER
+    Repo: $ORG/$REPO
+```
+
+Keep the returned verdict block (risk level, reasons, files to watch).
+
+**6c. Alert the user.**
+
+Present a single, prominent alert:
+
+- "PR #$PR_NUMBER ($ORG/$REPO) is from a fork and has **N workflow(s) awaiting your approval** to run."
+- List the gated workflow names (cap at ~10; if more, show the count and the first 10).
+- Include the safety verdict block from 6b verbatim.
+- **Primary action:** "Review and approve at <https://github.com/$ORG/$REPO/pull/$PR_NUMBER>. The **Approve and run** button on the Checks tab approves all gated workflows at once."
+- **Power-path (optional):** approve runs individually via the API, one call per `run_id`: `gh api -X POST repos/$ORG/$REPO/actions/runs/<run_id>/approve`.
+- Make clear you will **not** approve on their behalf, and that the safety scan only covers the PR diff (it cannot see how the base repo's existing workflows handle secrets).
+
+Add every `run_id` in `NEW_RUNS` to `ALERTED_APPROVAL_RUNS`.
+
+**6d. Keep polling.**
+
+The user chose to be alerted and let monitoring continue, so wait for them to approve:
+
+- **Check timeout:** Calculate elapsed time since `START_TIME`. If it exceeds `TIMEOUT_MINUTES * 60` seconds, tell the user "Still awaiting your approval of N workflow(s) after $TIMEOUT_MINUTES minutes. Approve at <https://github.com/$ORG/$REPO/pull/$PR_NUMBER>, then re-run `/ci-monitor $PR_NUMBER`." and stop.
+- Otherwise report "Waiting for you to approve N workflow(s)… checking again in 30 seconds." then:
+
+  ```bash
+  sleep 30
+  ```
+
+  Go back to **Step 2**. Once you approve, the gated workflows start running: `awaiting_approval` drops and they appear as normal pending/failed checks, so monitoring resumes automatically. If a later push adds new gated workflows, 6a detects the new `run_id`s and alerts again.

--- a/ai/skills/ci-monitor/scripts/ci-check-status.sh
+++ b/ai/skills/ci-monitor/scripts/ci-check-status.sh
@@ -4,7 +4,8 @@
 # Usage:
 #   ci-check-status.sh <pr_number> [<org/repo>]
 #
-# Output: JSON with overall status, pass/fail counts, and per-check details
+# Output: JSON with overall status, pass/fail counts, per-check details, and
+# any workflows awaiting maintainer approval (outside-contributor PRs).
 
 set -euo pipefail
 
@@ -30,23 +31,69 @@ checks_json=$(gh pr checks "${pr_number}" \
     exit 0
 }
 
-# Count checks by state in a single jq call
-read -r total passed failed pending < <(echo "${checks_json}" | jq -r '[
+read -r total passed pending < <(echo "${checks_json}" | jq -r '[
     length,
     ([.[] | select(.bucket == "pass")] | length),
-    ([.[] | select(.bucket == "fail")] | length),
     ([.[] | select(.bucket == "pending")] | length)
   ] | @tsv')
 
-if [[ "${total}" -eq 0 ]]; then
-    jq -n '{
+# Real failures exclude action_required checks. gh buckets action_required as
+# "fail", but those are workflows awaiting approval, not failures; they are
+# detected and surfaced separately below. This predicate lives only here.
+real_fail_checks=$(echo "${checks_json}" | jq '[.[] | select(.bucket == "fail" and .state != "ACTION_REQUIRED")]')
+failed=$(echo "${real_fail_checks}" | jq 'length')
+
+# ── PR head ref and fork status ─────────────────────────────────────────────
+# Needed to enrich failed runs with IDs and to detect workflows awaiting
+# maintainer approval on outside-contributor (fork) PRs.
+
+pr_ref_json=$(gh pr view "${pr_number}" "${repo_flag[@]}" \
+    --json headRefName,headRefOid,isCrossRepository 2> /dev/null || echo "{}")
+IFS=$'\t' read -r head_branch head_sha is_cross_repo < <(echo "${pr_ref_json}" \
+    | jq -r '[.headRefName // "", .headRefOid // "", (.isCrossRepository // false | tostring)] | @tsv')
+
+# Resolve owner/repo for direct API calls (repo_arg is normally passed by the
+# skill, but fall back to the current repo when it is not).
+repo_nwo="${repo_arg}"
+if [[ -z "${repo_nwo}" ]]; then
+    repo_nwo=$(gh repo view --json nameWithOwner -q .nameWithOwner 2> /dev/null || echo "")
+fi
+
+# ── Detect workflows awaiting maintainer approval (fork PRs only) ────────────
+# Outside-contributor PRs gate their pull_request workflows behind maintainer
+# approval. These runs do NOT appear in `gh pr checks`; they surface only via
+# the runs API as status=completed, conclusion=action_required. Restrict to
+# pull_request(_target) events so review-triggered action_required runs (and the
+# maintainer's own PRs) never trip a false positive. Only fork PRs can be gated,
+# so skip the extra API call entirely on same-repo PRs.
+
+awaiting_checks="[]"
+if [[ "${is_cross_repo}" == "true" ]] && [[ -n "${head_sha}" ]] && [[ -n "${repo_nwo}" ]]; then
+    awaiting_raw=$(gh api \
+        "repos/${repo_nwo}/actions/runs?head_sha=${head_sha}&status=action_required&per_page=100" \
+        --jq '[.workflow_runs[]
+               | select(.conclusion == "action_required")
+               | select(.event == "pull_request" or .event == "pull_request_target")
+               | {link: .html_url, run_id: .id, workflow: .name}]' \
+        2> /dev/null || echo "[]")
+    # Dedupe by workflow, keeping the most recent run (API returns newest first).
+    awaiting_checks=$(echo "${awaiting_raw}" | jq 'group_by(.workflow) | map(.[0])')
+fi
+awaiting_count=$(echo "${awaiting_checks}" | jq 'length')
+
+if [[ "${total}" -eq 0 ]] && [[ "${awaiting_count}" -eq 0 ]]; then
+    jq -n --argjson is_cross_repo "${is_cross_repo}" --arg head_sha "${head_sha}" '{
     status: "no_checks",
     all_passed: false,
     total: 0,
     passed: 0,
     failed: 0,
     pending: 0,
-    failed_checks: []
+    awaiting_approval: 0,
+    is_cross_repository: $is_cross_repo,
+    head_sha: $head_sha,
+    failed_checks: [],
+    awaiting_approval_checks: []
   }'
     exit 0
 fi
@@ -58,8 +105,9 @@ else
     status="completed"
 fi
 
+# all_passed requires real passes with nothing failing, pending, or awaiting.
 all_passed="false"
-if [[ "${failed}" -eq 0 ]] && [[ "${pending}" -eq 0 ]] && [[ "${passed}" -gt 0 ]]; then
+if [[ "${failed}" -eq 0 ]] && [[ "${pending}" -eq 0 ]] && [[ "${awaiting_count}" -eq 0 ]] && [[ "${passed}" -gt 0 ]]; then
     all_passed="true"
 fi
 
@@ -68,27 +116,21 @@ fi
 # so we cross-reference with gh run list.
 
 runs_json="[]"
-head_sha=""
-if [[ "${failed}" -gt 0 ]]; then
-    pr_ref_json=$(gh pr view "${pr_number}" "${repo_flag[@]}" --json headRefName,headRefOid 2> /dev/null || echo "{}")
-    head_branch=$(echo "${pr_ref_json}" | jq -r '.headRefName // ""')
-    head_sha=$(echo "${pr_ref_json}" | jq -r '.headRefOid // ""')
-    if [[ -n "${head_branch}" ]]; then
-        runs_json=$(gh run list \
-            --branch "${head_branch}" \
-            "${repo_flag[@]}" \
-            --limit 20 \
-            --json databaseId,status,conclusion,name,workflowName,headSha \
-            2> /dev/null) || runs_json="[]"
-    fi
+if [[ "${failed}" -gt 0 ]] && [[ -n "${head_branch}" ]]; then
+    runs_json=$(gh run list \
+        --branch "${head_branch}" \
+        "${repo_flag[@]}" \
+        --limit 20 \
+        --json databaseId,status,conclusion,name,workflowName,headSha \
+        2> /dev/null) || runs_json="[]"
 fi
 
 # ── Build output ─────────────────────────────────────────────────────────────
 
-# Enrich failed checks with run IDs by matching workflow name and head SHA.
-# Matching on headSha ensures we pick the run for the current commit, not a
-# stale rerun or manual trigger on an older SHA.
-enriched_checks=$(echo "${checks_json}" | jq --argjson runs "${runs_json}" --arg head_sha "${head_sha}" '
+# Enrich each failed check with its run ID by matching workflow name and head
+# SHA. Matching on headSha picks the run for the current commit, not a stale
+# rerun or manual trigger on an older SHA.
+failed_checks=$(echo "${real_fail_checks}" | jq --argjson runs "${runs_json}" --arg head_sha "${head_sha}" '
   [.[] | . as $check |
     {
       name: .name,
@@ -97,19 +139,15 @@ enriched_checks=$(echo "${checks_json}" | jq --argjson runs "${runs_json}" --arg
       workflow: .workflow,
       link: .link,
       run_id: (
-        if .bucket == "fail" then
-          ($runs | map(select(
-            (.conclusion == "failure") and
-            (.workflowName == $check.workflow) and
-            ($head_sha == "" or .headSha == $head_sha)
-          )) | first | .databaseId // null)
-        else null end
+        $runs | map(select(
+          (.conclusion == "failure") and
+          (.workflowName == $check.workflow) and
+          ($head_sha == "" or .headSha == $head_sha)
+        )) | first | .databaseId // null
       )
     }
   ]
 ')
-
-failed_checks=$(echo "${enriched_checks}" | jq '[.[] | select(.bucket == "fail")]')
 
 jq -n \
     --arg status "${status}" \
@@ -118,7 +156,11 @@ jq -n \
     --argjson passed "${passed}" \
     --argjson failed "${failed}" \
     --argjson pending "${pending}" \
+    --argjson awaiting_approval "${awaiting_count}" \
+    --argjson is_cross_repo "${is_cross_repo}" \
+    --arg head_sha "${head_sha}" \
     --argjson failed_checks "${failed_checks}" \
+    --argjson awaiting_approval_checks "${awaiting_checks}" \
     '{
     status: $status,
     all_passed: $all_passed,
@@ -126,5 +168,9 @@ jq -n \
     passed: $passed,
     failed: $failed,
     pending: $pending,
-    failed_checks: $failed_checks
+    awaiting_approval: $awaiting_approval,
+    is_cross_repository: $is_cross_repo,
+    head_sha: $head_sha,
+    failed_checks: $failed_checks,
+    awaiting_approval_checks: $awaiting_approval_checks
   }'


### PR DESCRIPTION
## Summary

- `ci-check-status.sh` now calls the GitHub runs API to detect `pull_request` workflows gated behind maintainer approval on fork PRs. The output JSON gains `awaiting_approval`, `awaiting_approval_checks`, `is_cross_repository`, and `head_sha` fields, and `all_passed` now requires zero gated workflows.
- The skill routes to a new Step 6 when `awaiting_approval > 0`, spawning the `assess-fork-pr` agent for a read-only safety verdict before alerting the user. Alerts deduplicate by `run_id` across re-polls. The fix handler now includes a checkout safety check before committing.
- `ai/agents/assess-fork-pr.md` is the new read-only triage agent that checks a fork PR diff for secret exfiltration signals, CI tampering, and scope mismatches, returning a compact low/medium/high verdict.

## Test plan

- Run `/ci-monitor` on a fork PR with gated workflows and confirm the alert includes the workflow names and the `assess-fork-pr` verdict.
- Confirm re-polling does not re-alert for already-alerted `run_id`s.
- Run on a same-repo PR and confirm no awaiting-approval path is triggered.
- Run on a fork PR with all checks passed and confirm the fork caveat appears.