### PR TITLE
Trim CLAUDE.md into skills and drop posthog-remote MCP

### DIFF
--- a/ai/CLAUDE.md
+++ b/ai/CLAUDE.md
@@ -61,23 +61,16 @@ Write as the user in all public-facing content — never refer to yourself as an
 
 **Always use `gh` CLI** for GitHub operations. Never use GitHub MCP server tools.
 
-**Never post PR review comments without explicit user approval.** Use correct endpoints:
-- Reply to review comment: `gh api repos/owner/repo/pulls/123/comments/456/replies --method POST`
-- New review comment: `gh pr review 123 --comment --body "comment"`
-- Root PR comment (rarely appropriate): `gh issue comment 123 --body "comment"`
-
-**Resolving PR review threads:** Use `~/.dotfiles/bin/gh-resolve-threads` instead of hand-rolling a GraphQL mutation. Run with `--help` for options. Common forms:
-- `gh-resolve-threads <pr-url-or-number> --comment-id <id>` -- resolve the thread for a specific comment
-- `gh-resolve-threads <pr> --outdated` -- resolve only outdated threads
-- `gh-resolve-threads <pr> --dry-run` -- preview before resolving
+**Never post PR review comments without explicit user approval.** See the `github-pr-operations` skill for endpoint reference and thread-resolution commands.
 
 ## Project-Specific Workflow
 
 ### posthog/posthog
 
-- Read README.md and `docs/FLOX_MULTI_INSTANCE_WORKFLOW.md`.
-- Prompt whether to create a new git worktree using the `phw` command.
-- On task completion, run: `mypy --version && mypy -p posthog | mypy-baseline filter || (echo "run 'pnpm run mypy-baseline-sync' to update the baseline" && exit 1)`
+- **Never use `posthog-db` to investigate production issues.** It does not have prod data — for prod investigations, use the `metabase-prod-query` skill.
+- **Never use socket IP addresses in PostHog services.** They're the load balancer's IP — use `X-Forwarded-For` (primary), `X-Real-IP` (fallback), or `Forwarded` (RFC 7239).
+
+See the `posthog-context` skill for repo-specific workflow, full database access rules, production architecture notes, and the SDK repository table.
 
 ### Other Repositories
 
@@ -87,48 +80,6 @@ Write as the user in all public-facing content — never refer to yourself as an
 - Never nest worktrees or place them within the main repo. Never use two worktrees on the same branch simultaneously.
 - When done: prompt to commit, then `git worktree remove <path>`.
 - Occasionally audit with `git worktree list` and `git worktree prune`.
-
-## PostHog: Database Access
-
-- **`posthog-db` MCP** is the **local dev database**. Use it for testing locally, inspecting schema, exploring relationships, and developing queries.
-- **Never use `posthog-db` to investigate production issues.** It does not have prod data.
-- **For prod investigations, use the `metabase-prod-query` skill.** It wraps `hogli metabase:*` with explicit per-query approval (required even in auto mode), region handling, and `--save` discipline. Never invoke the underlying `hogli metabase:*` commands directly. Go through the skill.
-
-## PostHog: Production Architecture
-
-PostHog runs behind load balancers and proxies. Always consider this for IP addresses, rate limiting, authentication, and geolocation.
-
-- **AWS NLB** → **Contour/Envoy Ingress** → **Application Pods**
-- Contour: `num-trusted-hops: 1`; NLB: `preserve_client_ip.enabled=true`
-
-**Never use socket IP addresses** — they will be the load balancer's IP. Use `X-Forwarded-For` (primary), `X-Real-IP` (fallback), `Forwarded` (RFC 7239), socket IP (local dev only).
-
-Infrastructure repos:
-- `~/dev/posthog/posthog-cloud-infra` — Terraform/AWS (NLB, VPC)
-- `~/dev/posthog/charts` — Helm/K8s (Contour config, ingress rules, header policies)
-
-### PostHog SDK Repositories
-
-#### Client-side
-
-| Repository | Local Path | GitHub URL |
-|------------|------------|------------|
-| posthog-js, posthog-rn | `~/dev/posthog/posthog-js` | https://github.com/PostHog/posthog-js |
-| posthog-ios | `~/dev/posthog/posthog-ios` | https://github.com/PostHog/posthog-ios |
-| posthog-android | `~/dev/posthog/posthog-android` | https://github.com/PostHog/posthog-android |
-| posthog-flutter | `~/dev/posthog/posthog-flutter` | https://github.com/PostHog/posthog-flutter |
-
-#### Server-side
-
-| Repository | Local Path | GitHub URL |
-|------------|------------|------------|
-| posthog-python | `~/dev/posthog/posthog-python` | https://github.com/PostHog/posthog-python |
-| posthog-node | `~/dev/posthog/posthog-js` | https://github.com/PostHog/posthog-node |
-| posthog-php | `~/dev/posthog/posthog-php` | https://github.com/PostHog/posthog-php |
-| posthog-ruby | `~/dev/posthog/posthog-ruby` | https://github.com/PostHog/posthog-ruby |
-| posthog-go | `~/dev/posthog/posthog-go` | https://github.com/PostHog/posthog-go |
-| posthog-dotnet | `~/dev/posthog/posthog-dotnet` | https://github.com/PostHog/posthog-dotnet |
-| posthog-elixir | `~/dev/posthog/posthog-elixir` | https://github.com/PostHog/posthog-elixir |
 
 ## Coding
 

