### PR TITLE
Signal Slack DM delivery failures in headless workers

### DIFF
--- a/bin/lib/claude-worker.sh
+++ b/bin/lib/claude-worker.sh
@@ -6,6 +6,14 @@
 # $SESSION_ID and a DM step from `slack_dm_instructions`), and finishes with
 # `claude_worker_run "<heartbeat label>" "$PROMPT"`.
 #
+# A headless `claude --print` run has no further turns, so a worker that can't
+# deliver its Slack DM cannot "wait and retry later" — it just ends, and the
+# wrapper would see exit 0 and report success even though nothing was sent.
+# `slack_dm_instructions` tells the worker to print WORKER_DM_FAILED_SENTINEL
+# (plus the undelivered body) when it gives up, and `claude_worker_run` greps
+# the captured stdout for that marker and exits non-zero so the failure is
+# visible in the log instead of masked as success.
+#
 # Knobs (set before claude_worker_run; all have no defaults here so each
 # worker's env-overridable defaults stay next to its config):
 #   MAX_BUDGET_USD          --max-budget-usd for the claude run
@@ -27,6 +35,12 @@
 # Hardcoded so scheduled runs don't burn a slack_search_users round trip on a
 # fixed input.
 SLACK_DM_USER_ID="${SLACK_DM_USER_ID:-U086UNZDP37}"
+
+# Marker a worker prints (per slack_dm_instructions) when it exhausts Slack send
+# retries. claude_worker_run greps the run's stdout for it to detect a delivery
+# failure that would otherwise look like success (the run still exits 0). Kept
+# distinctive so it never collides with real output.
+WORKER_DM_FAILED_SENTINEL="<<<WORKER_DM_DELIVERY_FAILED>>>"
 
 # claude_worker_init <state-name>
 # Sets WORKING_DIR (the repo root, auto-detected so the worker runs correctly
@@ -67,6 +81,22 @@ ${step}. Send ${content} as a Slack DM using
       ${footer_intro}
         cd ${WORKING_DIR}
         claude --resume ${SESSION_ID}
+
+   If the send fails, retry it inline a few times (up to 4 attempts total).
+   Do NOT start a background timer or wait for a completion notification to
+   fire a later retry: this is a non-interactive --print run with no further
+   turns, so nothing will ever wake you and the run would stall until it is
+   killed. Run the retries back to back, then stop.
+
+   If every attempt still fails (e.g. the Slack write path is down), give up
+   on delivery and, as the very LAST thing you output, print this marker on a
+   line by itself, exactly:
+
+     ${WORKER_DM_FAILED_SENTINEL}
+
+   then print the full DM body you could not send, so it is captured in the
+   run log for recovery. Print the marker ONLY when the DM was not delivered;
+   never print it after a successful send.
 EOF
 }
 
@@ -90,6 +120,10 @@ claude_worker_run() {
   fi
 
   log_info "Invoking claude --print"
+  # Capture stdout via tee so we can both stream it to the log and scan it for
+  # the DM-failure sentinel; PIPESTATUS[0] gives claude's exit, not tee's.
+  local out_file
+  out_file="$(mktemp "${TMPDIR:-/tmp}/${WORKER_STATE_NAME}-out.XXXXXX")"
   start_heartbeat 60 "$heartbeat_label"
   set +e
   caffeinate -i timeout --kill-after="$RUN_KILL_AFTER_SECONDS" \
@@ -99,17 +133,28 @@ claude_worker_run() {
       "${permission_args[@]}" \
       --max-budget-usd "$MAX_BUDGET_USD" \
       --output-format text \
-      "$prompt"
-  local exit_code=$?
+      "$prompt" | tee "$out_file"
+  local exit_code=${PIPESTATUS[0]}
   set -e
   stop_heartbeat
 
-  if [[ $exit_code -eq 0 ]]; then
-    log_success "${WORKER_STATE_NAME} finished (session $SESSION_ID)"
-  elif [[ $exit_code -eq 124 ]]; then
+  local dm_failed=0
+  if grep -qF "$WORKER_DM_FAILED_SENTINEL" "$out_file"; then
+    dm_failed=1
+  fi
+  rm -f "$out_file"
+
+  if [[ $exit_code -eq 124 ]]; then
     log_error "${WORKER_STATE_NAME} timed out after ${RUN_TIMEOUT_SECONDS}s"
-  else
+  elif [[ $exit_code -ne 0 ]]; then
     log_error "${WORKER_STATE_NAME} failed with exit code $exit_code"
+  elif [[ $dm_failed -eq 1 ]]; then
+    # Output was produced but Slack delivery failed; the body is in the log
+    # above. Surface as a non-zero exit so the run isn't logged as success.
+    log_error "${WORKER_STATE_NAME} produced output but could not deliver the Slack DM (write path down); undelivered body is in the log above. Resume: claude --resume ${SESSION_ID}"
+    exit_code=3
+  else
+    log_success "${WORKER_STATE_NAME} finished (session $SESSION_ID)"
   fi
 
   exit "$exit_code"


### PR DESCRIPTION
## Problem

Friday's standup DM never arrived. The Slack MCP write path was down: every `slack_send_message` returned `MCP error -32603: Internal Server Error` while reads kept working. The standup notes were generated and archived fine, but two things went wrong on the way out.

The headless worker exhausted its send retries and then improvised a "wait on a background timer" retry, which can never fire in a one-shot `claude --print` run because there are no further turns to wake into. The session just ended. Then the wrapper saw exit 0 and logged `[SUCCESS]`, so a total delivery failure looked like a clean run. No DM landed, and unlike the Wednesday run the draft fallback also 500'd, so nothing reached Slack at all.

This was the second time that week the same Slack write outage hit a scheduled run.

## Fix

All three headless workers (`standup-run`, `sprint-status-run`, `triage-run`) share `bin/lib/claude-worker.sh`, so the fix lives there.

`slack_dm_instructions` now forbids the timer-wait and explains why it hangs in `--print`, asks for inline bounded retries, and on total failure tells the worker to print the sentinel `<<<WORKER_DM_DELIVERY_FAILED>>>` followed by the undelivered body so it stays recoverable from the log.

`claude_worker_run` tees stdout to a tempfile, greps for the sentinel via `PIPESTATUS`, and exits non-zero (3) with a `log_error` when delivery failed, so the run is no longer masked as success.

The signal is stdout-only, so it works under `triage-run`'s restricted `--allowedTools` allowlist (which forbids file writes) as well as the `bypassPermissions` workers.

This does not prevent a Slack outage. It makes the failure loud (non-zero exit, error in the log, undelivered body preserved) instead of silently green.

## Test plan

- [ ] `bash -n` passes on `claude-worker.sh`, `standup-run`, `sprint-status-run`, `triage-run`
- [ ] Unit test of the tee + `PIPESTATUS` + `grep -F` detection: success and crash and timeout cases stay on their existing paths; only the sentinel case flips to exit 3 with an error
- [ ] `slack_dm_instructions` renders with the sentinel and resume footer intact