### PR TITLE
Fix remaining gaps in remote commit signing via forwarded SSH agent

### DIFF
--- a/git/gitconfig.local.symlink.template
+++ b/git/gitconfig.local.symlink.template
@@ -2,5 +2,13 @@
 [user]
         name = AUTHORNAME
         email = AUTHOREMAIL
+        signingkey = ~/.ssh/agent.pub
+        localSigningKey = LOCAL_SIGNING_KEY
 [credential]
         helper = GIT_CREDENTIAL_HELPER
+[gpg]
+        format = ssh
+[gpg "ssh"]
+        allowedSignersFile = ~/.dotfiles/git/allowed_signers
+[commit]
+        gpgsign = true

--- a/macos/LaunchAgents/com.haacked.secretive-ssh-auth.plist
+++ b/macos/LaunchAgents/com.haacked.secretive-ssh-auth.plist
@@ -13,6 +13,10 @@
     first in case this runs before any shell has initialized it. Also
     seeds agent.pub from user.localSigningKey so GUI apps that sign a
     commit before any interactive shell has run don't find it missing.
+    Bare `git` resolves fine here: launchd runs jobs with PATH=/usr/bin:
+    /bin:/usr/sbin:/sbin, and /usr/bin/git (the Xcode CLT shim, a
+    Homebrew prerequisite already assumed elsewhere in this repo) is on
+    that PATH.
     -->
     <key>ProgramArguments</key>
     <array>

--- a/macos/LaunchAgents/com.haacked.secretive-ssh-auth.plist
+++ b/macos/LaunchAgents/com.haacked.secretive-ssh-auth.plist
@@ -4,12 +4,19 @@
 <dict>
     <key>Label</key>
     <string>com.haacked.secretive-ssh-auth</string>
+    <!--
+    Points the session-wide SSH_AUTH_SOCK default at the stable agent
+    symlink (see zsh/zshrc.symlink) rather than Secretive's socket
+    directly, so processes that never source .zshrc (GUI apps, tools
+    that spawn non-interactive shells) still pick up a forwarded agent
+    when one is live. Seeds the symlink to the local Secretive socket
+    first in case this runs before any shell has initialized it.
+    -->
     <key>ProgramArguments</key>
     <array>
-        <string>/bin/launchctl</string>
-        <string>setenv</string>
-        <string>SSH_AUTH_SOCK</string>
-        <string>/Users/haacked/Library/Containers/com.maxgoedjen.Secretive.SecretAgent/Data/socket.ssh</string>
+        <string>/bin/sh</string>
+        <string>-c</string>
+        <string>ln -sf "$HOME/Library/Containers/com.maxgoedjen.Secretive.SecretAgent/Data/socket.ssh" "$HOME/.ssh/agent.sock" &amp;&amp; /bin/launchctl setenv SSH_AUTH_SOCK "$HOME/.ssh/agent.sock"</string>
     </array>
     <key>RunAtLoad</key>
     <true/>

--- a/macos/LaunchAgents/com.haacked.secretive-ssh-auth.plist
+++ b/macos/LaunchAgents/com.haacked.secretive-ssh-auth.plist
@@ -10,13 +10,15 @@
     directly, so processes that never source .zshrc (GUI apps, tools
     that spawn non-interactive shells) still pick up a forwarded agent
     when one is live. Seeds the symlink to the local Secretive socket
-    first in case this runs before any shell has initialized it.
+    first in case this runs before any shell has initialized it. Also
+    seeds agent.pub from user.localSigningKey so GUI apps that sign a
+    commit before any interactive shell has run don't find it missing.
     -->
     <key>ProgramArguments</key>
     <array>
         <string>/bin/sh</string>
         <string>-c</string>
