### PR TITLE
Fix install.sh hook maintenance gaps

### DIFF
--- a/ai/install.sh
+++ b/ai/install.sh
@@ -333,6 +333,8 @@ if [ "$INSTALL_HOOKS" = "true" ]; then
 
         # Keep only the most recent backups; this runs on every install so
         # backups accumulate indefinitely without pruning.
+        # `tail -n +N` (start-from-line-N) is POSIX, unlike the obsolescent
+        # `tail +N` form.
         KEEP_BACKUPS=5
         ls -t "${SETTINGS_FILE}".backup.* 2>/dev/null | tail -n "+$((KEEP_BACKUPS + 1))" | while IFS= read -r old_backup; do
             rm -f "$old_backup"
@@ -457,11 +459,11 @@ EOF
 fi
 
 # Exclude fragile commands from rtk's Bash-rewrite hook. rtk's `find`
-# reimplementation hard-fails on -not/-exec, and its `git diff` (without
-# --stat) inconsistently strips the diff/index/---/+++ headers depending on
-# output size. Several skills (create-pr, commit, test-plan) read full diffs
-# verbatim, so exclude both at the rtk config level rather than working
-# around it in every skill.
+# reimplementation hard-fails on -not/-exec, and its `git diff`/`diff`
+# (without --stat) inconsistently strips the diff/index/---/+++ headers
+# depending on output size. Several skills (create-pr, commit, test-plan)
+# read full diffs verbatim, so exclude all three at the rtk config level
+# rather than working around it in every skill.
 if [ "$INSTALL_HOOKS" = "true" ] && command -v rtk >/dev/null 2>&1; then
     info "Configuring rtk hook exclusions…"
 

--- a/ai/install.sh
+++ b/ai/install.sh
@@ -456,6 +456,39 @@ EOF
     fi
 fi
 
+# Exclude fragile commands from rtk's Bash-rewrite hook. rtk's `find`
+# reimplementation hard-fails on -not/-exec, and its `git diff` (without
+# --stat) inconsistently strips the diff/index/---/+++ headers depending on
+# output size. Several skills (create-pr, commit, test-plan) read full diffs
+# verbatim, so exclude both at the rtk config level rather than working
+# around it in every skill.
+if [ "$INSTALL_HOOKS" = "true" ] && command -v rtk >/dev/null 2>&1; then
+    info "Configuring rtk hook exclusions…"
+
+    RTK_CONFIG="$HOME/Library/Application Support/rtk/config.toml"
+
+    if [ ! -f "$RTK_CONFIG" ]; then
+        rtk config --create >/dev/null 2>&1
+    fi
+
+    if [ ! -f "$RTK_CONFIG" ]; then
+        warning "rtk config file not found after 'rtk config --create' - skipping hook exclusions"
+    elif grep -qF 'exclude_commands = ["^find\\b", "^git diff\\b", "^diff\\b"]' "$RTK_CONFIG"; then
+        success "rtk hook exclusions already configured"
+    elif grep -q '^exclude_commands = \[\]$' "$RTK_CONFIG"; then
+        awk '
+            /^exclude_commands = \[\]$/ {
+                print "exclude_commands = [\"^find\\\\b\", \"^git diff\\\\b\", \"^diff\\\\b\"]"
+                next
+            }
+            { print }
+        ' "$RTK_CONFIG" > "${RTK_CONFIG}.tmp" && mv "${RTK_CONFIG}.tmp" "$RTK_CONFIG"
+        success "Excluded find/git diff/diff from rtk's Bash-rewrite hook"
+    else
+        warning "rtk config has custom exclude_commands - add \"^find\\\\b\", \"^git diff\\\\b\", \"^diff\\\\b\" to $RTK_CONFIG manually"
+    fi
+fi
+
 # Configure terminal bell notifications (global config, not settings.json)
 if [ "$INSTALL_HOOKS" = "true" ]; then
     info "Configuring terminal bell notifications…"

--- a/ai/install.sh
+++ b/ai/install.sh
@@ -330,6 +330,13 @@ if [ "$INSTALL_HOOKS" = "true" ]; then
     if [ -f "$SETTINGS_FILE" ]; then
         cp "$SETTINGS_FILE" "${SETTINGS_FILE}.backup.$(date +%Y%m%d_%H%M%S)"
         success "Backed up existing settings.json"
+
+        # Keep only the most recent backups; this runs on every install so
+        # backups accumulate indefinitely without pruning.
+        KEEP_BACKUPS=5
+        ls -t "${SETTINGS_FILE}".backup.* 2>/dev/null | tail -n "+$((KEEP_BACKUPS + 1))" | while IFS= read -r old_backup; do
+            rm -f "$old_backup"
+        done
     fi
 
     # Create minimal settings file if it doesn't exist


### PR DESCRIPTION
Two related fixes to how ai/install.sh manages Claude Code hooks.

Every hook install run backs up ~/.claude/settings.json but never removes old backups, so they pile up indefinitely. One machine had accumulated 100 of them going back to July 2025, about 900K of dead weight in ~/.claude. The install step now keeps only the 5 most recent backups after creating a new one.

Separately, rtk's Bash-rewrite hook (registered via `rtk hook claude`) turns out to be unsafe for two commands several skills rely on. `find` hard-fails under rtk's reimplementation when passed `-not` or `-exec`. Bare `git diff` (without `--stat`) inconsistently strips its own diff/index/---/+++ headers depending on output size, sometimes returning a condensed summary instead of the real patch. create-pr, commit, and test-plan all read full diffs verbatim to write descriptions, so this excludes both commands from the hook via rtk's own `exclude_commands` config, applied idempotently on every install.

## Test plan
- Ran the prune snippet standalone against a directory seeded with 7 backups at distinct mtimes; confirmed it kept the 5 newest and removed the 2 oldest.
- Ran the rtk-exclusion block against a fake HOME with four scenarios: pristine config, already-configured config, a config with a pre-existing custom `exclude_commands` value, and a missing config file entirely. Confirmed each behaves correctly (patches, no-ops, warns without clobbering, and bootstraps via `rtk config --create`, respectively).
- Verified ai/install.sh still passes `sh -n`.