### PR TITLE
Ensure tree-me PR worktrees always have a pullable upstream

### DIFF
--- a/bin/tree-me
+++ b/bin/tree-me
@@ -280,6 +280,19 @@ EOF
         fi
         echo "✓ PR #$pr_number checked out at: $path"
 
+        # `gh pr checkout` configures tracking for same-repo PRs and forks with
+        # "Allow edits from maintainers" enabled. It leaves the branch with no
+        # upstream for forks without that flag, so a bare `git pull` then fails
+        # with "no tracking information for the current branch". Backstop it:
+        # every PR head is reachable as refs/pull/<N>/head on origin, so point
+        # the branch there when nothing else set an upstream. This is a no-op
+        # when gh already configured tracking (the common case).
+        if [ -z "$(git -C "$path" config --get "branch.$branch.merge")" ]; then
+            git -C "$path" config "branch.$branch.remote" origin
+            git -C "$path" config "branch.$branch.merge" "refs/pull/$pr_number/head"
+            echo "ℹ Set '$branch' to pull from origin refs/pull/$pr_number/head" >&2
+        fi
+
         # Track with Graphite if available (use --force to auto-detect parent)
         (cd "$path" && graphite_track "$branch" "")
 


### PR DESCRIPTION
`gh pr checkout` sets up tracking for same-repo PRs and for fork PRs where "Allow edits from maintainers" is enabled. For fork PRs without that flag, it leaves the branch with no `merge` config, so a bare `git pull` fails with "no tracking information for the current branch".

Every PR head is reachable as `refs/pull/<N>/head` on origin, so the fix checks for a missing `merge` after checkout and points the branch there. It's a no-op whenever gh already configured tracking.

## Test plan

- [ ] Run `tree-me pr <internal-pr-number>` on a same-repo PR and confirm `git pull` works and the fallback message is not printed.
- [ ] For a fork PR with `maintainerCanModify=false`, confirm the branch gets `remote=origin` and `merge=refs/pull/<N>/head`, and `git pull` fetches without error.