-        <string>mkdir -p "$HOME/.ssh" &amp;&amp; ln -sf "$HOME/Library/Containers/com.maxgoedjen.Secretive.SecretAgent/Data/socket.ssh" "$HOME/.ssh/agent.sock" &amp;&amp; /bin/launchctl setenv SSH_AUTH_SOCK "$HOME/.ssh/agent.sock"</string>
+        <string>mkdir -p "$HOME/.ssh" &amp;&amp; ln -sf "$HOME/Library/Containers/com.maxgoedjen.Secretive.SecretAgent/Data/socket.ssh" "$HOME/.ssh/agent.sock" &amp;&amp; /bin/launchctl setenv SSH_AUTH_SOCK "$HOME/.ssh/agent.sock"; LOCAL_SIGNING_KEY=$(git config --global --get user.localSigningKey 2>/dev/null); [ -n "$LOCAL_SIGNING_KEY" ] &amp;&amp; [ -f "$LOCAL_SIGNING_KEY" ] &amp;&amp; cat "$LOCAL_SIGNING_KEY" &gt; "$HOME/.ssh/agent.pub"</string>
     </array>
     <key>RunAtLoad</key>
     <true/>

--- a/macos/LaunchAgents/com.haacked.secretive-ssh-auth.plist
+++ b/macos/LaunchAgents/com.haacked.secretive-ssh-auth.plist
@@ -16,7 +16,7 @@
     <array>
         <string>/bin/sh</string>
         <string>-c</string>
