### PR TITLE
Add auto-approve base-sync detection to ci-monitor

### DIFF
--- a/ai/skills/ci-monitor/SKILL.md
+++ b/ai/skills/ci-monitor/SKILL.md
@@ -225,7 +225,7 @@ A fork PR re-gates on every push, including a maintainer/contributor clicking **
 
 Save the output as `SAFETY`. It is read-only (it never approves anything) and fails closed: any error, uncertainty, a changed contributor patch, or a `pull_request_target` gated run yields `safe: false`.
 
-- If `SAFETY.safe` is `true` **and** `AUTO_APPROVE_BASE_SYNC` is `true`: this is a verified base-branch sync. Approve the gated runs yourself, once per `run_id` in `awaiting_approval_checks`:
+- If `SAFETY.safe` is `true` **and** `AUTO_APPROVE_BASE_SYNC` is `true`: this is a verified base-branch sync. Approve **only** the runs the script verified, once per `run_id` in `SAFETY.gated_run_ids` (not the ids from `awaiting_approval_checks` — those came from an earlier poll and may point at a different head; `gated_run_ids` is the exact set validated at `SAFETY.current_head_sha`). If `SAFETY.gated_run_ids` is empty, approve nothing and fall through to 6c.
 
   ```bash
   gh api -X POST repos/$ORG/$REPO/actions/runs/<run_id>/approve

--- a/ai/skills/ci-monitor/SKILL.md
+++ b/ai/skills/ci-monitor/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ci-monitor
 description: Monitor CI checks after pushing, detect flaky vs legit failures, and auto-fix
-argument-hint: "[<pr-number>|<pr-url>|--no-fix|--timeout <min>]"
+argument-hint: "[<pr-number>|<pr-url>|--no-fix|--timeout <min>|--auto-approve-base-sync]"
 allowed-tools: Bash(~/.claude/skills/ci-monitor/scripts/*:*, ~/.dotfiles/bin/detect-pr.sh:*, sleep:*, gh:*, git:*), Read(~/.claude/skills/ci-monitor/**), Write, Edit, Agent
 model: sonnet
 ---
@@ -18,6 +18,7 @@ Monitor GitHub CI checks for the current PR, wait for completion, classify failu
 
 - `--no-fix` - Monitor and report only; do not attempt fixes
 - `--timeout <minutes>` - Override default 30-minute timeout
+- `--auto-approve-base-sync` - For a re-gated fork PR, auto-approve the gated workflows **only** when the sole change since your last approval was a base-branch sync (merge/rebase of the base branch) with the contributor's patch unchanged. Off by default; without it, gated runs are always left for you to approve manually.
 
 **Usage examples:**
 
@@ -39,6 +40,7 @@ Extract the PR identifier and flags from `$ARGUMENTS`.
 **Flags to detect:**
 - `--no-fix` - Set `NO_FIX=true`
 - `--timeout <N>` - Set `TIMEOUT_MINUTES=N` (default: 30)
+- `--auto-approve-base-sync` - Set `AUTO_APPROVE_BASE_SYNC=true` (default: `false`)
 
 Remove flags from the argument string, leaving just the PR identifier (number, URL, or empty).
 
@@ -202,7 +204,7 @@ Follow the instructions in the handler. After the handler completes (fix committ
 
 ### Step 6: Awaiting Approval (Outside-Contributor PRs)
 
-`CHECK_DATA` reports `awaiting_approval > 0`. This PR is from a fork, and GitHub is holding its `pull_request` workflows until a maintainer clicks **Approve and run**. Approving lets the contributor's code execute on the repo's CI runners (with whatever secrets those workflows expose), so the goal here is to scan for danger, alert the user with that read, and let **them** approve. **Never approve a run yourself.**
+`CHECK_DATA` reports `awaiting_approval > 0`. This PR is from a fork, and GitHub is holding its `pull_request` workflows until a maintainer clicks **Approve and run**. Approving lets the contributor's code execute on the repo's CI runners (with whatever secrets those workflows expose), so the goal here is to scan for danger, alert the user with that read, and let **them** approve. **Do not approve a run yourself**, with one exception: a verified base-branch sync when the user passed `--auto-approve-base-sync` (6b). In every other case the human approves.
 
 The `awaiting_approval_checks` array holds one entry per gated workflow: `workflow`, `link` (the run URL), and `run_id`.
 
@@ -210,10 +212,32 @@ The `awaiting_approval_checks` array holds one entry per gated workflow: `workfl
 
 Compute `NEW_RUNS` = the entries in `awaiting_approval_checks` whose `run_id` is **not** in `ALERTED_APPROVAL_RUNS`.
 
