### PR TITLE
Resolve SSH signing key at sign time instead of caching it

### DIFF
--- a/bin/git-signing-key
+++ b/bin/git-signing-key
@@ -1,21 +1,20 @@
 #!/usr/bin/env bash
 # gpg.ssh.defaultKeyCommand: prints the SSH public key git should ask the
 # agent to sign with, resolved fresh on every call instead of cached in a
-# file. Heals ~/.ssh/agent.sock toward the local Secretive agent first,
-# since only zsh's precmd/login path knows about a live forwarded socket
-# to hand it.
+# file. Delegates to ssh-agent-sync for both healing the agent socket and
+# classifying which agent now owns it, since only zsh's precmd/login path
+# knows about a live forwarded socket to hand it.
 #
 # Output: a single "key::<ssh public key>" line, per git-config(1).
 
 set -euo pipefail
 
 sock="$HOME/.ssh/agent.sock"
-secretive="$HOME/Library/Containers/com.maxgoedjen.Secretive.SecretAgent/Data/socket.ssh"
 bin_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-"$bin_dir/ssh-agent-sync"
+mode=$("$bin_dir/ssh-agent-sync")
 
-if [[ -S "$sock" ]] && ! [[ "$sock" -ef "$secretive" ]]; then
+if [[ "$mode" == "forwarded" ]]; then
   forwarded_key=$(SSH_AUTH_SOCK="$sock" ssh-add -L 2>/dev/null | head -1) || forwarded_key=""
   if [[ -n "$forwarded_key" ]]; then
     printf 'key::%s\n' "$forwarded_key"

--- a/bin/git-signing-key
+++ b/bin/git-signing-key
@@ -13,7 +13,10 @@ set -euo pipefail
 sock="$HOME/.ssh/agent.sock"
 bin_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-mode=$("$bin_dir/ssh-agent-sync")
+# A healing hiccup (e.g. a transient mkdir/ln failure) shouldn't block local
+# signing, which doesn't depend on the socket at all, so a failure here
+# degrades to "none" instead of aborting under set -e.
+mode=$("$bin_dir/ssh-agent-sync") || mode="none"
 
 if [[ "$mode" == "forwarded" ]]; then
   forwarded_key=$(SSH_AUTH_SOCK="$sock" ssh-add -L 2>/dev/null | head -1) || true

--- a/bin/git-signing-key
+++ b/bin/git-signing-key
@@ -17,7 +17,10 @@ mode=$("$bin_dir/ssh-agent-sync")
 
 if [[ "$mode" == "forwarded" ]]; then
   forwarded_key=$(SSH_AUTH_SOCK="$sock" ssh-add -L 2>/dev/null | head -1) || true
-  if [[ -n "$forwarded_key" ]]; then
+  # ssh-add -L prints "The agent has no identities." to stdout (not stderr)
+  # and exits 1 when the agent is empty, so a bare non-empty check would
+  # treat that sentence as the key. Require an actual key-type prefix.
+  if [[ "$forwarded_key" == ssh-* || "$forwarded_key" == ecdsa-* || "$forwarded_key" == sk-* ]]; then
     printf 'key::%s\n' "$forwarded_key"
     exit 0
   fi

--- a/bin/git-signing-key
+++ b/bin/git-signing-key
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 # gpg.ssh.defaultKeyCommand: prints the SSH public key git should ask the
 # agent to sign with, resolved fresh on every call instead of cached in a
-# file. Delegates to ssh-agent-sync for both healing the agent socket and
-# classifying which agent now owns it, since only zsh's precmd/login path
-# knows about a live forwarded socket to hand it.
+# file. Delegates to ssh-agent-sync, which heals toward the local agent and
+# classifies the current socket state; establishing a forwarded link is
+# zsh's precmd/login path, since only it knows about a live forwarded
+# socket to hand it.
 #
 # Output: a single "key::<ssh public key>" line, per git-config(1).
 
@@ -15,7 +16,7 @@ bin_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 mode=$("$bin_dir/ssh-agent-sync")
 
 if [[ "$mode" == "forwarded" ]]; then
-  forwarded_key=$(SSH_AUTH_SOCK="$sock" ssh-add -L 2>/dev/null | head -1) || forwarded_key=""
+  forwarded_key=$(SSH_AUTH_SOCK="$sock" ssh-add -L 2>/dev/null | head -1) || true
   if [[ -n "$forwarded_key" ]]; then
     printf 'key::%s\n' "$forwarded_key"
     exit 0

--- a/bin/git-signing-key
+++ b/bin/git-signing-key
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# gpg.ssh.defaultKeyCommand: prints the SSH public key git should ask the
+# agent to sign with, resolved fresh on every call instead of cached in a
+# file. Heals ~/.ssh/agent.sock toward the local Secretive agent first,
+# since only zsh's precmd/login path knows about a live forwarded socket
+# to hand it.
+#
+# Output: a single "key::<ssh public key>" line, per git-config(1).
+
+set -euo pipefail
+
+sock="$HOME/.ssh/agent.sock"
+secretive="$HOME/Library/Containers/com.maxgoedjen.Secretive.SecretAgent/Data/socket.ssh"
+bin_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+"$bin_dir/ssh-agent-sync"
+
+if [[ -S "$sock" ]] && ! [[ "$sock" -ef "$secretive" ]]; then
+  forwarded_key=$(SSH_AUTH_SOCK="$sock" ssh-add -L 2>/dev/null | head -1) || forwarded_key=""
+  if [[ -n "$forwarded_key" ]]; then
+    printf 'key::%s\n' "$forwarded_key"
+    exit 0
+  fi
+fi
+
+local_signing_key=$(git config --global --includes --get user.localSigningKey 2>/dev/null) || local_signing_key=""
+if [[ -n "$local_signing_key" && -f "$local_signing_key" ]]; then
+  printf 'key::%s\n' "$(cat "$local_signing_key")"
+  exit 0
+fi
+
+echo "git-signing-key: no local or forwarded SSH signing key found" >&2
+exit 1