-        <string>ln -sf "$HOME/Library/Containers/com.maxgoedjen.Secretive.SecretAgent/Data/socket.ssh" "$HOME/.ssh/agent.sock" &amp;&amp; /bin/launchctl setenv SSH_AUTH_SOCK "$HOME/.ssh/agent.sock"</string>
+        <string>mkdir -p "$HOME/.ssh" &amp;&amp; ln -sf "$HOME/Library/Containers/com.maxgoedjen.Secretive.SecretAgent/Data/socket.ssh" "$HOME/.ssh/agent.sock" &amp;&amp; /bin/launchctl setenv SSH_AUTH_SOCK "$HOME/.ssh/agent.sock"</string>
     </array>
     <key>RunAtLoad</key>
     <true/>

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -50,7 +50,7 @@ setup_gitconfig () {
     if [ -z "$local_signing_key" ]
     then
       local_signing_key='TODO: create a key in Secretive, then set this to its .pub path'
-      user ' - No Secretive key found yet; localSigningKey left as a placeholder in gitconfig.local, fill it in once you have created one.'
+      user ' - No Secretive key found yet; localSigningKey left as a placeholder in gitconfig.local. Commit signing is on (commit.gpgsign=true), so git commit will fail until you create a key in Secretive and fill in user.localSigningKey (or set commit.gpgsign=false there temporarily).'
     fi
 
     sed -e "s/AUTHORNAME/$git_authorname/g" -e "s/AUTHOREMAIL/$git_authoremail/g" -e "s/GIT_CREDENTIAL_HELPER/$git_credential/g" -e "s|LOCAL_SIGNING_KEY|$local_signing_key|g" git/gitconfig.local.symlink.template > git/gitconfig.local.symlink

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -54,11 +54,13 @@ setup_gitconfig () {
     fi
 
     # Backslash and & are special in sed replacement text; escape them so
-    # values containing those characters substitute in literally.
+    # values containing those characters substitute in literally. The
+    # signing-key substitution below uses | as its delimiter (the key path
+    # may itself contain /), so also escape any literal | in that value.
     escaped_authorname=$(printf '%s' "$git_authorname" | sed -e 's/[\&]/\\&/g')
     escaped_authoremail=$(printf '%s' "$git_authoremail" | sed -e 's/[\&]/\\&/g')
     escaped_credential=$(printf '%s' "$git_credential" | sed -e 's/[\&]/\\&/g')
-    escaped_signing_key=$(printf '%s' "$local_signing_key" | sed -e 's/[\&]/\\&/g')
+    escaped_signing_key=$(printf '%s' "$local_signing_key" | sed -e 's/[\&|]/\\&/g')
 
     sed -e "s/AUTHORNAME/$escaped_authorname/g" -e "s/AUTHOREMAIL/$escaped_authoremail/g" -e "s/GIT_CREDENTIAL_HELPER/$escaped_credential/g" -e "s|LOCAL_SIGNING_KEY|$escaped_signing_key|g" git/gitconfig.local.symlink.template > git/gitconfig.local.symlink
 

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -46,20 +46,27 @@ setup_gitconfig () {
     user ' - What is your github author email?'
     read -e git_authoremail
 
-    local_signing_key=$(find "$HOME/Library/Containers/com.maxgoedjen.Secretive.SecretAgent/Data/PublicKeys" -name '*.pub' 2>/dev/null | head -1)
+    local_signing_key=$(find "$HOME/Library/Containers/com.maxgoedjen.Secretive.SecretAgent/Data/PublicKeys" -name '*.pub' 2>/dev/null | sort | head -1)
     if [ -z "$local_signing_key" ]
     then
       local_signing_key='TODO: create a key in Secretive, then set this to its .pub path'
       user ' - No Secretive key found yet; localSigningKey left as a placeholder in gitconfig.local. Commit signing is on (commit.gpgsign=true), so git commit will fail until you create a key in Secretive and fill in user.localSigningKey (or set commit.gpgsign=false there temporarily).'
     fi
 
-    # Backslash and & are special in sed replacement text; escape them so
-    # values containing those characters substitute in literally. The
-    # signing-key substitution below uses | as its delimiter (the key path
-    # may itself contain /), so also escape any literal | in that value.
-    escaped_authorname=$(printf '%s' "$git_authorname" | sed -e 's/[\&]/\\&/g')
-    escaped_authoremail=$(printf '%s' "$git_authoremail" | sed -e 's/[\&]/\\&/g')
-    escaped_credential=$(printf '%s' "$git_credential" | sed -e 's/[\&]/\\&/g')
+    # Backslash and & are special in sed replacement text, and each value
+    # below also needs its substitution's own delimiter escaped so a literal
+    # delimiter character can't terminate the command early. Note: inside a
+    # bracket expression like [\&/], backslash has no special meaning per
+    # POSIX (it's just another literal member of the set), so listing it
+    # alongside the other characters is sufficient; it does not need its own
+    # separate escape. The name/email/credential substitutions use / as their
+    # delimiter, so escape / too (via a |-delimited sed command, since / is
+    # also the character being matched here). The signing-key substitution
+    # uses | as its delimiter (the key path may itself contain /), so escape
+    # any literal | in that value instead.
+    escaped_authorname=$(printf '%s' "$git_authorname" | sed -e 's|[\&/]|\\&|g')
+    escaped_authoremail=$(printf '%s' "$git_authoremail" | sed -e 's|[\&/]|\\&|g')
+    escaped_credential=$(printf '%s' "$git_credential" | sed -e 's|[\&/]|\\&|g')
     escaped_signing_key=$(printf '%s' "$local_signing_key" | sed -e 's/[\&|]/\\&/g')
 
     sed -e "s/AUTHORNAME/$escaped_authorname/g" -e "s/AUTHOREMAIL/$escaped_authoremail/g" -e "s/GIT_CREDENTIAL_HELPER/$escaped_credential/g" -e "s|LOCAL_SIGNING_KEY|$escaped_signing_key|g" git/gitconfig.local.symlink.template > git/gitconfig.local.symlink

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -46,7 +46,14 @@ setup_gitconfig () {
     user ' - What is your github author email?'
     read -e git_authoremail
 
-    sed -e "s/AUTHORNAME/$git_authorname/g" -e "s/AUTHOREMAIL/$git_authoremail/g" -e "s/GIT_CREDENTIAL_HELPER/$git_credential/g" git/gitconfig.local.symlink.template > git/gitconfig.local.symlink
+    local_signing_key=$(find "$HOME/Library/Containers/com.maxgoedjen.Secretive.SecretAgent/Data/PublicKeys" -name '*.pub' 2>/dev/null | head -1)
+    if [ -z "$local_signing_key" ]
+    then
+      local_signing_key='TODO: create a key in Secretive, then set this to its .pub path'
+      user ' - No Secretive key found yet; localSigningKey left as a placeholder in gitconfig.local, fill it in once you have created one.'
+    fi
+
+    sed -e "s/AUTHORNAME/$git_authorname/g" -e "s/AUTHOREMAIL/$git_authoremail/g" -e "s/GIT_CREDENTIAL_HELPER/$git_credential/g" -e "s|LOCAL_SIGNING_KEY|$local_signing_key|g" git/gitconfig.local.symlink.template > git/gitconfig.local.symlink
 
     success 'gitconfig'
   fi

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -53,7 +53,14 @@ setup_gitconfig () {
       user ' - No Secretive key found yet; localSigningKey left as a placeholder in gitconfig.local. Commit signing is on (commit.gpgsign=true), so git commit will fail until you create a key in Secretive and fill in user.localSigningKey (or set commit.gpgsign=false there temporarily).'
     fi
 
-    sed -e "s/AUTHORNAME/$git_authorname/g" -e "s/AUTHOREMAIL/$git_authoremail/g" -e "s/GIT_CREDENTIAL_HELPER/$git_credential/g" -e "s|LOCAL_SIGNING_KEY|$local_signing_key|g" git/gitconfig.local.symlink.template > git/gitconfig.local.symlink
+    # Backslash and & are special in sed replacement text; escape them so
+    # values containing those characters substitute in literally.
+    escaped_authorname=$(printf '%s' "$git_authorname" | sed -e 's/[\&]/\\&/g')
+    escaped_authoremail=$(printf '%s' "$git_authoremail" | sed -e 's/[\&]/\\&/g')
+    escaped_credential=$(printf '%s' "$git_credential" | sed -e 's/[\&]/\\&/g')
+    escaped_signing_key=$(printf '%s' "$local_signing_key" | sed -e 's/[\&]/\\&/g')
+
+    sed -e "s/AUTHORNAME/$escaped_authorname/g" -e "s/AUTHOREMAIL/$escaped_authoremail/g" -e "s/GIT_CREDENTIAL_HELPER/$escaped_credential/g" -e "s|LOCAL_SIGNING_KEY|$escaped_signing_key|g" git/gitconfig.local.symlink.template > git/gitconfig.local.symlink
 
     success 'gitconfig'
   fi

--- a/zsh/zshrc.symlink
+++ b/zsh/zshrc.symlink
@@ -27,16 +27,18 @@ fi
 # set it just keep whatever signingkey they had before this existed.
 SSH_AGENT_SOCK="$HOME/.ssh/agent.sock"
 SSH_AGENT_PUB="$HOME/.ssh/agent.pub"
+mkdir -p "$HOME/.ssh"
 if [ -n "$SSH_CONNECTION" ] && [ -S "$SSH_AUTH_SOCK" ]; then
   ln -sf "$SSH_AUTH_SOCK" "$SSH_AGENT_SOCK"
-  SSH_AUTH_SOCK="$SSH_AGENT_SOCK" ssh-add -L 2>/dev/null | head -1 > "$SSH_AGENT_PUB"
+  FORWARDED_KEY=$(SSH_AUTH_SOCK="$SSH_AGENT_SOCK" ssh-add -L 2>/dev/null | head -1)
+  [ -n "$FORWARDED_KEY" ] && echo "$FORWARDED_KEY" > "$SSH_AGENT_PUB"
 elif [ ! -S "$SSH_AGENT_SOCK" ] && [ -S "$HOME/Library/Containers/com.maxgoedjen.Secretive.SecretAgent/Data/socket.ssh" ]; then
   ln -sf "$HOME/Library/Containers/com.maxgoedjen.Secretive.SecretAgent/Data/socket.ssh" "$SSH_AGENT_SOCK"
   LOCAL_SIGNING_KEY=$(git config --get user.localSigningKey 2>/dev/null)
   [ -n "$LOCAL_SIGNING_KEY" ] && [ -f "$LOCAL_SIGNING_KEY" ] && cat "$LOCAL_SIGNING_KEY" > "$SSH_AGENT_PUB"
 fi
 [ -S "$SSH_AGENT_SOCK" ] && export SSH_AUTH_SOCK="$SSH_AGENT_SOCK"
-unset SSH_AGENT_SOCK SSH_AGENT_PUB LOCAL_SIGNING_KEY
+unset SSH_AGENT_SOCK SSH_AGENT_PUB LOCAL_SIGNING_KEY FORWARDED_KEY
 
 # --- Secrets (never committed) ---
 if [ -f "$HOME/.secrets" ]; then

--- a/zsh/zshrc.symlink
+++ b/zsh/zshrc.symlink
@@ -47,7 +47,7 @@ if [ -n "$SSH_CONNECTION" ] && [ -S "$SSH_AUTH_SOCK" ]; then
   [ -n "$FORWARDED_KEY" ] && echo "$FORWARDED_KEY" > "$SSH_AGENT_PUB"
 elif [ "$LOCAL_AGENT_LINKED" = true ] && [ -S "$SECRETIVE_SOCK" ]; then
   ln -sf "$SECRETIVE_SOCK" "$SSH_AGENT_SOCK"
-  LOCAL_SIGNING_KEY=$(git config --get user.localSigningKey 2>/dev/null)
+  LOCAL_SIGNING_KEY=$(git config --global --get user.localSigningKey 2>/dev/null)
   [ -n "$LOCAL_SIGNING_KEY" ] && [ -f "$LOCAL_SIGNING_KEY" ] && cat "$LOCAL_SIGNING_KEY" > "$SSH_AGENT_PUB"
 fi
 [ -S "$SSH_AGENT_SOCK" ] && export SSH_AUTH_SOCK="$SSH_AGENT_SOCK"

--- a/zsh/zshrc.symlink
+++ b/zsh/zshrc.symlink
@@ -19,14 +19,24 @@ fi
 # the local Secretive agent. Because it's an indirection, a Claude Code
 # session started hours ago picks up whichever agent is current the next
 # time it signs something, without needing to restart.
+#
+# git commit -S needs the exact public key to ask the agent for, so
+# user.signingkey (~/.gitconfig.local) points at agent.pub, a matching
+# indirection kept in sync alongside the socket. user.localSigningKey names
+# this machine's own key and is the fallback source; machines that haven't
+# set it just keep whatever signingkey they had before this existed.
 SSH_AGENT_SOCK="$HOME/.ssh/agent.sock"
+SSH_AGENT_PUB="$HOME/.ssh/agent.pub"
 if [ -n "$SSH_CONNECTION" ] && [ -S "$SSH_AUTH_SOCK" ]; then
   ln -sf "$SSH_AUTH_SOCK" "$SSH_AGENT_SOCK"
+  SSH_AUTH_SOCK="$SSH_AGENT_SOCK" ssh-add -L 2>/dev/null | head -1 > "$SSH_AGENT_PUB"
 elif [ ! -S "$SSH_AGENT_SOCK" ] && [ -S "$HOME/Library/Containers/com.maxgoedjen.Secretive.SecretAgent/Data/socket.ssh" ]; then
   ln -sf "$HOME/Library/Containers/com.maxgoedjen.Secretive.SecretAgent/Data/socket.ssh" "$SSH_AGENT_SOCK"
+  LOCAL_SIGNING_KEY=$(git config --get user.localSigningKey 2>/dev/null)
+  [ -n "$LOCAL_SIGNING_KEY" ] && [ -f "$LOCAL_SIGNING_KEY" ] && cat "$LOCAL_SIGNING_KEY" > "$SSH_AGENT_PUB"
 fi
 [ -S "$SSH_AGENT_SOCK" ] && export SSH_AUTH_SOCK="$SSH_AGENT_SOCK"
-unset SSH_AGENT_SOCK
+unset SSH_AGENT_SOCK SSH_AGENT_PUB LOCAL_SIGNING_KEY
 
 # --- Secrets (never committed) ---
 if [ -f "$HOME/.secrets" ]; then

--- a/zsh/zshrc.symlink
+++ b/zsh/zshrc.symlink
@@ -27,18 +27,31 @@ fi
 # set it just keep whatever signingkey they had before this existed.
 SSH_AGENT_SOCK="$HOME/.ssh/agent.sock"
 SSH_AGENT_PUB="$HOME/.ssh/agent.pub"
+SECRETIVE_SOCK="$HOME/Library/Containers/com.maxgoedjen.Secretive.SecretAgent/Data/socket.ssh"
 mkdir -p "$HOME/.ssh"
+
+# The LaunchAgent (macos/LaunchAgents/com.haacked.secretive-ssh-auth.plist)
+# pre-seeds agent.sock to the local Secretive socket at login, so by the time
+# a shell starts it's usually already a valid socket. Treat the symlink as
+# "local" (safe to re-seed agent.pub) whenever it's missing/broken or still
+# pointing at Secretive, and only skip it when another pane already redirected
+# it to a live forwarded agent.
+LOCAL_AGENT_LINKED=false
+if [ ! -S "$SSH_AGENT_SOCK" ] || [ "$(readlink "$SSH_AGENT_SOCK")" = "$SECRETIVE_SOCK" ]; then
+  LOCAL_AGENT_LINKED=true
+fi
+
 if [ -n "$SSH_CONNECTION" ] && [ -S "$SSH_AUTH_SOCK" ]; then
   ln -sf "$SSH_AUTH_SOCK" "$SSH_AGENT_SOCK"
   FORWARDED_KEY=$(SSH_AUTH_SOCK="$SSH_AGENT_SOCK" ssh-add -L 2>/dev/null | head -1)
   [ -n "$FORWARDED_KEY" ] && echo "$FORWARDED_KEY" > "$SSH_AGENT_PUB"
-elif [ ! -S "$SSH_AGENT_SOCK" ] && [ -S "$HOME/Library/Containers/com.maxgoedjen.Secretive.SecretAgent/Data/socket.ssh" ]; then
-  ln -sf "$HOME/Library/Containers/com.maxgoedjen.Secretive.SecretAgent/Data/socket.ssh" "$SSH_AGENT_SOCK"
+elif [ "$LOCAL_AGENT_LINKED" = true ] && [ -S "$SECRETIVE_SOCK" ]; then
+  ln -sf "$SECRETIVE_SOCK" "$SSH_AGENT_SOCK"
   LOCAL_SIGNING_KEY=$(git config --get user.localSigningKey 2>/dev/null)
   [ -n "$LOCAL_SIGNING_KEY" ] && [ -f "$LOCAL_SIGNING_KEY" ] && cat "$LOCAL_SIGNING_KEY" > "$SSH_AGENT_PUB"
 fi
 [ -S "$SSH_AGENT_SOCK" ] && export SSH_AUTH_SOCK="$SSH_AGENT_SOCK"
-unset SSH_AGENT_SOCK SSH_AGENT_PUB LOCAL_SIGNING_KEY FORWARDED_KEY
+unset SSH_AGENT_SOCK SSH_AGENT_PUB SECRETIVE_SOCK LOCAL_AGENT_LINKED LOCAL_SIGNING_KEY FORWARDED_KEY
 
 # --- Secrets (never committed) ---
 if [ -f "$HOME/.secrets" ]; then


### PR DESCRIPTION
## Summary

Follow-up to #135. Live testing surfaced two remaining gaps that kept commit signing from actually routing through a forwarded agent, plus a bootstrap improvement discovered along the way.

- The LaunchAgent that sets the session-wide `SSH_AUTH_SOCK` default pointed straight at Secretive's socket, so any process that never sources `.zshrc` (GUI apps, tools that spawn non-interactive shells, including Claude Code's own tool calls) stayed on the local agent even with a live forwarded connection. It now points at the same `agent.sock` symlink `zshrc.symlink` maintains, seeding it to the local socket on first run.
- `git commit -S` needs the exact public key to ask the agent for, and `signingkey` was hardcoded per machine, so signing only worked with whichever key lived on that specific host, even once `SSH_AUTH_SOCK` correctly pointed at a forwarded agent. `agent.pub` now tracks whichever key is actually active, captured from the forwarded agent when one is live and from a new `user.localSigningKey` gitconfig setting otherwise.
- Bootstrap now generates the git signing config (previously set up by hand on each machine). Four of the five settings are identical everywhere now that `signingkey` points at the `agent.pub` indirection; `localSigningKey` is discovered by looking for a `.pub` file under Secretive's `PublicKeys` directory, falling back to a placeholder when no key exists yet.

## Test plan

- [x] Verified on phils-macbook-pro with a live forwarded connection from phils-macbook-neo: a commit signed there resolves to `GitHub@secretive.Phil's-MacBook-Neo.local`, confirmed via `git log --show-signature`.
- [x] Confirmed a freshly spawned process (new Terminal window) inherits the corrected `SSH_AUTH_SOCK` default without needing `.zshrc` to run.
- [x] Dry-ran the bootstrap template substitution against this machine's real Secretive key path and confirmed it produces the same config already in use.
- [ ] Bootstrap a new machine (or simulate by removing `git/gitconfig.local.symlink`) and confirm `setup_gitconfig` produces a working config, including the no-key-yet placeholder path.