--- a/ai/agents/investigator.md
+++ b/ai/agents/investigator.md
@@ -31,7 +31,7 @@ Do not ask clarifying questions — sibling investigators are running concurrent
    2. If that returns nothing, call `list_prometheus_metric_names` to find the right metric, then query directly.
    3. Note which approach you used in the Assumptions field.
 2. **Pick the region.** PostHog runs in US and EU. If the hypothesis doesn't specify, check the context or default to US (`mcp__grafana__*`); note which you used.
-3. **Execute queries.** Use Grafana MCP tools (`mcp__grafana__*` or `mcp__grafana-eu__*`) for metrics and logs, `mcp__posthog-db__*` for database state. Do not copy large query outputs into your report — extract the key numbers.
+3. **Execute queries.** Use Grafana MCP tools (`mcp__grafana__*` or `mcp__grafana-eu__*`) for metrics and logs, `mcp__posthog-db__*` for database state, `posthog-cli api` (via Bash) for PostHog product data. Do not copy large query outputs into your report — extract the key numbers.
 4. **Reach a verdict.** Confirmed, Rejected, or Inconclusive. Don't hedge into "maybe" — commit to one of the three, with confidence.
 5. **Stop.** Do not investigate adjacent hypotheses that occur to you mid-flight. Note them in "Follow-ups" instead.
 
@@ -49,9 +49,9 @@ You have access to:
 - `mcp__grafana__*` — US Grafana (metrics, logs, dashboards, Loki, Prometheus)
 - `mcp__grafana-eu__*` — EU Grafana (same capabilities, EU region)
 - `mcp__posthog-db__*` — PostHog production database (for tenant state, schema inspection)
-- `mcp__posthog-remote__exec` — PostHog hosted MCP, SQL over the PostHog data warehouse (event volume, feature flag change history, product analytics). Use when the hypothesis is about PostHog product data rather than infrastructure signals.
+- `Bash`, restricted to `posthog-cli api ...` — SQL over the PostHog data warehouse (event volume, feature flag change history, product analytics). Use when the hypothesis is about PostHog product data rather than infrastructure signals. Before your first call, run `posthog-cli api --agent-help` and follow its workflow exactly — it is the canonical, versioned reference for tool discovery and schema drill-down, and takes precedence over any paraphrase of it here.
 
-Do not use Bash, file tools, or web search. If the answer cannot be reached with the above tools, return Inconclusive and describe the missing data source in Follow-ups.
+Do not run any other Bash command, and do not use file tools or web search. If the answer cannot be reached with the above tools, return Inconclusive and describe the missing data source in Follow-ups.
 
 ## Output format
 

--- a/ai/install.sh
+++ b/ai/install.sh
@@ -265,7 +265,6 @@ fi
 # Format: "name|description|command"
 MCP_SERVERS="
 posthog-db|PostHog database connection|/Users/haacked/.local/bin/postgres-mcp --access-mode=restricted
-posthog-remote|PostHog hosted MCP (SQL over data warehouse)|npx -y mcp-remote@latest https://mcp.posthog.com/mcp?features=sql,data_warehouse --header \"Authorization:\${POSTHOG_MCP_AUTH_HEADER}\"
 memory|Persistent memory across sessions|npx -y @modelcontextprotocol/server-memory
 grafana|Grafana MCP server|/Users/haacked/.dotfiles/bin/mcp-grafana-wrapper.sh
 "
@@ -276,9 +275,6 @@ set_server_env() {
     case "$server_name" in
         posthog-db)
             echo "-e DATABASE_URI=postgresql://posthog:posthog@localhost:5432/posthog"
-            ;;
-        posthog-remote)
-            echo "-e POSTHOG_MCP_AUTH_HEADER=\"\${POSTHOG_MCP_AUTH_HEADER}\""
             ;;
         *)
             echo ""