-- If `NEW_RUNS` is empty, you have already alerted for everything currently gated. Skip to **6d** (keep polling quietly).
+- If `NEW_RUNS` is empty, you have already alerted for everything currently gated. Skip to **6e** (keep polling quietly).
 - Otherwise continue to 6b.
 
-**6b. Scan for approval safety.**
+**6b. Check whether this re-gating is only a base-branch sync.**
+
+A fork PR re-gates on every push, including a maintainer/contributor clicking **Update branch** (a merge or rebase of the base branch). When the *only* change since your last approval was such a sync, with the contributor's own patch unchanged, re-approving is exactly as safe as the approval you already gave. Determine that:
+
+```bash
+~/.claude/skills/ci-monitor/scripts/ci-approval-safety.sh $PR_NUMBER "$ORG/$REPO" 2>&1
+```
+
+Save the output as `SAFETY`. It is read-only (it never approves anything) and fails closed: any error, uncertainty, a changed contributor patch, or a `pull_request_target` gated run yields `safe: false`.
+
+- If `SAFETY.safe` is `true` **and** `AUTO_APPROVE_BASE_SYNC` is `true`: this is a verified base-branch sync. Approve the gated runs yourself, once per `run_id` in `awaiting_approval_checks`:
+
+  ```bash
+  gh api -X POST repos/$ORG/$REPO/actions/runs/<run_id>/approve
+  ```
+
+  Then emit a one-line audit alert naming the count, the last approved sha (`SAFETY.last_approved_sha`), and the current head sha (`SAFETY.current_head_sha`), and stating that it was a base-branch sync only with the contributor patch unchanged. Add every approved `run_id` to `ALERTED_APPROVAL_RUNS`, then go to **6e**. Skip 6c and 6d; no human action is needed, and the prior approval's safety scan still applies because the patch is unchanged.
+
+- If `SAFETY.safe` is `true` but `AUTO_APPROVE_BASE_SYNC` is `false`: continue to 6c, but include in the alert that this appears to be a base-branch sync only (contributor patch unchanged since `$SAFETY.last_approved_sha`), so approval is low-risk. Still let the user approve.
+
+- If `SAFETY.safe` is `false`: continue to 6c as normal (new or changed contributor code, or undeterminable; treat as a fresh approval decision).
+
+**6c. Scan for approval safety.**
 
 Delegate a read-only safety read to the `assess-fork-pr` agent and **wait for its verdict** (you need it before alerting):
 
@@ -228,20 +252,20 @@ Agent tool with:
 
 Keep the returned verdict block (risk level, reasons, files to watch).
 
-**6c. Alert the user.**
+**6d. Alert the user.**
 
 Present a single, prominent alert:
 
 - "PR #$PR_NUMBER ($ORG/$REPO) is from a fork and has **N workflow(s) awaiting your approval** to run."
 - List the gated workflow names (cap at ~10; if more, show the count and the first 10).
-- Include the safety verdict block from 6b verbatim.
+- Include the safety verdict block from 6c verbatim.
 - **Primary action:** "Review and approve at <https://github.com/$ORG/$REPO/pull/$PR_NUMBER>. The **Approve and run** button on the Checks tab approves all gated workflows at once."
 - **Power-path (optional):** approve runs individually via the API, one call per `run_id`: `gh api -X POST repos/$ORG/$REPO/actions/runs/<run_id>/approve`.
 - Make clear you will **not** approve on their behalf, and that the safety scan only covers the PR diff (it cannot see how the base repo's existing workflows handle secrets).
 
 Add every `run_id` in `NEW_RUNS` to `ALERTED_APPROVAL_RUNS`.
 
-**6d. Keep polling.**
+**6e. Keep polling.**
 
 The user chose to be alerted and let monitoring continue, so wait for them to approve:
 

--- a/ai/skills/ci-monitor/scripts/ci-approval-safety.sh
+++ b/ai/skills/ci-monitor/scripts/ci-approval-safety.sh
@@ -15,7 +15,11 @@
 #   ci-approval-safety.sh <pr_number> [<org/repo>]
 #
 # Output: JSON { safe, reason, last_approved_sha, current_head_sha,
-#                gated_count, gated_workflows }
+#                gated_count, gated_workflows, gated_run_ids }
+#
+# gated_run_ids holds every gated run at the verified current head. The caller
+# approves exactly these ids, so "what was verified" and "what gets approved" are
+# the same set of runs at the same sha, not two snapshots taken at different times.
 
 set -euo pipefail
 
@@ -38,7 +42,7 @@ emit_unsafe() {
     jq -n --arg reason "$1" '{
         safe: false, reason: $reason,
         last_approved_sha: null, current_head_sha: null,
-        gated_count: 0, gated_workflows: []
+        gated_count: 0, gated_workflows: [], gated_run_ids: []
     }'
     exit 0
 }