--- a/bin/lib/test-git-signing-integration.sh
+++ b/bin/lib/test-git-signing-integration.sh
@@ -1,0 +1,149 @@
+#!/bin/bash
+# End-to-end integration test: a real `git commit -S` against this
+# worktree's gpg.ssh.defaultKeyCommand wiring (bin/git-signing-key +
+# bin/ssh-agent-sync), covering the plan's Stage 4 scenarios in isolated
+# fake HOMEs. Never touches the live machine's ~/.gitconfig or ~/.ssh.
+#
+# SSH_AUTH_SOCK is exported once per test to the *stable symlink path*
+# ($home/.ssh/agent.sock) and never changed again, mirroring how a real
+# shell/launchd only ever exports that fixed path. What changes between
+# scenarios is the symlink's target on disk, healed by ssh-agent-sync
+# inside git-signing-key immediately before ssh-keygen (a sibling process
+# git spawns afterward) connects through it.
+#
+# Usage: test-git-signing-integration.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=bin/lib/test-helpers.sh
+source "$SCRIPT_DIR/test-helpers.sh"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+GIT_SIGNING_KEY="$REPO_ROOT/bin/git-signing-key"
+
+agent_pids=()
+homes=()
+cleanup() {
+  local pid
+  for pid in "${agent_pids[@]:-}"; do
+    [[ -n "$pid" ]] && kill "$pid" 2>/dev/null
+  done
+  local h
+  for h in "${homes[@]:-}"; do
+    rm -rf "$h"
+  done
+}
+trap cleanup EXIT
+
+# Rooted at /tmp (not $TMPDIR) with a short prefix: the Secretive-style
+# AF_UNIX path built under it can otherwise exceed macOS's ~104-byte socket
+# path limit.
+new_home() {
+  local h
+  h=$(cd "$(mktemp -d /tmp/t.XXXXXX)" && pwd -P)
+  homes+=("$h")
+  printf '%s\n' "$h"
+}
+
+# A gitconfig wired the same way as git/gitconfig.symlink, pointed at this
+# worktree's git-signing-key so the test exercises uncommitted changes.
+write_gitconfig() {
+  local home="$1"
+  cat > "$home/.gitconfig" <<EOF
+[user]
+	name = Test User
+	email = test@example.com
+[gpg]
+	format = ssh
+[gpg "ssh"]
+	program = /usr/bin/ssh-keygen
+	defaultKeyCommand = $GIT_SIGNING_KEY
+[commit]
+	gpgsign = true
+[init]
+	defaultBranch = main
+EOF
+}
+
+# Starts a fake "Secretive" agent at the real expected socket path under
+# $1 and configures it as user.localSigningKey via a freshly generated key.
+setup_local_agent() {
+  local home="$1"
+  local secretive="$home/Library/Containers/com.maxgoedjen.Secretive.SecretAgent/Data/socket.ssh"
+  mkdir -p "$(dirname "$secretive")"
+  agent_pids+=("$(start_agent "$secretive")")
+  ssh-keygen -q -t ed25519 -N '' -f "$home/local_key" -C local
+  SSH_AUTH_SOCK="$secretive" ssh-add "$home/local_key" >/dev/null 2>&1
+  git config --file "$home/.gitconfig" user.localSigningKey "$home/local_key.pub"
+}
+
+commit_in_scratch_repo() {
+  local home="$1" auth_sock="$2"
+  shift 2
+  local repo="$home/scratch-repo"
+  mkdir -p "$repo"
+  (
+    cd "$repo" || exit 1
+    "$@" HOME="$home" SSH_AUTH_SOCK="$auth_sock" git init -q &&
+      echo hello > file.txt &&
+      "$@" HOME="$home" SSH_AUTH_SOCK="$auth_sock" git add file.txt &&
+      "$@" HOME="$home" SSH_AUTH_SOCK="$auth_sock" git commit -q -S -m "test commit"
+  )
+}
+
+signed_with_key() {
+  local home="$1" expected_pub="$2"
+  local repo="$home/scratch-repo"
+  local allowed="$home/allowed_signers"
+  printf 'test@example.com %s\n' "$(cat "$expected_pub")" > "$allowed"
+  HOME="$home" git -C "$repo" -c gpg.ssh.allowedSignersFile="$allowed" log --show-signature -1 2>&1 |
+    grep -q 'Good "git" signature'
+}
+
+# ── Test: local-only — no forwarded agent, only the local (Secretive) one ──
+
+HOME1=$(new_home)
+write_gitconfig "$HOME1"
+setup_local_agent "$HOME1"
+
+commit_in_scratch_repo "$HOME1" "$HOME1/.ssh/agent.sock" env
+assert "local-only: signs with the local key" signed_with_key "$HOME1" "$HOME1/local_key.pub"
+
+# ── Test: forwarded agent already linked at agent.sock ──────────────────────
+
+HOME2=$(new_home)
+write_gitconfig "$HOME2"
+mkdir -p -m 700 "$HOME2/.ssh"
+FORWARDED2="$HOME2/forwarded-agent.sock"
+agent_pids+=("$(start_agent "$FORWARDED2")")
+ssh-keygen -q -t ed25519 -N '' -f "$HOME2/forwarded_key" -C forwarded
+SSH_AUTH_SOCK="$FORWARDED2" ssh-add "$HOME2/forwarded_key" >/dev/null 2>&1
+ln -sf "$FORWARDED2" "$HOME2/.ssh/agent.sock"
+
+commit_in_scratch_repo "$HOME2" "$HOME2/.ssh/agent.sock" env
+assert "forwarded: signs with the forwarded key" signed_with_key "$HOME2" "$HOME2/forwarded_key.pub"
+
+# ── Test: torn-down forwarded agent, no shell prompt in between ────────────
+# The scenario the whole plan exists for: agent.sock is a dangling symlink
+# left by a forwarded session that already ended. SSH_AUTH_SOCK is exported
+# (as it would be by a shell or launchd long ago) but nothing has refreshed
+# the symlink's target since. Signed from a bare `env -i` process — no
+# shell init, no PATH beyond the OS defaults — to prove the healing doesn't
+# depend on a shell prompt having drawn.
+
+HOME3=$(new_home)
+write_gitconfig "$HOME3"
+setup_local_agent "$HOME3"
+SECRETIVE3="$HOME3/Library/Containers/com.maxgoedjen.Secretive.SecretAgent/Data/socket.ssh"
+mkdir -p -m 700 "$HOME3/.ssh"
+ln -sf "$HOME3/torn-down.sock" "$HOME3/.ssh/agent.sock"
+
+commit_in_scratch_repo "$HOME3" "$HOME3/.ssh/agent.sock" env -i PATH=/usr/bin:/bin:/usr/sbin:/sbin
+assert "torn-down gap: self-heals and signs with the local key" \
+  signed_with_key "$HOME3" "$HOME3/local_key.pub"
+assert "torn-down gap: agent.sock healed to the local (Secretive) socket" \
+  test "$HOME3/.ssh/agent.sock" -ef "$SECRETIVE3"
+
+# ── Results ──────────────────────────────────────────────────────────────────
+
+print_results