--- a/ai/skills/github-pr-operations/SKILL.md
+++ b/ai/skills/github-pr-operations/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: github-pr-operations
+description: Reference for GitHub PR review endpoints and resolving review threads via gh CLI. Use when replying to a PR review comment, posting a new review comment, or resolving review threads.
+---
+
+# GitHub PR Operations
+
+Endpoint reference for PR review operations. The always-on rules (never post without approval, always use `gh` CLI, no AI attribution) live in the root `CLAUDE.md` — this skill is just the mechanics. For the end-to-end review-comment workflow (deciding what's a real issue, drafting replies, when to resolve vs. leave open), use the `address-pr-reviews` skill instead — it embeds these same commands in context.
+
+## Posting review comments
+
+- Reply to review comment: `gh api repos/owner/repo/pulls/123/comments/456/replies --method POST`
+- New review comment: `gh pr review 123 --comment --body "comment"`
+- Root PR comment (rarely appropriate): `gh issue comment 123 --body "comment"`
+
+## Resolving PR review threads
+
+Use `~/.dotfiles/bin/gh-resolve-threads` instead of hand-rolling a GraphQL mutation. Run with `--help` for options. Common forms:
+
+- `gh-resolve-threads <pr-url-or-number> --comment-id <id>` -- resolve the thread for a specific comment
+- `gh-resolve-threads <pr> --outdated` -- resolve only outdated threads
+- `gh-resolve-threads <pr> --dry-run` -- preview before resolving

--- a/ai/skills/posthog-context/SKILL.md
+++ b/ai/skills/posthog-context/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: posthog-context
+description: PostHog repo-specific workflow, database access rules, production architecture notes, and SDK repository locations. Use when working in posthog/posthog or any PostHog SDK repo.
+---
+
+# PostHog Context
+
+## posthog/posthog
+
+- Read README.md and `docs/FLOX_MULTI_INSTANCE_WORKFLOW.md`.
+- Prompt whether to create a new git worktree using the `phw` command.
+- On task completion, run: `mypy --version && mypy -p posthog | mypy-baseline filter || (echo "run 'pnpm run mypy-baseline-sync' to update the baseline" && exit 1)`
+
+## Database Access
+
+- **`posthog-db` MCP** is the **local dev database**. Use it for testing locally, inspecting schema, exploring relationships, and developing queries.
+- **Never use `posthog-db` to investigate production issues.** It does not have prod data.
+- **For prod investigations, use the `metabase-prod-query` skill.** It wraps `hogli metabase:*` with explicit per-query approval (required even in auto mode), region handling, and `--save` discipline. Never invoke the underlying `hogli metabase:*` commands directly. Go through the skill.
+
+## Production Architecture
+
+PostHog runs behind load balancers and proxies. Always consider this for IP addresses, rate limiting, authentication, and geolocation.
+
+- **AWS NLB** → **Contour/Envoy Ingress** → **Application Pods**
+- Contour: `num-trusted-hops: 1`; NLB: `preserve_client_ip.enabled=true`
+
+**Never use socket IP addresses** — they will be the load balancer's IP. Use `X-Forwarded-For` (primary), `X-Real-IP` (fallback), `Forwarded` (RFC 7239), socket IP (local dev only).
+
+Infrastructure repos:
+- `~/dev/posthog/posthog-cloud-infra` — Terraform/AWS (NLB, VPC)
+- `~/dev/posthog/charts` — Helm/K8s (Contour config, ingress rules, header policies)
+
+## PostHog SDK Repositories
+
+### Client-side
+
+| Repository | Local Path | GitHub URL |
+|------------|------------|------------|
+| posthog-js, posthog-rn | `~/dev/posthog/posthog-js` | https://github.com/PostHog/posthog-js |
+| posthog-ios | `~/dev/posthog/posthog-ios` | https://github.com/PostHog/posthog-ios |
+| posthog-android | `~/dev/posthog/posthog-android` | https://github.com/PostHog/posthog-android |
+| posthog-flutter | `~/dev/posthog/posthog-flutter` | https://github.com/PostHog/posthog-flutter |
+
+### Server-side
+
+| Repository | Local Path | GitHub URL |
+|------------|------------|------------|
+| posthog-python | `~/dev/posthog/posthog-python` | https://github.com/PostHog/posthog-python |
+| posthog-node | `~/dev/posthog/posthog-js` | https://github.com/PostHog/posthog-node |
+| posthog-php | `~/dev/posthog/posthog-php` | https://github.com/PostHog/posthog-php |
+| posthog-ruby | `~/dev/posthog/posthog-ruby` | https://github.com/PostHog/posthog-ruby |
+| posthog-go | `~/dev/posthog/posthog-go` | https://github.com/PostHog/posthog-go |
+| posthog-dotnet | `~/dev/posthog/posthog-dotnet` | https://github.com/PostHog/posthog-dotnet |
+| posthog-elixir | `~/dev/posthog/posthog-elixir` | https://github.com/PostHog/posthog-elixir |


### PR DESCRIPTION
Move the GitHub PR operations reference and PostHog specific workflow, database access, production architecture, and SDK repo notes out of the always loaded CLAUDE.md into two new skills, github-pr-operations and posthog-context. Safety critical rules (never post PR comments without approval, never use posthog-db against prod, never use socket IP addresses) stay in CLAUDE.md as standing one liners.

Remove the decommissioned posthog-remote MCP server from install.sh.

Update investigator.md to query PostHog product data via posthog-cli over Bash instead of the removed mcp__posthog-remote__exec tool.

## Test plan

- Ran `sh -n ai/install.sh` to confirm it still parses.
- Grepped the repo for posthog-remote to confirm no dangling references remain.
- Read the trimmed CLAUDE.md and the new skill files end to end to confirm nothing safety critical was silently dropped in the move.