### PR TITLE
Skip locked worktrees in bclean-local without prompting

### DIFF
--- a/bin/git-bclean-local
+++ b/bin/git-bclean-local
@@ -43,16 +43,18 @@ for branch in "${gone_branches[@]}"; do
         if err=$(git worktree remove "$wt_path" 2>&1); then
             echo "Removed worktree: $wt_path"
         else
-            echo "Warning: could not remove worktree at $wt_path"
-            echo "  Reason: $err"
-            read -rp "Force remove and delete branch '$branch'? [y/N] " answer
-            if [[ "$answer" =~ ^[Yy]$ ]]; then
-                git worktree remove --force "$wt_path"
-                echo "Force-removed worktree: $wt_path"
+            # A locked worktree (e.g. an active supacode build) can't be removed
+            # without -f -f. Skip it rather than fighting the lock owner, and keep
+            # the branch so it gets cleaned up once the worktree is released.
+            if [[ "$err" == *"locked working tree"* ]]; then
+                reason="locked"
+                [[ "$err" == *'"owner":"supacode"'* ]] && reason="locked by supacode"
+                echo "Skipping $branch (worktree $reason): $wt_path"
             else
-                echo "Skipping $branch"
-                continue
+                echo "Skipping $branch (could not remove worktree): $wt_path"
+                echo "  Reason: $err"
             fi
+            continue
         fi
     fi
 


### PR DESCRIPTION
When `git worktree remove` fails because the worktree is locked (e.g. an active supacode build holds it), `git bdone` used to print a warning and prompt "Force remove and delete branch? [y/N]". Answering "y" then ran `--force`, which still fails against a lock. Git requires `-f -f` to override a lock, and a single `--force` isn't enough.

The new behavior: if the error indicates a locked worktree, print a one-line note and skip to the next branch without prompting. The branch is kept so it gets cleaned up next time `git bdone` runs after the lock is released. Non-lock failures still print the underlying reason.

**Test plan:**
- Run `git bdone` in a repo where a supacode-locked worktree exists for a merged branch; confirm it prints a skip note and exits cleanly without prompting.
- Run `git bdone` in a clean repo with merged branches; confirm normal worktree removal still works.