### PR TITLE
Improve tree-me PR checkout with fallback naming strategies

### DIFF
--- a/bin/README-tree-me.md
+++ b/bin/README-tree-me.md
@@ -66,7 +66,17 @@ tree-me pr 123                              # By PR number
 tree-me pr https://github.com/org/repo/pull/456  # By URL
 ```
 
-Checks out the PR (via `gh pr checkout`) into a worktree at `~/dev/worktrees/<repo>/pr-123`. The local branch matches the PR's head branch (falling back to `pr-123` if that name is already taken locally), so for PRs from forks with "Allow edits from maintainers" enabled a bare `git push` goes straight back to the contributor's branch.
+Checks out the PR (via `gh pr checkout`) into a worktree named after its head branch, so for PRs from forks with "Allow edits from maintainers" enabled a bare `git push` goes straight back to the contributor's branch. Both the folder and the branch use the same name:
+
+| Case | Folder / branch name |
+| --- | --- |
+| Same-repo PR | `~/dev/worktrees/<repo>/<branch>` |
+| Fork PR | `~/dev/worktrees/<repo>/pr-123-<branch>` |
+| Name already taken (same-repo) | Falls back to `pr-123-<branch>` |
+| Name still taken | Falls back to `pr-123-<branch>-2`, `-3`, etc. |
+| Head branch unknown | Falls back to `pr-123` |
+
+Re-running `tree-me pr 123` cds back into the worktree it already created, whichever name it landed on.
 
 ### List worktrees
 

--- a/bin/tree-me
+++ b/bin/tree-me
@@ -274,11 +274,16 @@ EOF
         fi
 
         # Extend with a numbered suffix on the last candidate in case even
-        # "pr-<n>-<branch>" is somehow already taken.
-        base="${try_names[-1]}"
+        # "pr-<n>-<branch>" is somehow already taken, which happens when a
+        # leftover local branch from a prior `tree-me rm` has diverged from
+        # the PR: `gh pr checkout` below can't fast-forward it, so the retry
+        # loop falls through to a fresh numbered name. Indexed by length
+        # rather than "${try_names[-1]}" for portability (negative array
+        # subscripts need bash 4.2+).
+        last_candidate="${try_names[$((${#try_names[@]} - 1))]}"
         max_suffix=11
         for ((n = 2; n <= max_suffix; n++)); do
-            try_names+=("${base}-${n}")
+            try_names+=("${last_candidate}-${n}")
         done
 
         # Re-running `tree-me pr` for the same PR should cd back into whichever

--- a/bin/tree-me
+++ b/bin/tree-me
@@ -245,37 +245,81 @@ EOF
             exit 1
         fi
 
-        # The worktree directory is keyed on the PR number (stable, unique per
-        # PR), so re-runs and same-named branches from different forks never
-        # collide. The local branch matches the PR's head branch so a bare
-        # `git push` goes straight back to it.
-        path="$WORKTREE_ROOT/$repo/pr-$pr_number"
+        # Look up the PR's head branch and whether it comes from a fork. Branch
+        # names live in a single namespace per repo, so a same-repo PR's head
+        # branch is already a unique, stable identity; a fork's branch name has
+        # no such guarantee (two forks can both have a branch called "fix"), so
+        # it's always prefixed with the PR number. A failed lookup (bad PR
+        # number, no auth, no network) is fatal here rather than silently
+        # falling through to the retry loop below, which would otherwise burn
+        # through every fallback name hitting the same underlying failure.
+        pr_info=$(gh pr view "$pr_number" --json headRefName,isCrossRepository \
+            -q '[.headRefName, (.isCrossRepository | tostring)] | @tsv' 2>/dev/null || true)
+        if [ -z "$pr_info" ]; then
+            echo "Error: Failed to look up PR #$pr_number (check the number and your 'gh' auth)" >&2
+            exit 1
+        fi
+        # Split on the first tab with parameter expansion rather than `read`,
+        # which strips a leading/trailing tab as IFS whitespace and would
+        # misparse an empty headRefName by shifting isCrossRepository into it.
+        head_branch="${pr_info%%$'\t'*}"
+        is_fork="${pr_info#*$'\t'}"
 
-        if [ -d "$path" ] && git -C "$path" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-            echo "✓ Worktree already exists: $path"
-            echo "TREE_ME_CD:$path"
-            exit 0
+        if [ -z "$head_branch" ]; then
+            try_names=("pr-$pr_number")
+        elif [ "$is_fork" = "true" ]; then
+            try_names=("pr-$pr_number-$head_branch")
+        else
+            try_names=("$head_branch" "pr-$pr_number-$head_branch")
         fi
 
-        # Name the branch after the PR's head ref. Fall back to pr-<number> when
-        # that name is unknown or already taken by a local branch (e.g. the head
-        # ref is "master", or another fork's PR already claimed it).
-        head_branch=$(gh pr view "$pr_number" --json headRefName -q .headRefName 2>/dev/null || true)
-        branch="${head_branch:-pr-$pr_number}"
-        if [ "$branch" != "pr-$pr_number" ] && git show-ref --verify --quiet "refs/heads/$branch"; then
-            echo "ℹ Branch '$branch' already exists locally; using 'pr-$pr_number' instead" >&2
-            branch="pr-$pr_number"
-        fi
+        # Extend with a numbered suffix on the last candidate in case even
+        # "pr-<n>-<branch>" is somehow already taken.
+        base="${try_names[-1]}"
+        max_suffix=11
+        for ((n = 2; n <= max_suffix; n++)); do
+            try_names+=("${base}-${n}")
+        done
+
+        # Re-running `tree-me pr` for the same PR should cd back into whichever
+        # name it landed on last time, not create a second worktree.
+        for candidate in "${try_names[@]}"; do
+            existing=$(worktree_path_for "$candidate")
+            if [ -n "$existing" ]; then
+                echo "✓ Worktree already exists: $existing"
+                echo "TREE_ME_CD:$existing"
+                exit 0
+            fi
+        done
 
         # Create a detached worktree, then let `gh pr checkout` create the
         # branch inside it. Delegating to gh sets up the push/tracking config so
         # that PRs from forks with "Allow edits from maintainers" enabled push
         # back to the contributor's branch. A plain `git fetch pull/N/head`
         # leaves the branch disconnected from the PR.
-        git worktree add --detach "$path" >&2
-        if ! (cd "$path" && gh pr checkout "$pr_number" --branch "$branch" >&2); then
-            git worktree remove --force "$path" 2>/dev/null || true
-            echo "Error: Failed to check out PR #$pr_number" >&2
+        #
+        # A candidate name can be taken by an unrelated branch or worktree; on
+        # failure, fall back to the next name in the list.
+        path=""
+        branch=""
+        for candidate in "${try_names[@]}"; do
+            if [ "$candidate" != "${try_names[0]}" ]; then
+                echo "ℹ Retrying checkout as '$candidate'…" >&2
+            fi
+            candidate_path="$WORKTREE_ROOT/$repo/$candidate"
+            if ! git worktree add --detach "$candidate_path" >&2; then
+                continue
+            fi
+            if (cd "$candidate_path" && gh pr checkout "$pr_number" --branch "$candidate" >&2); then
+                branch="$candidate"
+                path="$candidate_path"
+                break
+            fi
+            git worktree remove --force "$candidate_path" 2>/dev/null || true
+        done
+
+        if [ -z "$path" ]; then
+            echo "Error: Failed to check out PR #$pr_number (tried: ${try_names[*]})" >&2
             exit 1
         fi
         echo "✓ PR #$pr_number checked out at: $path"


### PR DESCRIPTION
`tree-me pr` used to always create the worktree at `pr-<number>` and only used the PR's head branch name for the local branch. Now the worktree folder and branch share a name derived from the head branch, falling back through a list of candidates when there's a collision, so checking out several PRs at once doesn't leave you with a pile of generic `pr-*` directories.

The naming logic: same-repo PRs try the head branch name first, then `pr-<n>-<branch>`. Fork PRs go straight to `pr-<n>-<branch>` since branch names aren't unique across forks. Unknown head branch falls back to `pr-<n>`. If all of those are taken (for example a leftover branch from a previous `tree-me rm` that diverged from the PR), it appends `-2`, `-3`, and so on. Re-running `tree-me pr` for the same PR reuses whichever name it landed on instead of creating a duplicate.

Also swaps a `${arr[-1]}` negative-index lookup for arithmetic-expansion indexing, since negative subscripts need bash 4.2+ and this script should work on bash 4.0.

## Test plan

- [ ] Run `tree-me pr <number>` for a same-repo PR and confirm the worktree/branch name matches the head branch
- [ ] Run `tree-me pr <number>` for a fork PR and confirm it's prefixed with `pr-<n>-`
- [ ] Re-run `tree-me pr <number>` for an already-checked-out PR and confirm it cds into the existing worktree instead of erroring or duplicating