### PR TITLE
Fix stale feature/early-access label in flags triage

### DIFF
--- a/ai/agents/triage-feature-flags.md
+++ b/ai/agents/triage-feature-flags.md
@@ -29,7 +29,7 @@ When you identify a relevant issue, suggest one or more of these labels:
 | `team/feature-flags` | Always add this for issues owned by the team |
 | `feature/feature-flags` | Issues specifically about feature flag functionality |
 | `feature/cohorts` | Issues specifically about cohorts/user segments |
-| `feature/early-access` | Issues about early access feature management |
+| `feature/early-access-management` | Issues about early access feature management |
 
 ## Keywords to Look For
 

--- a/ai/skills/triage-issues/SKILL.md
+++ b/ai/skills/triage-issues/SKILL.md
@@ -55,7 +55,7 @@ gh issue list --repo PostHog/posthog --state open --limit {limit} --json number,
 The `{exclusion_labels}` vary by team. For feature-flags:
 
 ```text
--label:team/feature-flags -label:feature/feature-flags -label:feature/cohorts -label:feature/early-access
+-label:team/feature-flags -label:feature/feature-flags -label:feature/cohorts -label:feature/early-access-management
 ```
 
 **Note:** The `date -v-Nd` syntax is macOS-specific. On Linux, use `date -d "N days ago"`.

--- a/bin/triage-flags-pr-candidates
+++ b/bin/triage-flags-pr-candidates
@@ -52,7 +52,7 @@ trap 'rm -f "$tmp_rows" "$tmp_files"' EXIT
 # @tsv escapes any embedded tabs/newlines, so the columns stay parseable below.
 gh search prs --repo "$REPO" --state open --limit "$LIMIT" \
   --json number,title,author,authorAssociation \
-  -- "created:>=$since -label:team/feature-flags -label:feature/feature-flags -label:feature/cohorts -label:feature/early-access" \
+  -- "created:>=$since -label:team/feature-flags -label:feature/feature-flags -label:feature/cohorts -label:feature/early-access-management" \
   | jq -r --arg bots "$BOT_RE" '
       .[]
       | select(.authorAssociation=="MEMBER" or .authorAssociation=="OWNER" or .authorAssociation=="COLLABORATOR")


### PR DESCRIPTION
The label `feature/early-access` was renamed to `feature/early-access-management` in the PostHog repo. This updates the triage agent, triage-issues skill, and `triage-flags-pr-candidates` script to use the correct label name so triage exclusions filter properly.

**Test plan:**
- Run `triage-flags-pr-candidates` and confirm PRs already labeled `feature/early-access-management` are excluded from results.
- Run the triage-feature-flags agent on a relevant issue and confirm it suggests `feature/early-access-management` (not `feature/early-access`).