### PR TITLE
Sign commits via forwarded SSH agent when working remotely

### DIFF
--- a/ssh/config
+++ b/ssh/config
@@ -3,5 +3,9 @@ Host github.com
 	ControlPath ~/.ssh/sockets/%r@%h-%p
 	ControlPersist 600
 
+Host phils-macbook-pro macbook
+	HostName 100.119.94.39
+	ForwardAgent yes
+
 Host *
 	IdentityAgent "/Users/haacked/Library/Containers/com.maxgoedjen.Secretive.SecretAgent/Data/socket.ssh"

--- a/zsh/zshrc.symlink
+++ b/zsh/zshrc.symlink
@@ -25,7 +25,7 @@ if [ -n "$SSH_CONNECTION" ] && [ -S "$SSH_AUTH_SOCK" ]; then
 elif [ ! -S "$SSH_AGENT_SOCK" ] && [ -S "$HOME/Library/Containers/com.maxgoedjen.Secretive.SecretAgent/Data/socket.ssh" ]; then
   ln -sf "$HOME/Library/Containers/com.maxgoedjen.Secretive.SecretAgent/Data/socket.ssh" "$SSH_AGENT_SOCK"
 fi
-export SSH_AUTH_SOCK="$SSH_AGENT_SOCK"
+[ -S "$SSH_AGENT_SOCK" ] && export SSH_AUTH_SOCK="$SSH_AGENT_SOCK"
 unset SSH_AGENT_SOCK
 
 # --- Secrets (never committed) ---

--- a/zsh/zshrc.symlink
+++ b/zsh/zshrc.symlink
@@ -12,8 +12,15 @@ if [ -f "$HOME/.dotfiles/zsh/ssh-tmux.zsh" ]; then
   . "$HOME/.dotfiles/zsh/ssh-tmux.zsh"
 fi
 
-# Secretive SSH agent
-if [ -S "$HOME/Library/Containers/com.maxgoedjen.Secretive.SecretAgent/Data/socket.ssh" ]; then
+# SSH agent: forwarded socket paths change every connection, but tmux panes
+# (see ssh-tmux.zsh) keep whatever SSH_AUTH_SOCK they started with. Route
+# through a stable symlink and repoint it here so existing panes pick up a
+# fresh forwarded agent instead of a dead socket. Falls back to the local
+# Secretive agent when not connected over SSH.
+if [ -n "$SSH_CONNECTION" ] && [ -S "$SSH_AUTH_SOCK" ]; then
+  ln -sf "$SSH_AUTH_SOCK" "$HOME/.ssh/agent.sock"
+  export SSH_AUTH_SOCK="$HOME/.ssh/agent.sock"
+elif [ -S "$HOME/Library/Containers/com.maxgoedjen.Secretive.SecretAgent/Data/socket.ssh" ]; then
   export SSH_AUTH_SOCK="$HOME/Library/Containers/com.maxgoedjen.Secretive.SecretAgent/Data/socket.ssh"
 fi
 

--- a/zsh/zshrc.symlink
+++ b/zsh/zshrc.symlink
@@ -12,17 +12,21 @@ if [ -f "$HOME/.dotfiles/zsh/ssh-tmux.zsh" ]; then
   . "$HOME/.dotfiles/zsh/ssh-tmux.zsh"
 fi
 
-# SSH agent: forwarded socket paths change every connection, but tmux panes
-# (see ssh-tmux.zsh) keep whatever SSH_AUTH_SOCK they started with. Route
-# through a stable symlink and repoint it here so existing panes pick up a
-# fresh forwarded agent instead of a dead socket. Falls back to the local
-# Secretive agent when not connected over SSH.
+# SSH agent: every shell exports the same stable symlink, whether it's an SSH
+# session, a tmux pane (see ssh-tmux.zsh), or a host-native one like a
+# Supacode tab viewed through Jump Desktop's screen share. A live forwarded
+# SSH connection repoints the symlink to itself; otherwise it falls back to
+# the local Secretive agent. Because it's an indirection, a Claude Code
+# session started hours ago picks up whichever agent is current the next
+# time it signs something, without needing to restart.
+SSH_AGENT_SOCK="$HOME/.ssh/agent.sock"
 if [ -n "$SSH_CONNECTION" ] && [ -S "$SSH_AUTH_SOCK" ]; then
-  ln -sf "$SSH_AUTH_SOCK" "$HOME/.ssh/agent.sock"
-  export SSH_AUTH_SOCK="$HOME/.ssh/agent.sock"
-elif [ -S "$HOME/Library/Containers/com.maxgoedjen.Secretive.SecretAgent/Data/socket.ssh" ]; then
-  export SSH_AUTH_SOCK="$HOME/Library/Containers/com.maxgoedjen.Secretive.SecretAgent/Data/socket.ssh"
+  ln -sf "$SSH_AUTH_SOCK" "$SSH_AGENT_SOCK"
+elif [ ! -S "$SSH_AGENT_SOCK" ] && [ -S "$HOME/Library/Containers/com.maxgoedjen.Secretive.SecretAgent/Data/socket.ssh" ]; then
+  ln -sf "$HOME/Library/Containers/com.maxgoedjen.Secretive.SecretAgent/Data/socket.ssh" "$SSH_AGENT_SOCK"
 fi
+export SSH_AUTH_SOCK="$SSH_AGENT_SOCK"
+unset SSH_AGENT_SOCK
 
 # --- Secrets (never committed) ---
 if [ -f "$HOME/.secrets" ]; then


### PR DESCRIPTION
## Summary

- Add a host alias (`macbook` / `phils-macbook-pro`) with `ForwardAgent yes` for the Mac's Tailscale IP, so an outgoing SSH connection carries a forwarded Secretive agent.
- Route every shell (SSH sessions, tmux panes, and host-native ones like a Supacode tab viewed through Jump Desktop) through a stable `~/.ssh/agent.sock` symlink instead of binding directly to the local Secretive socket. A live forwarded connection repoints the symlink, so already-running sessions pick up the change on their next use without restarting.
- Falls back to the local Secretive agent automatically when nothing is forwarding one.

## Test plan

- [ ] From the client, run `ssh macbook` and confirm `~/.ssh/agent.sock` on the host now points at the freshly forwarded socket.
- [ ] From a host-native session (e.g. a Supacode tab opened via Jump Desktop, not SSH), run `git commit -S` while the forwarding connection from above is live, and confirm the Touch ID/Watch prompt appears on the client, not the host.
- [ ] Close the forwarding connection, open a new shell on the host, and confirm `SSH_AUTH_SOCK` falls back to the local Secretive socket.