--- a/bin/lib/test-git-signing-integration.sh
+++ b/bin/lib/test-git-signing-integration.sh
@@ -47,9 +47,14 @@ new_home() {
 
 # A gitconfig wired the same way as git/gitconfig.symlink, pointed at this
 # worktree's git-signing-key so the test exercises uncommitted changes.
+# Includes ~/.gitconfig.local the same way the real machine does, so
+# setup_local_agent's use of it below exercises the --includes flag
+# git-signing-key depends on rather than a value git would find anyway.
 write_gitconfig() {
   local home="$1"
   cat > "$home/.gitconfig" <<EOF
+[include]
+	path = $home/.gitconfig.local
 [user]
 	name = Test User
 	email = test@example.com
@@ -74,7 +79,7 @@ setup_local_agent() {
   agent_pids+=("$(start_agent "$secretive")")
   ssh-keygen -q -t ed25519 -N '' -f "$home/local_key" -C local
   SSH_AUTH_SOCK="$secretive" ssh-add "$home/local_key" >/dev/null 2>&1
-  git config --file "$home/.gitconfig" user.localSigningKey "$home/local_key.pub"
+  git config --file "$home/.gitconfig.local" user.localSigningKey "$home/local_key.pub"
 }
 
 commit_in_scratch_repo() {
@@ -100,7 +105,7 @@ signed_with_key() {
     grep -q 'Good "git" signature'
 }
 
-# ── Test: local-only — no forwarded agent, only the local (Secretive) one ──
+# ── Test: local-only, no forwarded agent, only the local (Secretive) one ───
 
 HOME1=$(new_home)
 write_gitconfig "$HOME1"
@@ -127,8 +132,8 @@ assert "forwarded: signs with the forwarded key" signed_with_key "$HOME2" "$HOME
 # The scenario the whole plan exists for: agent.sock is a dangling symlink
 # left by a forwarded session that already ended. SSH_AUTH_SOCK is exported
 # (as it would be by a shell or launchd long ago) but nothing has refreshed
-# the symlink's target since. Signed from a bare `env -i` process — no
-# shell init, no PATH beyond the OS defaults — to prove the healing doesn't
+# the symlink's target since. Signed from a bare `env -i` process (no
+# shell init, no PATH beyond the OS defaults) to prove the healing doesn't
 # depend on a shell prompt having drawn.
 
 HOME3=$(new_home)

--- a/bin/lib/test-git-signing-key.sh
+++ b/bin/lib/test-git-signing-key.sh
@@ -24,10 +24,17 @@ cleanup() {
 trap cleanup EXIT
 
 # ── Test: local signing key configured and present on disk ─────────────────
+# Set through an [include], mirroring the real machine's ~/.gitconfig ->
+# ~/.gitconfig.local layout, so this exercises the --includes flag
+# git-signing-key depends on rather than a value git would find anyway.
 
 KEY_FILE="$FAKE_HOME/id_test.pub"
 echo "ssh-ed25519 AAAAtest test@example.com" > "$KEY_FILE"
-HOME="$FAKE_HOME" git config --global user.localSigningKey "$KEY_FILE"
+cat > "$FAKE_HOME/.gitconfig" <<EOF
+[include]
+	path = $FAKE_HOME/.gitconfig.local
+EOF
+git config --file "$FAKE_HOME/.gitconfig.local" user.localSigningKey "$KEY_FILE"
 
 out=$(HOME="$FAKE_HOME" "$BIN")
 assert "prints key:: plus the local signing key contents" \
@@ -48,7 +55,7 @@ assert "prints key:: plus the forwarded agent's key" \
 
 # ── Test: forwarded agent live but empty ────────────────────────────────────
 # `ssh-add -L` against an agent with no loaded identities prints "The agent
-# has no identities." to stdout and exits 1 — a plausible real scenario
+# has no identities." to stdout and exits 1, a plausible real scenario
 # (agent forwarded before any key was added to it). That sentence must not
 # be mistaken for a key; git-signing-key must fall back to the local key.
 
@@ -63,7 +70,7 @@ assert "falls back to the local key when the forwarded agent has no identities" 
 # ── Test: forwarded agent gone by the time ssh-add -L runs ─────────────────
 # A bound-but-unlistened socket passes the -S liveness check ssh-agent-sync
 # uses to leave the link alone, but refuses the connection `ssh-add -L`
-# needs — the agent-died-mid-flight case. git-signing-key must fall back to
+# needs: the agent-died-mid-flight case. git-signing-key must fall back to
 # the local key rather than failing outright.
 
 DEAD_FORWARDED="$FAKE_HOME/dead-forwarded.sock"

--- a/bin/lib/test-git-signing-key.sh
+++ b/bin/lib/test-git-signing-key.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# Tests for git-signing-key's key-resolution logic: local fallback, a live
+# forwarded agent, and a forwarded agent that's gone by the time `ssh-add
+# -L` runs.
+#
+# Usage: test-git-signing-key.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=bin/lib/test-helpers.sh
+source "$SCRIPT_DIR/test-helpers.sh"
+BIN="$(cd "$SCRIPT_DIR/.." && pwd)/git-signing-key"
+
+agent_pids=()
+FAKE_HOME=$(cd "$(mktemp -d /tmp/t.XXXXXX)" && pwd -P)
+cleanup() {
+  local pid
+  for pid in "${agent_pids[@]:-}"; do
+    [[ -n "$pid" ]] && kill "$pid" 2>/dev/null
+  done
+  rm -rf "$FAKE_HOME"
+}
+trap cleanup EXIT
+
+# ── Test: local signing key configured and present on disk ─────────────────
+
+KEY_FILE="$FAKE_HOME/id_test.pub"
+echo "ssh-ed25519 AAAAtest test@example.com" > "$KEY_FILE"
+HOME="$FAKE_HOME" git config --global user.localSigningKey "$KEY_FILE"
+
+out=$(HOME="$FAKE_HOME" "$BIN")
+assert "prints key:: plus the local signing key contents" \
+  test "$out" = "key::$(cat "$KEY_FILE")"
+
+# ── Test: live forwarded agent already linked at agent.sock ────────────────
+
+mkdir -p -m 700 "$FAKE_HOME/.ssh"
+FORWARDED="$FAKE_HOME/forwarded-agent.sock"
+agent_pids+=("$(start_agent "$FORWARDED")")
+ssh-keygen -q -t ed25519 -N '' -f "$FAKE_HOME/forwarded_key" -C forwarded
+SSH_AUTH_SOCK="$FORWARDED" ssh-add "$FAKE_HOME/forwarded_key" >/dev/null 2>&1
+ln -sf "$FORWARDED" "$FAKE_HOME/.ssh/agent.sock"
+
+out=$(HOME="$FAKE_HOME" "$BIN")
+assert "prints key:: plus the forwarded agent's key" \
+  test "$out" = "key::$(cat "$FAKE_HOME/forwarded_key.pub")"
+
+# ── Test: forwarded agent gone by the time ssh-add -L runs ─────────────────
+# A bound-but-unlistened socket passes the -S liveness check ssh-agent-sync
+# uses to leave the link alone, but refuses the connection `ssh-add -L`
+# needs — the agent-died-mid-flight case. git-signing-key must fall back to
+# the local key rather than failing outright.
+
+DEAD_FORWARDED="$FAKE_HOME/dead-forwarded.sock"
+mksock "$DEAD_FORWARDED"
+ln -sf "$DEAD_FORWARDED" "$FAKE_HOME/.ssh/agent.sock"
+
+out=$(HOME="$FAKE_HOME" "$BIN")
+assert "falls back to the local key when the forwarded agent is unreachable" \
+  test "$out" = "key::$(cat "$KEY_FILE")"
+
+# ── Test: no local or forwarded key available ───────────────────────────────
+
+rm -rf "$FAKE_HOME/.ssh"
+rm -f "$KEY_FILE"
+
+rc=0
+HOME="$FAKE_HOME" "$BIN" >/dev/null 2>/dev/null || rc=$?
+assert "exits non-zero when no key is found" test "$rc" -ne 0
+
+# ── Results ──────────────────────────────────────────────────────────────────
+
+print_results

--- a/bin/lib/test-git-signing-key.sh
+++ b/bin/lib/test-git-signing-key.sh
@@ -46,6 +46,20 @@ out=$(HOME="$FAKE_HOME" "$BIN")
 assert "prints key:: plus the forwarded agent's key" \
   test "$out" = "key::$(cat "$FAKE_HOME/forwarded_key.pub")"
 
+# ── Test: forwarded agent live but empty ────────────────────────────────────
+# `ssh-add -L` against an agent with no loaded identities prints "The agent
+# has no identities." to stdout and exits 1 — a plausible real scenario
+# (agent forwarded before any key was added to it). That sentence must not
+# be mistaken for a key; git-signing-key must fall back to the local key.
+
+EMPTY_FORWARDED="$FAKE_HOME/empty-forwarded.sock"
+agent_pids+=("$(start_agent "$EMPTY_FORWARDED")")
+ln -sf "$EMPTY_FORWARDED" "$FAKE_HOME/.ssh/agent.sock"
+
+out=$(HOME="$FAKE_HOME" "$BIN")
+assert "falls back to the local key when the forwarded agent has no identities" \
+  test "$out" = "key::$(cat "$KEY_FILE")"
+
 # ── Test: forwarded agent gone by the time ssh-add -L runs ─────────────────
 # A bound-but-unlistened socket passes the -S liveness check ssh-agent-sync
 # uses to leave the link alone, but refuses the connection `ssh-add -L`

--- a/bin/lib/test-helpers.sh
+++ b/bin/lib/test-helpers.sh
@@ -3,11 +3,27 @@
 #
 # Usage: source "$SCRIPT_DIR/test-helpers.sh"
 #
-# Provides assert/assert_not functions and a print_results finalizer.
-# Each test file should call print_results at the end.
+# Provides assert/assert_not functions, socket/agent fixtures for SSH-agent
+# tests, and a print_results finalizer. Each test file should call
+# print_results at the end.
 
 passes=0
 failures=0
+
+# Binds a dead AF_UNIX socket at $1: passes -S liveness checks but refuses
+# connections, for simulating an agent that's gone by connect time.
+mksock() {
+    python3 -c 'import socket, sys; socket.socket(socket.AF_UNIX).bind(sys.argv[1])' "$1"
+}
+
+# Starts a real ssh-agent listening on $1 without eval'ing its output (that
+# would export SSH_AUTH_SOCK into the caller's own environment). Echoes its
+# PID so the caller can kill it during cleanup.
+start_agent() {
+    local sock="$1" out
+    out=$(ssh-agent -a "$sock")
+    printf '%s\n' "$out" | sed -n 's/^SSH_AGENT_PID=\([0-9]*\);.*/\1/p'
+}
 
 assert() {
     local description="$1"

--- a/bin/lib/test-ssh-agent-sync.sh
+++ b/bin/lib/test-ssh-agent-sync.sh
@@ -54,6 +54,15 @@ out=$(HOME="$FAKE_HOME" "$BIN" "$DEAD_FORWARDED")
 assert "dead forwarded arg with dangling sock prints local" test "$out" = "local"
 assert "dangling sock re-heals to Secretive" test "$SOCK" -ef "$SECRETIVE"
 
+# ── Test: dead forwarded arg while sock is already healthy stays local ──────
+# Proves the elif [[ ! -S "$sock" ]] guard is a no-op here: unlike the test
+# above, $SOCK already points at Secretive, so a dead forwarded arg must not
+# needlessly re-link or misclassify it.
+
+out=$(HOME="$FAKE_HOME" "$BIN" "$DEAD_FORWARDED")
+assert "dead forwarded arg with an already-healthy sock still prints local" test "$out" = "local"
+assert "already-healthy sock is left pointing at Secretive" test "$SOCK" -ef "$SECRETIVE"
+
 # ── Test: nothing present ───────────────────────────────────────────────────
 
 rm -rf "$FAKE_HOME/.ssh" "$FAKE_HOME/Library"

--- a/bin/lib/test-ssh-agent-sync.sh
+++ b/bin/lib/test-ssh-agent-sync.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+# Tests for the local/forwarded/none classification in ssh-agent-sync.
+#
+# Usage: test-ssh-agent-sync.sh
+#
+# Builds a throwaway HOME with fake Secretive/forwarded sockets (real
+# AF_UNIX binds, since -S only recognizes actual sockets) and exercises the
+# script's healing and classification logic against it.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=bin/lib/test-helpers.sh
+source "$SCRIPT_DIR/test-helpers.sh"
+BIN="$(cd "$SCRIPT_DIR/.." && pwd)/ssh-agent-sync"
+
+# Resolve through symlinks (macOS /var -> /private/var) so `-ef` comparisons
+# against paths built from $HOME match what the script itself resolves. Kept
+# short and rooted at /tmp rather than the default $TMPDIR: appending the
+# hardcoded Secretive container path can otherwise exceed macOS's ~104-byte
+# AF_UNIX path limit.
+FAKE_HOME=$(cd "$(mktemp -d /tmp/t.XXXXXX)" && pwd -P)
+trap 'rm -rf "$FAKE_HOME"' EXIT
+SECRETIVE="$FAKE_HOME/Library/Containers/com.maxgoedjen.Secretive.SecretAgent/Data/socket.ssh"
+SOCK="$FAKE_HOME/.ssh/agent.sock"
+
+# ── Test: live forwarded socket ─────────────────────────────────────────────
+
+mkdir -p "$(dirname "$SECRETIVE")"
+mksock "$SECRETIVE"
+FORWARDED="$FAKE_HOME/forwarded.sock"
+mksock "$FORWARDED"
+
+out=$(HOME="$FAKE_HOME" "$BIN" "$FORWARDED")
+assert "live forwarded arg prints forwarded" test "$out" = "forwarded"
+assert "symlink points at the forwarded socket" test "$SOCK" -ef "$FORWARDED"
+
+# ── Test: no arg, sock missing, Secretive present ───────────────────────────
+
+rm -rf "$FAKE_HOME/.ssh"
+
+out=$(HOME="$FAKE_HOME" "$BIN")
+assert "no forwarded arg with Secretive present prints local" test "$out" = "local"
+assert "symlink points at Secretive" test "$SOCK" -ef "$SECRETIVE"
+
+# ── Test: dead forwarded arg with a dangling sock re-heals to local ─────────
+
+rm -rf "$FAKE_HOME/.ssh"
+mkdir -p "$FAKE_HOME/.ssh"
+ln -s "$FAKE_HOME/torn-down.sock" "$SOCK"
+DEAD_FORWARDED="$FAKE_HOME/dead-forwarded.sock"
+
+out=$(HOME="$FAKE_HOME" "$BIN" "$DEAD_FORWARDED")
+assert "dead forwarded arg with dangling sock prints local" test "$out" = "local"
+assert "dangling sock re-heals to Secretive" test "$SOCK" -ef "$SECRETIVE"
+
+# ── Test: nothing present ───────────────────────────────────────────────────
+
+rm -rf "$FAKE_HOME/.ssh" "$FAKE_HOME/Library"
+
+out=$(HOME="$FAKE_HOME" "$BIN")
+assert "nothing present prints none" test "$out" = "none"
+assert "no symlink is created" test ! -e "$SOCK"
+
+# ── Results ──────────────────────────────────────────────────────────────────
+
+print_results

--- a/bin/ssh-agent-sync
+++ b/bin/ssh-agent-sync
@@ -10,6 +10,9 @@
 set -euo pipefail
 
 sock="$HOME/.ssh/agent.sock"
+# This path is also hardcoded in git/gitconfig.symlink's core.sshCommand
+# (IdentityAgent=...), for git's own SSH transport rather than signing.
+# Keep both in sync if Secretive ever changes its container/bundle id.
 secretive="$HOME/Library/Containers/com.maxgoedjen.Secretive.SecretAgent/Data/socket.ssh"
 forwarded="${1:-}"
 

--- a/bin/ssh-agent-sync
+++ b/bin/ssh-agent-sync
@@ -2,7 +2,8 @@
 # Points ~/.ssh/agent.sock at the right SSH agent socket: a live forwarded
 # agent when one is given and reachable, otherwise the local Secretive
 # agent. Safe to call repeatedly; only touches the symlink when it isn't
-# already pointing at the right target.
+# already pointing at the right target. Prints the resolved mode ("local",
+# "forwarded", or "none") so callers don't have to re-derive it themselves.
 #
 # Usage: ssh-agent-sync [forwarded-socket-path]
 
@@ -16,8 +17,14 @@ mkdir -p "$HOME/.ssh"
 
 if [[ -n "$forwarded" && -S "$forwarded" ]]; then
   [[ "$sock" -ef "$forwarded" ]] || ln -sf "$forwarded" "$sock"
-elif [[ ! -S "$sock" ]] || [[ "$sock" -ef "$secretive" ]]; then
-  if [[ -S "$secretive" ]] && ! [[ -S "$sock" && "$sock" -ef "$secretive" ]]; then
-    ln -sf "$secretive" "$sock"
-  fi
+elif [[ ! -S "$sock" ]] && [[ -S "$secretive" ]]; then
+  ln -sf "$secretive" "$sock"
+fi
+
+if [[ -S "$sock" ]] && [[ "$sock" -ef "$secretive" ]]; then
+  echo "local"
+elif [[ -S "$sock" ]]; then
+  echo "forwarded"
+else
+  echo "none"
 fi

--- a/bin/ssh-agent-sync
+++ b/bin/ssh-agent-sync
@@ -13,7 +13,7 @@ sock="$HOME/.ssh/agent.sock"
 secretive="$HOME/Library/Containers/com.maxgoedjen.Secretive.SecretAgent/Data/socket.ssh"
 forwarded="${1:-}"
 
-mkdir -p "$HOME/.ssh"
+mkdir -p -m 700 "$HOME/.ssh"
 
 if [[ -n "$forwarded" && -S "$forwarded" ]]; then
   [[ "$sock" -ef "$forwarded" ]] || ln -sf "$forwarded" "$sock"

--- a/bin/ssh-agent-sync
+++ b/bin/ssh-agent-sync
@@ -13,7 +13,7 @@ sock="$HOME/.ssh/agent.sock"
 secretive="$HOME/Library/Containers/com.maxgoedjen.Secretive.SecretAgent/Data/socket.ssh"
 forwarded="${1:-}"
 
-mkdir -p -m 700 "$HOME/.ssh"
+[[ -d "$HOME/.ssh" ]] || mkdir -p -m 700 "$HOME/.ssh"
 
 if [[ -n "$forwarded" && -S "$forwarded" ]]; then
   [[ "$sock" -ef "$forwarded" ]] || ln -sf "$forwarded" "$sock"

--- a/bin/ssh-agent-sync
+++ b/bin/ssh-agent-sync
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Points ~/.ssh/agent.sock at the right SSH agent socket: a live forwarded
+# agent when one is given and reachable, otherwise the local Secretive
+# agent. Safe to call repeatedly; only touches the symlink when it isn't
+# already pointing at the right target.
+#
+# Usage: ssh-agent-sync [forwarded-socket-path]
+
+set -euo pipefail
+
+sock="$HOME/.ssh/agent.sock"
+secretive="$HOME/Library/Containers/com.maxgoedjen.Secretive.SecretAgent/Data/socket.ssh"
+forwarded="${1:-}"
+
+mkdir -p "$HOME/.ssh"
+
+if [[ -n "$forwarded" && -S "$forwarded" ]]; then
+  [[ "$sock" -ef "$forwarded" ]] || ln -sf "$forwarded" "$sock"
+elif [[ ! -S "$sock" ]] || [[ "$sock" -ef "$secretive" ]]; then
+  if [[ -S "$secretive" ]] && ! [[ -S "$sock" && "$sock" -ef "$secretive" ]]; then
+    ln -sf "$secretive" "$sock"
+  fi
+fi

--- a/git/gitconfig.local.symlink.template
+++ b/git/gitconfig.local.symlink.template
@@ -2,7 +2,6 @@
 [user]
         name = AUTHORNAME
         email = AUTHOREMAIL
-        signingkey = ~/.ssh/agent.pub
         localSigningKey = LOCAL_SIGNING_KEY
 [credential]
         helper = GIT_CREDENTIAL_HELPER

--- a/git/gitconfig.symlink
+++ b/git/gitconfig.symlink
@@ -52,6 +52,10 @@
 [core]
 	editor = zed --wait
 	excludesfile = ~/.gitignore.global
+	# This Secretive socket path is also hardcoded in bin/ssh-agent-sync
+	# (for commit-signing agent resolution, a separate mechanism from this
+	# SSH transport setting). Keep both in sync if Secretive ever changes
+	# its container/bundle id.
 	sshCommand = ssh -o IdentityAgent=/Users/haacked/Library/Containers/com.maxgoedjen.Secretive.SecretAgent/Data/socket.ssh
 [init]
 	defaultBranch = main

--- a/git/gitconfig.symlink
+++ b/git/gitconfig.symlink
@@ -59,12 +59,11 @@
 	name = Phil Haack
 	email = haacked@gmail.com
 	branchprefix = haacked/
-	# signingkey is machine-specific (Secretive keys differ per Mac); set it in
-	# ~/.gitconfig.local, not here.
 [credential "https://dev.azure.com"]
 	useHttpPath = true
 [gpg "ssh"]
 	program = /usr/bin/ssh-keygen
+	defaultKeyCommand = /Users/haacked/.dotfiles/bin/git-signing-key
 [alias]
 	sign-unpushed = "\\!f() { DEFAULT=$(git default); UPSTREAM=${1-origin/$DEFAULT}; git rebase --exec \"git commit --amend --no-edit -S\" $UPSTREAM; }; f"
 [branch]

--- a/macos/LaunchAgents/com.haacked.secretive-ssh-auth.plist
+++ b/macos/LaunchAgents/com.haacked.secretive-ssh-auth.plist
@@ -6,23 +6,22 @@
     <string>com.haacked.secretive-ssh-auth</string>
     <!--
     Points the session-wide SSH_AUTH_SOCK default at the stable agent
-    symlink (see zsh/zshrc.symlink) rather than Secretive's socket
-    directly, so processes that never source .zshrc (GUI apps, tools
-    that spawn non-interactive shells) still pick up a forwarded agent
-    when one is live. Seeds the symlink to the local Secretive socket
-    first in case this runs before any shell has initialized it. Also
-    seeds agent.pub from user.localSigningKey so GUI apps that sign a
-    commit before any interactive shell has run don't find it missing.
-    Bare `git` resolves fine here: launchd runs jobs with PATH=/usr/bin:
-    /bin:/usr/sbin:/sbin, and /usr/bin/git (the Xcode CLT shim, a
-    Homebrew prerequisite already assumed elsewhere in this repo) is on
-    that PATH.
+    symlink (see zsh/zshrc.symlink and bin/ssh-agent-sync) rather than
+    Secretive's socket directly, so processes that never source .zshrc
+    (GUI apps, tools that spawn non-interactive shells) still pick up a
+    live agent. Runs ssh-agent-sync with no argument, since only an
+    interactive SSH shell knows about a live forwarded socket to hand
+    it; this job can only heal toward the local Secretive agent, which
+    is enough to seed the symlink before any shell has run. Signing
+    itself resolves the right key fresh at sign time via
+    gpg.ssh.defaultKeyCommand (bin/git-signing-key), so there's no key
+    file to seed here.
     -->
     <key>ProgramArguments</key>
     <array>
         <string>/bin/sh</string>
         <string>-c</string>
-        <string>mkdir -p "$HOME/.ssh" &amp;&amp; ln -sf "$HOME/Library/Containers/com.maxgoedjen.Secretive.SecretAgent/Data/socket.ssh" "$HOME/.ssh/agent.sock" &amp;&amp; /bin/launchctl setenv SSH_AUTH_SOCK "$HOME/.ssh/agent.sock"; LOCAL_SIGNING_KEY=$(git config --global --includes --get user.localSigningKey 2>/dev/null); [ -n "$LOCAL_SIGNING_KEY" ] &amp;&amp; [ -f "$LOCAL_SIGNING_KEY" ] &amp;&amp; cat "$LOCAL_SIGNING_KEY" &gt; "$HOME/.ssh/agent.pub"</string>
+        <string>"$HOME/.dotfiles/bin/ssh-agent-sync" &gt;/dev/null &amp;&amp; /bin/launchctl setenv SSH_AUTH_SOCK "$HOME/.ssh/agent.sock"</string>
     </array>
     <key>RunAtLoad</key>
     <true/>

--- a/macos/LaunchAgents/com.haacked.secretive-ssh-auth.plist
+++ b/macos/LaunchAgents/com.haacked.secretive-ssh-auth.plist
@@ -22,7 +22,7 @@
     <array>
         <string>/bin/sh</string>
         <string>-c</string>
-        <string>mkdir -p "$HOME/.ssh" &amp;&amp; ln -sf "$HOME/Library/Containers/com.maxgoedjen.Secretive.SecretAgent/Data/socket.ssh" "$HOME/.ssh/agent.sock" &amp;&amp; /bin/launchctl setenv SSH_AUTH_SOCK "$HOME/.ssh/agent.sock"; LOCAL_SIGNING_KEY=$(git config --global --get user.localSigningKey 2>/dev/null); [ -n "$LOCAL_SIGNING_KEY" ] &amp;&amp; [ -f "$LOCAL_SIGNING_KEY" ] &amp;&amp; cat "$LOCAL_SIGNING_KEY" &gt; "$HOME/.ssh/agent.pub"</string>
+        <string>mkdir -p "$HOME/.ssh" &amp;&amp; ln -sf "$HOME/Library/Containers/com.maxgoedjen.Secretive.SecretAgent/Data/socket.ssh" "$HOME/.ssh/agent.sock" &amp;&amp; /bin/launchctl setenv SSH_AUTH_SOCK "$HOME/.ssh/agent.sock"; LOCAL_SIGNING_KEY=$(git config --global --includes --get user.localSigningKey 2>/dev/null); [ -n "$LOCAL_SIGNING_KEY" ] &amp;&amp; [ -f "$LOCAL_SIGNING_KEY" ] &amp;&amp; cat "$LOCAL_SIGNING_KEY" &gt; "$HOME/.ssh/agent.pub"</string>
     </array>
     <key>RunAtLoad</key>
     <true/>

--- a/zsh/zshrc.symlink
+++ b/zsh/zshrc.symlink
@@ -34,7 +34,7 @@ fi
 # pay for a redundant ln on every keypress.
 #
 # The forwarded socket is captured once into _SSH_FWD_SOCK at shell startup,
-# before the first sync overwrites SSH_AUTH_SOCK with the symlink path — an
+# before the first sync overwrites SSH_AUTH_SOCK with the symlink path: an
 # SSH shell that re-derived "the forwarded socket" from SSH_AUTH_SOCK on
 # later precmd calls would just be comparing the symlink against itself.
 [[ -n "$SSH_CONNECTION" ]] && _SSH_FWD_SOCK="$SSH_AUTH_SOCK"

--- a/zsh/zshrc.symlink
+++ b/zsh/zshrc.symlink
@@ -47,7 +47,7 @@ if [ -n "$SSH_CONNECTION" ] && [ -S "$SSH_AUTH_SOCK" ]; then
   [ -n "$FORWARDED_KEY" ] && echo "$FORWARDED_KEY" > "$SSH_AGENT_PUB"
 elif [ "$LOCAL_AGENT_LINKED" = true ] && [ -S "$SECRETIVE_SOCK" ]; then
   ln -sf "$SECRETIVE_SOCK" "$SSH_AGENT_SOCK"
-  LOCAL_SIGNING_KEY=$(git config --global --get user.localSigningKey 2>/dev/null)
+  LOCAL_SIGNING_KEY=$(git config --global --includes --get user.localSigningKey 2>/dev/null)
   [ -n "$LOCAL_SIGNING_KEY" ] && [ -f "$LOCAL_SIGNING_KEY" ] && cat "$LOCAL_SIGNING_KEY" > "$SSH_AGENT_PUB"
 fi
 [ -S "$SSH_AGENT_SOCK" ] && export SSH_AUTH_SOCK="$SSH_AGENT_SOCK"

--- a/zsh/zshrc.symlink
+++ b/zsh/zshrc.symlink
@@ -48,9 +48,9 @@ _ssh_agent_sync() {
     fi
   elif [[ ! -S "$sock" ]] && [[ -S "$secretive" ]]; then
     ln -sf "$secretive" "$sock"
-    local local_key
-    local_key=$(git config --global --includes --get user.localSigningKey 2>/dev/null)
-    [[ -n "$local_key" && -f "$local_key" ]] && cat "$local_key" > "$pub"
+    local local_signing_key
+    local_signing_key=$(git config --global --includes --get user.localSigningKey 2>/dev/null)
+    [[ -n "$local_signing_key" && -f "$local_signing_key" ]] && cat "$local_signing_key" > "$pub"
   fi
 
   [[ -S "$sock" ]] && export SSH_AUTH_SOCK="$sock"

--- a/zsh/zshrc.symlink
+++ b/zsh/zshrc.symlink
@@ -20,40 +20,28 @@ fi
 # session started hours ago picks up whichever agent is current the next
 # time it signs something, without needing to restart.
 #
-# git commit -S needs the exact public key to ask the agent for, so
-# user.signingkey (~/.gitconfig.local) points at agent.pub, a matching
-# indirection kept in sync alongside the socket. user.localSigningKey names
-# this machine's own key and is the fallback source; machines that haven't
-# set it just keep whatever signingkey they had before this existed.
+# git commit -S resolves the exact public key to ask for at signing time via
+# gpg.ssh.defaultKeyCommand (bin/git-signing-key), which itself calls
+# ssh-agent-sync. There's no cached key file to keep in sync here: whichever
+# agent is live when git signs is the one it asks.
 #
 # Re-synced on every precmd, not just shell startup: the symlink is shared
 # host-wide, so a long-lived local shell that was already running before a
 # remote SSH session started won't source this file again when that session
 # ends. Without a precmd recheck it would keep pointing at a forwarding
-# socket sshd has already torn down. Each branch first checks (via -ef, no
-# subprocess) whether the link already points where it should, so idle
-# prompts don't pay for a redundant ln/ssh-add/git-config on every keypress.
-mkdir -p "$HOME/.ssh"
+# socket sshd has already torn down. ssh-agent-sync only touches the symlink
+# when it isn't already pointing at the right target, so idle prompts don't
+# pay for a redundant ln on every keypress.
+#
+# The forwarded socket is captured once into _SSH_FWD_SOCK at shell startup,
+# before the first sync overwrites SSH_AUTH_SOCK with the symlink path — an
+# SSH shell that re-derived "the forwarded socket" from SSH_AUTH_SOCK on
+# later precmd calls would just be comparing the symlink against itself.
+[[ -n "$SSH_CONNECTION" ]] && _SSH_FWD_SOCK="$SSH_AUTH_SOCK"
 
 _ssh_agent_sync() {
-  local sock="$HOME/.ssh/agent.sock" pub="$HOME/.ssh/agent.pub"
-  local secretive="$HOME/Library/Containers/com.maxgoedjen.Secretive.SecretAgent/Data/socket.ssh"
-
-  if [[ -n "$SSH_CONNECTION" && -S "$SSH_AUTH_SOCK" ]]; then
-    if ! [[ "$sock" -ef "$SSH_AUTH_SOCK" ]]; then
-      ln -sf "$SSH_AUTH_SOCK" "$sock"
-      local forwarded_key
-      forwarded_key=$(SSH_AUTH_SOCK="$sock" ssh-add -L 2>/dev/null | head -1)
-      [[ -n "$forwarded_key" ]] && print -r -- "$forwarded_key" > "$pub"
-    fi
-  elif [[ ! -S "$sock" ]] && [[ -S "$secretive" ]]; then
-    ln -sf "$secretive" "$sock"
-    local local_signing_key
-    local_signing_key=$(git config --global --includes --get user.localSigningKey 2>/dev/null)
-    [[ -n "$local_signing_key" && -f "$local_signing_key" ]] && cat "$local_signing_key" > "$pub"
-  fi
-
-  [[ -S "$sock" ]] && export SSH_AUTH_SOCK="$sock"
+  "$HOME/.dotfiles/bin/ssh-agent-sync" "$_SSH_FWD_SOCK" >/dev/null
+  [[ -S "$HOME/.ssh/agent.sock" ]] && export SSH_AUTH_SOCK="$HOME/.ssh/agent.sock"
 }
 _ssh_agent_sync
 autoload -Uz add-zsh-hook

--- a/zsh/zshrc.symlink
+++ b/zsh/zshrc.symlink
@@ -46,13 +46,11 @@ _ssh_agent_sync() {
       forwarded_key=$(SSH_AUTH_SOCK="$sock" ssh-add -L 2>/dev/null | head -1)
       [[ -n "$forwarded_key" ]] && print -r -- "$forwarded_key" > "$pub"
     fi
-  elif [[ ! -S "$sock" ]] || [[ "$sock" -ef "$secretive" ]]; then
-    if [[ -S "$secretive" ]] && ! [[ -S "$sock" && "$sock" -ef "$secretive" ]]; then
-      ln -sf "$secretive" "$sock"
-      local local_key
-      local_key=$(git config --global --includes --get user.localSigningKey 2>/dev/null)
-      [[ -n "$local_key" && -f "$local_key" ]] && cat "$local_key" > "$pub"
-    fi
+  elif [[ ! -S "$sock" ]] && [[ -S "$secretive" ]]; then
+    ln -sf "$secretive" "$sock"
+    local local_key
+    local_key=$(git config --global --includes --get user.localSigningKey 2>/dev/null)
+    [[ -n "$local_key" && -f "$local_key" ]] && cat "$local_key" > "$pub"
   fi
 
   [[ -S "$sock" ]] && export SSH_AUTH_SOCK="$sock"

--- a/zsh/zshrc.symlink
+++ b/zsh/zshrc.symlink
@@ -25,33 +25,41 @@ fi
 # indirection kept in sync alongside the socket. user.localSigningKey names
 # this machine's own key and is the fallback source; machines that haven't
 # set it just keep whatever signingkey they had before this existed.
-SSH_AGENT_SOCK="$HOME/.ssh/agent.sock"
-SSH_AGENT_PUB="$HOME/.ssh/agent.pub"
-SECRETIVE_SOCK="$HOME/Library/Containers/com.maxgoedjen.Secretive.SecretAgent/Data/socket.ssh"
+#
+# Re-synced on every precmd, not just shell startup: the symlink is shared
+# host-wide, so a long-lived local shell that was already running before a
+# remote SSH session started won't source this file again when that session
+# ends. Without a precmd recheck it would keep pointing at a forwarding
+# socket sshd has already torn down. Each branch first checks (via -ef, no
+# subprocess) whether the link already points where it should, so idle
+# prompts don't pay for a redundant ln/ssh-add/git-config on every keypress.
 mkdir -p "$HOME/.ssh"
 
-# The LaunchAgent (macos/LaunchAgents/com.haacked.secretive-ssh-auth.plist)
-# pre-seeds agent.sock to the local Secretive socket at login, so by the time
-# a shell starts it's usually already a valid socket. Treat the symlink as
-# "local" (safe to re-seed agent.pub) whenever it's missing/broken or still
-# pointing at Secretive, and only skip it when another pane already redirected
-# it to a live forwarded agent.
-LOCAL_AGENT_LINKED=false
-if [ ! -S "$SSH_AGENT_SOCK" ] || [ "$(readlink "$SSH_AGENT_SOCK")" = "$SECRETIVE_SOCK" ]; then
-  LOCAL_AGENT_LINKED=true
-fi
+_ssh_agent_sync() {
+  local sock="$HOME/.ssh/agent.sock" pub="$HOME/.ssh/agent.pub"
+  local secretive="$HOME/Library/Containers/com.maxgoedjen.Secretive.SecretAgent/Data/socket.ssh"
 
-if [ -n "$SSH_CONNECTION" ] && [ -S "$SSH_AUTH_SOCK" ]; then
-  ln -sf "$SSH_AUTH_SOCK" "$SSH_AGENT_SOCK"
-  FORWARDED_KEY=$(SSH_AUTH_SOCK="$SSH_AGENT_SOCK" ssh-add -L 2>/dev/null | head -1)
-  [ -n "$FORWARDED_KEY" ] && echo "$FORWARDED_KEY" > "$SSH_AGENT_PUB"
-elif [ "$LOCAL_AGENT_LINKED" = true ] && [ -S "$SECRETIVE_SOCK" ]; then
-  ln -sf "$SECRETIVE_SOCK" "$SSH_AGENT_SOCK"
-  LOCAL_SIGNING_KEY=$(git config --global --includes --get user.localSigningKey 2>/dev/null)
-  [ -n "$LOCAL_SIGNING_KEY" ] && [ -f "$LOCAL_SIGNING_KEY" ] && cat "$LOCAL_SIGNING_KEY" > "$SSH_AGENT_PUB"
-fi
-[ -S "$SSH_AGENT_SOCK" ] && export SSH_AUTH_SOCK="$SSH_AGENT_SOCK"
-unset SSH_AGENT_SOCK SSH_AGENT_PUB SECRETIVE_SOCK LOCAL_AGENT_LINKED LOCAL_SIGNING_KEY FORWARDED_KEY
+  if [[ -n "$SSH_CONNECTION" && -S "$SSH_AUTH_SOCK" ]]; then
+    if ! [[ "$sock" -ef "$SSH_AUTH_SOCK" ]]; then
+      ln -sf "$SSH_AUTH_SOCK" "$sock"
+      local forwarded_key
+      forwarded_key=$(SSH_AUTH_SOCK="$sock" ssh-add -L 2>/dev/null | head -1)
+      [[ -n "$forwarded_key" ]] && print -r -- "$forwarded_key" > "$pub"
+    fi
+  elif [[ ! -S "$sock" ]] || [[ "$sock" -ef "$secretive" ]]; then
+    if [[ -S "$secretive" ]] && ! [[ -S "$sock" && "$sock" -ef "$secretive" ]]; then
+      ln -sf "$secretive" "$sock"
+      local local_key
+      local_key=$(git config --global --includes --get user.localSigningKey 2>/dev/null)
+      [[ -n "$local_key" && -f "$local_key" ]] && cat "$local_key" > "$pub"
+    fi
+  fi
+
+  [[ -S "$sock" ]] && export SSH_AUTH_SOCK="$sock"
+}
+_ssh_agent_sync
+autoload -Uz add-zsh-hook
+add-zsh-hook precmd _ssh_agent_sync
 
 # --- Secrets (never committed) ---
 if [ -f "$HOME/.secrets" ]; then


### PR DESCRIPTION
Commit signing now resolves the SSH key at the moment git signs, via `gpg.ssh.defaultKeyCommand` (`bin/git-signing-key`), instead of caching it in `~/.ssh/agent.pub`. That cache went stale whenever a forwarded SSH session ended before a shell prompt redrew, so a background process or GUI git client signing in between got "No private key found" until the next prompt.

`bin/ssh-agent-sync` is now the single place that decides which agent `~/.ssh/agent.sock` points at, forwarded or local Secretive. zshrc's precmd hook, the LaunchAgent, and `git-signing-key` all call it instead of each keeping their own copy of the sync logic.

`gpg.ssh.defaultKeyCommand` is set to an absolute path (`/Users/haacked/.dotfiles/bin/git-signing-key`) rather than `~/.dotfiles/...`. Git execs config commands directly with no shell involved, so a leading `~` never expands and would have failed on every commit.

**Test plan**
- [x] `bash bin/lib/test-ssh-agent-sync.sh`, `bash bin/lib/test-git-signing-key.sh`, and `bash bin/lib/test-git-signing-integration.sh` all pass
- [x] The integration test runs a real `git commit -S` in isolated fake HOMEs for local-only signing, a live forwarded agent, and a torn-down forwarded agent signed from a bare `env -i` process with no shell init, the scenario this change exists for
- [x] Swept local repos for a `user.signingkey` local override that would bypass `defaultKeyCommand`; none found
- [ ] After merge: reload the LaunchAgent, delete `~/.ssh/agent.pub`, and confirm `git commit -S` and `git log --show-signature` still work on this machine
- [ ] Repeat the migration on the Neo machine and add its key to `git/allowed_signers`