### PR TITLE
Add --plan-file support to /go and auto-invoke it after plan approval

### DIFF
--- a/ai/CLAUDE.md
+++ b/ai/CLAUDE.md
@@ -20,6 +20,8 @@
 
 ### Implementation Flow
 
+If arriving from an approved Plan Mode plan, use `Skill("go", args: "--plan-file <path>")` instead of the manual steps below — it runs plan-reuse, implementation, simplify, commit, PR, and both review loops automatically.
+
 1. Study existing patterns in the codebase
 2. `unit-test-writer` writes tests first (red)
 3. Implement minimal code to pass (green)

--- a/ai/bin/suggest-go-after-plan.sh
+++ b/ai/bin/suggest-go-after-plan.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Claude Code PostToolUse hook for ExitPlanMode.
+# After a plan is approved, nudges Claude to implement it via the /go skill
+# instead of ad hoc, so it gets the full plan -> PR -> review loop.
+
+if ! command -v jq >/dev/null 2>&1; then
+  exit 0
+fi
+
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  exit 0
+fi
+
+if ! git remote -v 2>/dev/null | grep -q 'github\.com'; then
+  exit 0
+fi
+
+INPUT=$(cat)
+
+# ExitPlanMode's tool result always contains a line like:
+#   Your plan has been saved to: /Users/you/.claude/plans/<slug>.md
+# Grep the raw stdin for that path rather than assuming tool_response's JSON
+# field nesting, which isn't documented. Anchor on "saved to:" and stop only
+# at the JSON string's closing quote (not at spaces), so paths containing
+# spaces (e.g. a home directory like "/Users/John Doe/...") still match.
+PLAN_FILE=$(printf '%s' "$INPUT" | grep -oE 'saved to:[^"]*\.claude/plans/[^"]*\.md' | sed -E 's/^saved to: *//' | head -1)
+
+if [ -z "$PLAN_FILE" ]; then
+  # Fallback: most recently modified plan file, but only if it was touched in
+  # the last 2 minutes — otherwise a format change upstream could silently
+  # point Claude at a stale, unrelated plan instead of failing closed.
+  PLAN_FILE=$(find "$HOME/.claude/plans" -maxdepth 1 -name '*.md' -newermt '-2 minutes' -exec ls -t {} + 2>/dev/null | head -1)
+fi
+
+[ -z "$PLAN_FILE" ] && exit 0
+
+jq -n --arg path "$PLAN_FILE" '
+  {
+    "hookSpecificOutput": {
+      "hookEventName": "PostToolUse",
+      "additionalContext": ("The plan at " + $path + " was just approved. Implement it now via the go skill instead of implementing directly: Skill(\"go\", args: \"--plan-file " + $path + "\"). Do not re-plan or ask what to build — jump straight to implementation using this plan.")
+    }
+  }
+'

--- a/ai/skills/go/SKILL.md
+++ b/ai/skills/go/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: go
 description: Plan, implement, and iteratively review a task end-to-end using Claude + Copilot reviewers in a linear flow.
-argument-hint: "<task description> [--skip-planner] [--skip-copilot]"
+argument-hint: "<task description> [--skip-planner] [--skip-copilot] [--plan-file <path>]"
 model: sonnet
 ---
 
@@ -13,9 +13,10 @@ The expensive steps (`review-fix-loop.sh`, `copilot-review-loop.sh`) run each ro
 
 ## Arguments
 
-- `<task description>` — what to build/fix. Required unless the branch already has uncommitted/unpushed work (see Step 1).
+- `<task description>` — what to build/fix. Required unless the branch already has uncommitted/unpushed work (see Step 1) or `--plan-file` is given.
 - `--skip-planner` — skip the `implementation-planner` sub-agent; implement directly from the description.
 - `--skip-copilot` — skip the Copilot rounds and the final Claude pass. Useful when there's no PR yet or Copilot is unavailable.
+- `--plan-file <path>` — use an already-approved plan file directly (e.g. one written by Plan Mode) instead of looking up or generating one. Implies skipping the planner.
 
 ## Steps
 
@@ -25,10 +26,13 @@ Extract from `$ARGUMENTS`:
 
 - `SKIP_PLANNER` — boolean, true if `--skip-planner` is present.
 - `SKIP_COPILOT` — boolean, true if `--skip-copilot` is present.