@@ -68,17 +72,19 @@ fi
 [[ -n "${repo_nwo}" ]] || emit_unsafe "could not resolve owner/repo"
 
 # ── Gated runs at the current head ───────────────────────────────────────────
-# The workflows currently held for approval. Restricted to pull_request(_target)
-# so unrelated action_required runs never appear. The verdict refuses any
-# pull_request_target gated run outright.
+# Every run currently held for approval at the verified head, ungrouped: the
+# caller approves these exact run_ids, so the set verified here is the set
+# approved. Restricted to pull_request(_target) so unrelated action_required runs
+# never appear. The verdict refuses any pull_request_target gated run outright,
+# and sees every run (not one-per-workflow) so a target run can't hide behind a
+# same-named pull_request run.
 
 gated_runs=$(gh api \
     "repos/${repo_nwo}/actions/runs?head_sha=${current_head_sha}&status=action_required&per_page=100" \
     --jq '[.workflow_runs[]
            | select(.conclusion == "action_required")
            | select(.event == "pull_request" or .event == "pull_request_target")
-           | {event: .event, run_id: .id, workflow: .name}]
-          | group_by(.workflow) | map(.[0])' \
+           | {event: .event, run_id: .id, workflow: .name}]' \
     2> /dev/null) || emit_unsafe "could not query gated runs"
 gated_count=$(echo "${gated_runs}" | jq 'length')
 
@@ -129,8 +135,10 @@ verdict=$(jq -n \
       gated_runs: $runs, compare_then: $c_then, compare_now: $c_now}' \
     | jq -f "${DECISION_JQ}")
 
-# Attach gated-run context for the caller's alert.
+# Attach gated-run context for the caller's alert. gated_run_ids is every gated
+# run to approve; gated_workflows/gated_count are deduped by workflow for display.
 echo "${verdict}" | jq \
-    --argjson count "${gated_count}" \
     --argjson runs "${gated_runs}" \
-    '. + {gated_count: $count, gated_workflows: [$runs[].workflow]}'
+    '. + {gated_count: ([$runs[].workflow] | unique | length),
+          gated_workflows: ([$runs[].workflow] | unique),
+          gated_run_ids: [$runs[].run_id]}'

