### PR TITLE
Fix launchd status misreporting running jobs as failed

### DIFF
--- a/bin/lib/launchd-service.sh
+++ b/bin/lib/launchd-service.sh
@@ -147,10 +147,11 @@ cmd_status() {
   agent_line=$(launchctl list | grep "$SERVICE_LABEL" || true)
   if [[ -n "$agent_line" ]]; then
     echo -e "Agent:    ${GREEN}loaded${NC}"
-    local status
-    status=$(awk '{print $1}' <<<"$agent_line")
-    if [[ "$status" == "-" ]]; then
-      echo "Last run: never (or currently running)"
+    local pid status
+    pid=$(awk '{print $1}' <<<"$agent_line")
+    status=$(awk '{print $2}' <<<"$agent_line")
+    if [[ "$pid" != "-" ]]; then
+      echo "Last run: running (pid $pid)"
     elif [[ "$status" == "0" ]]; then
       echo -e "Last run: ${GREEN}success (exit 0)${NC}"
     else


### PR DESCRIPTION
`launchctl list` prints PID, LastExitStatus, and label as separate columns. `cmd_status()` in `bin/lib/launchd-service.sh` read the PID column and treated it as the exit status, so whenever the LaunchAgent happened to be mid-run, its own PID showed up as a bogus "failed (exit <PID>)" error.

- Reads pid and status from their correct columns now
- Detects "running" from a live PID instead of misreading it as a failure code

**Test plan**

- Ran `review-all-prs-service.sh status` while the review-all-prs LaunchAgent was actively running and confirmed it now reports "running (pid <pid>)" instead of a bogus failure
- Ran `bash -n bin/lib/launchd-service.sh` to check syntax