+- `PLAN_FILE` — the path following `--plan-file`, if present.
 - `TASK` — everything else, joined with spaces.
-- `SLUG` — short kebab-case identifier derived from `TASK` (e.g. "add dark mode toggle" → "add-dark-mode-toggle"). Used in commit messages and planner descriptions.
+- `SLUG` — short kebab-case identifier derived from `TASK` (e.g. "add dark mode toggle" → "add-dark-mode-toggle"). Used in commit messages and planner descriptions. If `TASK` is empty and `PLAN_FILE` is set, `SLUG` is derived in Step 2 from the plan file instead.
 
-If `TASK` is empty, check for in-flight work:
+If `PLAN_FILE` is set and `TASK` is empty, skip the in-flight-work check below and go straight to Step 2 — the plan file is the entry point, not a task description.
+
+If `TASK` is empty and `PLAN_FILE` is not set, check for in-flight work:
 
 ```bash
 git status --porcelain
@@ -38,6 +42,8 @@ git log @{u}..HEAD --oneline 2>/dev/null || git log -5 --oneline
 If the working tree is dirty or there are unpushed commits, set `CONTINUING=true`, derive `SLUG` from the most recent commit subject, and jump to Step 4. Otherwise stop and ask the user what to build.
 
 ### Step 2: Plan
+
+If `PLAN_FILE` was supplied via `--plan-file`, skip the planner and the existing-plan search below entirely: read the plan file with the Read tool, and derive `SLUG` from its first `#` heading (kebab-cased) if `TASK` wasn't otherwise provided — fall back to slugifying `TASK` or the current branch name if the plan has no clear heading. Still compute `plan_dir` using the snippet below, then copy the plan file to `$plan_dir/$SLUG.md` (creating the directory if needed) so it participates in the same archival convention as planner-authored plans and a later `/go` re-invocation on this branch still finds it — unless `plan_dir` comes back empty (unrecognized repo), in which case skip the copy and just proceed with the original `PLAN_FILE` path. Tell the user which plan you're using, then go to Step 3.
 
 If `SKIP_PLANNER` is true, skip the planner but still write a brief: one paragraph covering goal, files in scope, definition of done, and out of scope. Without it, every subagent spawned later interprets the raw task description independently and they diverge. Use the brief as the spec wherever later steps reference the plan, then go to Step 3.
 


### PR DESCRIPTION
Plan Mode always ended the same way: approve a plan, then either implement it ad hoc or cancel and manually retype `/go`. This wires the two together.

- Adds a `PostToolUse` hook script (`ai/bin/suggest-go-after-plan.sh`) that fires when a Plan Mode plan is approved. It finds the approved plan's file path in the tool's own output and nudges Claude to run `/go` on it instead of implementing directly. It's guarded to stay silent outside a git repo or a repo with no GitHub remote. The hook itself is registered in `~/.claude/settings.json`, which lives outside this repo and was updated locally.
- Extends `/go` with a `--plan-file <path>` flag. Plan Mode writes plans to `~/.claude/plans/`, a location `/go`'s existing plan lookup never checked (it only looks in the conventional `~/dev/.../plans/` directories). The new flag reads the plan directly, derives a slug from its heading, and copies it into `/go`'s conventional plan directory so it follows the same archival convention as planner-authored plans.
- Points to the new flow from `ai/CLAUDE.md`'s Implementation Flow section.

## Test plan

- [x] Ran the hook script with a mocked `ExitPlanMode` payload; confirmed it emits valid JSON with `additionalContext` pointing at the approved plan file
- [x] Ran it from a non-git directory and from a git repo with no GitHub remote; confirmed silent exit in both cases
- [x] Ran it against a plan path containing a space (simulating a home directory like `/Users/John Doe/`); confirmed the path is captured correctly
- [x] Confirmed the fallback lookup only fires for plan files modified in the last two minutes, and ignores older ones
- [x] `shellcheck` and `markdownlint` both clean on the changed files
- [ ] Full end-to-end test (real Plan Mode session approving a plan, hook firing, `/go --plan-file` picking it up) still needs to happen after this merges, since `/go`'s symlinked skill only reflects `main`