--- a/ai/skills/ci-monitor/scripts/ci-approval-safety.sh
+++ b/ai/skills/ci-monitor/scripts/ci-approval-safety.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# ci-approval-safety.sh - Decide whether a re-gated fork PR can be auto-approved.
+#
+# An outside-contributor (fork) PR re-gates its workflows on every new push,
+# including a maintainer/contributor clicking "Update branch" (a merge or rebase
+# of the base branch). This script reports whether the only change since the
+# last approval was such a base-branch sync, with no new contributor code - in
+# which case re-approval is as safe as the approval you already gave.
+#
+# This script is READ-ONLY: it emits a verdict and never approves anything.
+# The decision is a pure function (helpers/approval-safety.jq); this wrapper only
+# gathers the inputs. It fails closed (safe:false) on any error or uncertainty.
+#
+# Usage:
+#   ci-approval-safety.sh <pr_number> [<org/repo>]
+#
+# Output: JSON { safe, reason, last_approved_sha, current_head_sha,
+#                gated_count, gated_workflows }
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=helpers/ci-helpers.sh
+source "${SCRIPT_DIR}/helpers/ci-helpers.sh"
+ci_require_cmds gh jq
+
+DECISION_JQ="${SCRIPT_DIR}/helpers/approval-safety.jq"
+LAST_APPROVED_JQ="${SCRIPT_DIR}/helpers/last-approved-sha.jq"
+
+pr_number="${1:?Usage: ci-approval-safety.sh <pr_number> [<org/repo>]}"
+repo_arg="${2:-}"
+
+repo_flag=()
+ci_repo_flag repo_flag "${repo_arg}"
+
+# Emit a fail-closed verdict and exit 0 (callers parse JSON, not exit codes).
+emit_unsafe() {
+    jq -n --arg reason "$1" '{
+        safe: false, reason: $reason,
+        last_approved_sha: null, current_head_sha: null,
+        gated_count: 0, gated_workflows: []
+    }'
+    exit 0
+}
+
+# ── PR identity ──────────────────────────────────────────────────────────────
+
+pr_json=$(gh pr view "${pr_number}" "${repo_flag[@]}" \
+    --json headRefName,headRefOid,baseRefName,isCrossRepository,headRepositoryOwner \
+    2> /dev/null) || emit_unsafe "could not fetch PR #${pr_number}"
+
+IFS=$'\t' read -r head_branch current_head_sha base_ref is_cross_repo fork_owner < <(
+    echo "${pr_json}" | jq -r '[
+        .headRefName // "",
+        .headRefOid // "",
+        .baseRefName // "",
+        (.isCrossRepository // false | tostring),
+        .headRepositoryOwner.login // ""
+    ] | @tsv')
+
+[[ "${is_cross_repo}" == "true" ]] || emit_unsafe "not a fork PR; approval gating does not apply"
+[[ -n "${current_head_sha}" && -n "${base_ref}" ]] || emit_unsafe "could not resolve PR head/base"
+
+repo_nwo="${repo_arg}"
+if [[ -z "${repo_nwo}" ]]; then
+    repo_nwo=$(gh repo view --json nameWithOwner -q .nameWithOwner 2> /dev/null || echo "")
+fi
+[[ -n "${repo_nwo}" ]] || emit_unsafe "could not resolve owner/repo"
+
+# ── Gated runs at the current head ───────────────────────────────────────────
+# The workflows currently held for approval. Restricted to pull_request(_target)
+# so unrelated action_required runs never appear. The verdict refuses any
+# pull_request_target gated run outright.
+
+gated_runs=$(gh api \
+    "repos/${repo_nwo}/actions/runs?head_sha=${current_head_sha}&status=action_required&per_page=100" \
+    --jq '[.workflow_runs[]
+           | select(.conclusion == "action_required")
+           | select(.event == "pull_request" or .event == "pull_request_target")
+           | {event: .event, run_id: .id, workflow: .name}]
+          | group_by(.workflow) | map(.[0])' \
+    2> /dev/null) || emit_unsafe "could not query gated runs"
+gated_count=$(echo "${gated_runs}" | jq 'length')
+
+# Nothing gated means nothing to approve; skip the heavier prior-runs and compare
+# fetches below, which would only reach the same fail-closed verdict.
+[[ "${gated_count}" -gt 0 ]] || emit_unsafe "no gated runs awaiting approval"
+
+# ── Last approved head sha ───────────────────────────────────────────────────
+# The head sha of the most recent run for this fork branch that already ran.
+# Matched on head_branch + fork owner to disambiguate same-named branches from
+# other forks. The selection is a pure function (helpers/last-approved-sha.jq)
+# so it can be fixture-tested; `gh api --jq` cannot define the $fork variable, so
+# fetch raw and pipe to jq.
+runs_raw=$(gh api \
+    "repos/${repo_nwo}/actions/runs?event=pull_request&branch=${head_branch}&per_page=100" \
+    2> /dev/null) || emit_unsafe "could not query prior runs"
+last_approved_sha=$(echo "${runs_raw}" | jq -r --arg fork "${fork_owner}" -f "${LAST_APPROVED_JQ}")
+
+# ── Three-dot compares (only when needed) ────────────────────────────────────
+# Resolve the base branch to a single sha and reuse it for both compares, so a
+# merge to master landing between the two API calls can't cause a spurious
+# mismatch.
+
+compare_then='{}'
+compare_now='{}'
+if [[ -n "${last_approved_sha}" && "${last_approved_sha}" != "${current_head_sha}" ]]; then
+    base_sha=$(gh api "repos/${repo_nwo}/commits/${base_ref}" -q .sha 2> /dev/null || echo "")
+    [[ -n "${base_sha}" ]] || emit_unsafe "could not resolve base branch '${base_ref}' to a sha"
+
+    # Keep only the head blob sha per changed file: the content signature the
+    # verdict compares. Identical for both compares so it lives in one place.
+    compare_fields='{files: [(.files // [])[] | {filename, status, sha, previous_filename}]}'
+    compare_then=$(gh api "repos/${repo_nwo}/compare/${base_sha}...${last_approved_sha}" \
+        --jq "${compare_fields}" 2> /dev/null) || emit_unsafe "could not compare base...last_approved_sha"
+    compare_now=$(gh api "repos/${repo_nwo}/compare/${base_sha}...${current_head_sha}" \
+        --jq "${compare_fields}" 2> /dev/null) || emit_unsafe "could not compare base...current_head"
+fi
+
+# ── Verdict ──────────────────────────────────────────────────────────────────
+
+verdict=$(jq -n \
+    --arg last "${last_approved_sha}" \
+    --arg cur "${current_head_sha}" \
+    --argjson runs "${gated_runs}" \
+    --argjson c_then "${compare_then}" \
+    --argjson c_now "${compare_now}" \
+    '{last_approved_sha: $last, current_head_sha: $cur,
+      gated_runs: $runs, compare_then: $c_then, compare_now: $c_now}' \
+    | jq -f "${DECISION_JQ}")
+
+# Attach gated-run context for the caller's alert.
+echo "${verdict}" | jq \
+    --argjson count "${gated_count}" \
+    --argjson runs "${gated_runs}" \
+    '. + {gated_count: $count, gated_workflows: [$runs[].workflow]}'

--- a/ai/skills/ci-monitor/scripts/helpers/approval-safety.jq
+++ b/ai/skills/ci-monitor/scripts/helpers/approval-safety.jq
@@ -1,0 +1,54 @@
+# approval-safety.jq - Pure verdict for auto-approving a re-gated fork PR.
+#
+# Decides whether the gated workflows on an outside-contributor PR can be
+# auto-approved because the only change since the last approval was a sync from
+# the base branch (a merge or rebase of master), with no new contributor code.
+#
+# Why the blob-sha signature of a three-dot compare is a sound safety check:
+# `compare/BASE...HEAD` diffs from merge-base(BASE, HEAD) to HEAD. The merge base
+# is always an ancestor of BASE (trusted master), so its tree is entirely
+# trusted. Any contributor content that is NOT already in master therefore MUST
+# appear in the three-dot diff. The `sha` field is the whole-file (blob) content
+# hash, so any change to a touched file's content flips the signature. An
+# attacker cannot hide content in the merge base, because the merge base is an
+# ancestor of master and a contributor cannot write to master. So: identical
+# signatures before and after => the contributor added nothing new.
+#
+# Fails closed (safe:false) on every uncertainty. False negatives are harmless
+# (a human still approves); a false positive runs unreviewed code, so it must
+# never happen.
+#
+# Input (stdin), one object:
+#   { last_approved_sha, current_head_sha, gated_runs:[{event,...}],
+#     compare_then:<compare API JSON>, compare_now:<compare API JSON> }
+# Output: { safe, reason, last_approved_sha, current_head_sha }
+
+# Content signature of a compare response: every touched file by name, change
+# type, blob sha, and rename source. .github/ is deliberately NOT excluded - a
+# contributor-modified workflow file IS contributor content and must fail closed.
+def sig(c): [ (c.files // [])[] | {filename, status, sha, previous_filename} ]
+            | sort_by(.filename);
+
+. as $in
+| (($in.gated_runs // [])) as $runs
+| (($in.compare_then.files // []) | length) as $n_then
+| (($in.compare_now.files // []) | length) as $n_now
+| (
+    if (($in.last_approved_sha // "") == "") then
+      {safe: false, reason: "no prior approved run found for this PR head branch"}
+    elif (($runs | length) == 0) then
+      {safe: false, reason: "no gated runs awaiting approval"}
+    elif ($runs | any(.event == "pull_request_target")) then
+      {safe: false, reason: "a gated run uses pull_request_target; refusing to auto-approve"}
+    elif ($in.last_approved_sha == $in.current_head_sha) then
+      {safe: true, reason: "current head identical to last approved sha"}
+    elif ($n_then >= 300 or $n_now >= 300) then
+      {safe: false, reason: "compare diff may be truncated (>=300 files); cannot verify contributor patch"}
+    elif (sig($in.compare_then) == sig($in.compare_now)) then
+      {safe: true, reason: "contributor patch unchanged since last approval (base-branch sync only)"}
+    else
+      {safe: false, reason: "contributor patch changed since last approval"}
+    end
+  )
+| . + {last_approved_sha: ($in.last_approved_sha // null),
+       current_head_sha: ($in.current_head_sha // null)}

--- a/ai/skills/ci-monitor/scripts/helpers/last-approved-sha.jq
+++ b/ai/skills/ci-monitor/scripts/helpers/last-approved-sha.jq
@@ -1,0 +1,18 @@
+# last-approved-sha.jq - Head sha of the most recent run that already ran for a
+# fork PR's head branch (the last state CI was let through on).
+#
+# Input (stdin): a GitHub "list workflow runs" response, { workflow_runs: [...] }.
+# Arg $fork: the fork owner login, to disambiguate same-named branches from
+# other forks.
+# Output: the head_sha string, or "" when no such run exists.
+#
+# A gated run sits at conclusion == "action_required"; any run past that state
+# was let through. The signal is "ran before", not "was deliberately approved" -
+# the caller only trusts this sha by comparing content signatures against it, so
+# a stale or over-broad pick can only fail closed, never auto-approve new code.
+# The runs API returns newest first, so `first` is the most recent.
+[ .workflow_runs[]
+  | select(.head_repository.owner.login == $fork)
+  | select(.status == "completed" or .status == "in_progress")
+  | select((.conclusion // "") != "action_required") ]
+| first | .head_sha // ""

--- a/ai/skills/ci-monitor/scripts/tests/test-approval-safety.sh
+++ b/ai/skills/ci-monitor/scripts/tests/test-approval-safety.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# Tests for approval-safety.jq, the pure auto-approve verdict.
+#
+# Feeds fixtures straight into the jq decision program and asserts on `safe`.
+# The property under test is "false negatives are safe": every uncertain or
+# changed input must yield safe:false; only an unchanged contributor patch may
+# yield safe:true.
+#
+# Usage: test-approval-safety.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DECISION_JQ="${SCRIPT_DIR}/../helpers/approval-safety.jq"
+
+passes=0
+failures=0
+
+# decide '<input json>' -> prints the `safe` boolean
+decide() {
+    jq -n "$1" | jq -f "${DECISION_JQ}" | jq -r '.safe'
+}
+
+assert_safe() {
+    local description="$1" input="$2" expected="$3"
+    local actual
+    actual=$(decide "${input}")
+    if [[ "${actual}" == "${expected}" ]]; then
+        passes=$((passes + 1))
+    else
+        echo "FAIL: ${description}"
+        echo "  expected safe=${expected}, got safe=${actual}"
+        echo "  reason: $(jq -n "${input}" | jq -f "${DECISION_JQ}" | jq -r '.reason')"
+        failures=$((failures + 1))
+    fi
+}
+
+# A contributor patch: one file with a fixed blob sha.
+patch_a='{files: [{filename: "src/app.rs", status: "modified", sha: "aaa111", previous_filename: null}]}'
+# Same files, one blob sha changed: the contributor edited something.
+patch_a_changed='{files: [{filename: "src/app.rs", status: "modified", sha: "bbb222", previous_filename: null}]}'
+gated_pr='[{event: "pull_request", run_id: 1, workflow: "CI"}]'
+gated_target='[{event: "pull_request_target", run_id: 2, workflow: "Label"}]'
+
+# 1. Pure base-branch merge, no file overlap -> contributor patch identical -> true
+assert_safe "pure base-sync, patch unchanged" \
+    "{last_approved_sha: \"old\", current_head_sha: \"new\", gated_runs: ${gated_pr}, compare_then: ${patch_a}, compare_now: ${patch_a}}" \
+    "true"
+
+# 2. A new contributor commit changed a blob -> false
+assert_safe "contributor changed a file -> false" \
+    "{last_approved_sha: \"old\", current_head_sha: \"new\", gated_runs: ${gated_pr}, compare_then: ${patch_a}, compare_now: ${patch_a_changed}}" \
+    "false"
+
+# 3. Merge touched a file the contributor also changed (blob differs) -> fail closed
+#    (Modeled as the file dropping out of the "now" diff: file set differs.)
+assert_safe "overlap changes file set -> false" \
+    "{last_approved_sha: \"old\", current_head_sha: \"new\", gated_runs: ${gated_pr}, compare_then: ${patch_a}, compare_now: {files: []}}" \
+    "false"
+
+# 4. Any gated run is pull_request_target -> false
+assert_safe "pull_request_target gated -> false" \
+    "{last_approved_sha: \"old\", current_head_sha: \"new\", gated_runs: ${gated_target}, compare_then: ${patch_a}, compare_now: ${patch_a}}" \
+    "false"
+
+# 5. compare truncation (>=300 files) -> false
+big=$(jq -n '{files: [range(300) | {filename: ("f" + (tostring)), status: "modified", sha: "x", previous_filename: null}]}')
+assert_safe "truncated compare (>=300 files) -> false" \
+    "{last_approved_sha: \"old\", current_head_sha: \"new\", gated_runs: ${gated_pr}, compare_then: ${big}, compare_now: ${big}}" \
+    "false"
+
+# 6. No prior approved run -> false
+assert_safe "no prior approval -> false" \
+    "{last_approved_sha: \"\", current_head_sha: \"new\", gated_runs: ${gated_pr}, compare_then: ${patch_a}, compare_now: ${patch_a}}" \
+    "false"
+
+# 7. Force-push that only rebases onto newer master -> contributor patch identical -> true
+assert_safe "rebase-only force-push -> true" \
+    "{last_approved_sha: \"old\", current_head_sha: \"rebased\", gated_runs: ${gated_pr}, compare_then: ${patch_a}, compare_now: ${patch_a}}" \
+    "true"
+
+# 8. .github/ workflow change must NOT be ignored -> false
+gh_then='{files: [{filename: ".github/workflows/ci.yml", status: "modified", sha: "w1", previous_filename: null}]}'
+gh_now='{files: [{filename: ".github/workflows/ci.yml", status: "modified", sha: "w2", previous_filename: null}]}'
+assert_safe "workflow file change -> false" \
+    "{last_approved_sha: \"old\", current_head_sha: \"new\", gated_runs: ${gated_pr}, compare_then: ${gh_then}, compare_now: ${gh_now}}" \
+    "false"
+
+# 9. Head identical to last approved sha (re-gated same sha, e.g. new base workflow) -> true
+assert_safe "head == last approved sha -> true" \
+    "{last_approved_sha: \"same\", current_head_sha: \"same\", gated_runs: ${gated_pr}, compare_then: {}, compare_now: {}}" \
+    "true"
+
+echo ""
+echo "Passed: ${passes}, Failed: ${failures}"
+[[ "${failures}" -eq 0 ]]

--- a/ai/skills/ci-monitor/scripts/tests/test-last-approved-sha.sh
+++ b/ai/skills/ci-monitor/scripts/tests/test-last-approved-sha.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Tests for last-approved-sha.jq, the prior-approval baseline selection.
+#
+# This pick is security-critical: it is the sha the auto-approve verdict trusts
+# as "already reviewed". A wrong pick can only fail closed (signatures won't
+# match), but it must never silently select a run from a different fork or a
+# still-gated run.
+#
+# Usage: test-last-approved-sha.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SELECT_JQ="${SCRIPT_DIR}/../helpers/last-approved-sha.jq"
+
+passes=0
+failures=0
+
+# run '<fork>' '<runs json>' -> prints the selected head_sha
+run() {
+    echo "$2" | jq -r --arg fork "$1" -f "${SELECT_JQ}"
+}
+
+assert_sha() {
+    local description="$1" fork="$2" runs="$3" expected="$4"
+    local actual
+    actual=$(run "${fork}" "${runs}")
+    if [[ "${actual}" == "${expected}" ]]; then
+        passes=$((passes + 1))
+    else
+        echo "FAIL: ${description}"
+        echo "  expected '${expected}', got '${actual}'"
+        failures=$((failures + 1))
+    fi
+}
+
+run_obj() {
+    # status conclusion fork_owner head_sha
+    jq -n --arg s "$1" --arg c "$2" --arg f "$3" --arg h "$4" \
+        '{status: $s, conclusion: $c, head_repository: {owner: {login: $f}}, head_sha: $h}'
+}
+
+# Newest-first ordering: most recent ran-state run wins.
+ordered=$(jq -n \
+    --argjson a "$(run_obj completed success contributor newsha)" \
+    --argjson b "$(run_obj completed success contributor oldsha)" \
+    '{workflow_runs: [$a, $b]}')
+assert_sha "picks newest ran run" "contributor" "${ordered}" "newsha"
+
+# A still-gated run (conclusion action_required) is not an approved baseline.
+gated_then_ran=$(jq -n \
+    --argjson g "$(run_obj completed action_required contributor gatedsha)" \
+    --argjson r "$(run_obj completed success contributor ransha)" \
+    '{workflow_runs: [$g, $r]}')
+assert_sha "skips still-gated run, picks the one that ran" "contributor" "${gated_then_ran}" "ransha"
+
+# A same-named branch on a different fork must not be selected.
+other_fork=$(jq -n \
+    --argjson o "$(run_obj completed success attacker theirsha)" \
+    --argjson m "$(run_obj completed success contributor mysha)" \
+    '{workflow_runs: [$o, $m]}')
+assert_sha "ignores same-named branch from another fork" "contributor" "${other_fork}" "mysha"
+
+# An in-progress run (approved, still running) counts as a ran baseline.
+in_progress=$(jq -n \
+    --argjson p "$(run_obj in_progress null contributor runningsha)" \
+    '{workflow_runs: [$p]}')
+assert_sha "counts in-progress (approved) run" "contributor" "${in_progress}" "runningsha"
+
+# No matching run -> empty string (verdict then fails closed).
+none=$(jq -n --argjson g "$(run_obj completed action_required contributor onlygated)" '{workflow_runs: [$g]}')
+assert_sha "no prior ran run -> empty" "contributor" "${none}" ""
+
+# Empty payload -> empty string.
+assert_sha "empty workflow_runs -> empty" "contributor" '{"workflow_runs": []}' ""
+
+echo ""
+echo "Passed: ${passes}, Failed: ${failures}"
+[[ "${failures}" -eq 0 ]]


### PR DESCRIPTION
When a fork PR re-gates its CI after a contributor or maintainer clicks "Update branch" (a base-branch merge/rebase), ci-monitor now runs a read-only safety check before presenting the manual approval prompt. The check compares the three-dot diff blob-sha signature of the contributor's patch before and after the sync: identical signatures mean the contributor added nothing new and re-approving is as safe as the original.

The verdict is a pure jq function (`helpers/approval-safety.jq`) fed JSON by a bash I/O wrapper (`ci-approval-safety.sh`). The wrapper fails closed on any error, uncertainty, changed contributor patch, `pull_request_target` gated run, or diff truncation (>=300 files). A new `--auto-approve-base-sync` flag, off by default, is the only way to trigger automatic approval. Without it, the safety result still enriches the manual-approval alert with a "this looks like a base-sync, low-risk" note.

Security property verified empirically: GitHub's compare API `.files[].sha` field is the blob content hash of the file at HEAD (matched against both the contents API and local `git rev-parse`), and it is stable across different base SHAs for the same content.

## Test plan

- `test-approval-safety.sh`: 9 verdict fixtures (unchanged patch, changed blob, `pull_request_target`, >=300-file truncation, no prior run, rebase force-push, `.github/` workflow edit, head==last SHA)
- `test-last-approved-sha.sh`: 6 baseline-selection fixtures (newest-first, gated run excluded, different-fork same branch name, in-progress run, empty)
- Live: `ci-approval-safety.sh 127 haacked/dotfiles` returns `safe:false, reason: "not a fork PR"` (expected fail-closed)
- Live: the `jq -f last-approved-sha.jq` path exercised against `repos/cli/cli/actions/runs` and returned a non-empty SHA