### PR TITLE
Widen nightly PR review to the flags team's whole queue

### DIFF
--- a/bin/review-all-prs-service.sh
+++ b/bin/review-all-prs-service.sh
@@ -19,7 +19,7 @@ source "${SCRIPT_DIR}/lib/launchd-service.sh"
 SERVICE_NAME="review-all-prs"
 WORKER="${SCRIPT_DIR}/run-pr-reviews.sh"
 # Keep in sync with the args in macos/LaunchAgents/com.haacked.review-all-prs.plist.
-WORKER_ARGS=(--auto --team team-feature-flags --priority-team team-feature-flags)
+WORKER_ARGS=(--auto --team team-feature-flags --priority-team team-feature-flags --all)
 SCHEDULE_DESC="hourly 6 PM-2 AM on weekdays, around the clock on weekends"
 
 # Today's review session counts, appended to `status`.

--- a/bin/review-all-prs.sh
+++ b/bin/review-all-prs.sh
@@ -24,9 +24,14 @@
 #
 # --all widens the default reviewer-requested list to the team's review queue.
 # With no --priority-team or --team it defaults to team-feature-flags, then
-# folds in: PRs you've already reviewed (implies --include-reviewed), PRs
-# requested from the team, and all open non-draft PRs authored by team members.
-# This is a deliberate superset for triage, not a mirror of any project board.
+# folds in: PRs requested from the team, and all open non-draft PRs authored
+# by team members. This is a deliberate superset for triage, not a mirror of
+# any project board. It does NOT imply --include-reviewed: PRs you've already
+# reviewed with no new commits since stay hidden unless you pass
+# --include-reviewed explicitly. That keeps --all safe to feed into automated
+# reviewing (run-pr-reviews.sh) without re-running full reviews on unchanged
+# PRs; pass --include-reviewed too when you want the interactive listing to
+# show already-settled PRs as well.
 #
 # By default, results are grouped by priority tier, then most recently updated
 # within each tier. An explicit --sort KEY orders the whole list by that key,
@@ -104,11 +109,13 @@ Options:
   --include-reviewed  Include PRs you've already reviewed
   --all               Widen the list to the team's whole review queue. Defaults
                       to ${DEFAULT_TEAM} when no --priority-team or --team is
-                      given. Implies --include-reviewed and
-                      adds, for those teams: PRs requested from the team and all
-                      open non-draft PRs authored by team members. Paginates so
-                      a busy team's queue isn't truncated at --limit. A triage
-                      superset, not a mirror of any project board.
+                      given. Adds, for those teams: PRs requested from the team
+                      and all open non-draft PRs authored by team members. Does
+                      NOT imply --include-reviewed; pass that too to also show
+                      PRs you've already reviewed with no new commits since.
+                      Paginates so a busy team's queue isn't truncated at
+                      --limit. A triage superset, not a mirror of any project
+                      board.
   --pending           List every PR where you have a pending (draft) review.
                       Uses involves:@me and paginates, so it finds drafts even
                       on PRs you weren't requested to review. Ignores --team.
@@ -215,7 +222,6 @@ while [[ $# -gt 0 ]]; do
       ;;
     --all)
       ALL=true
-      INCLUDE_REVIEWED=true
       shift
       ;;
     --pending|--draft)

--- a/bin/run-pr-reviews.sh
+++ b/bin/run-pr-reviews.sh
@@ -17,6 +17,9 @@
 #   --org ORG           GitHub org for --auto mode (default: PostHog)
 #   --team TEAM         Also find PRs requested from this team (repeatable)
 #   --priority-team TEAM  PRs authored by members of this team review first
+#   --all               Widen discovery to the team's whole review queue (see
+#                       review-all-prs.sh --all). Does not re-review PRs you've
+#                       already reviewed with no new commits since.
 #   -h, --help          Show this help message
 #
 # PRs are reviewed in priority order (see review-all-prs.sh): team-authored
@@ -68,6 +71,7 @@ AUTO_MODE=false
 ORG="PostHog"
 TEAMS=()
 PRIORITY_TEAM=""
+ALL=false
 # Set when a review fails because Claude itself is out of quota. Further
 # reviews in this session would fail the same way, so the main loop stops.
 RATE_LIMITED=false
@@ -93,6 +97,9 @@ Options:
   --org ORG           GitHub org for --auto mode (default: PostHog)
   --team TEAM         Also find PRs requested from this team (repeatable)
   --priority-team TEAM  PRs authored by members of this team review first
+  --all               Widen discovery to the team's whole review queue (see
+                      review-all-prs.sh --all). Does not re-review PRs
+                      you've already reviewed with no new commits since.
   -h, --help          Show this help message
 
 Output:
@@ -154,6 +161,10 @@ while [[ $# -gt 0 ]]; do
       fi
       PRIORITY_TEAM="$2"
       shift 2
+      ;;
+    --all)
+      ALL=true
+      shift
       ;;
     -h|--help)
       usage
@@ -360,6 +371,9 @@ get_pr_list() {
     done
     if [[ -n "$PRIORITY_TEAM" ]]; then
       team_args+=(--priority-team "$PRIORITY_TEAM")
+    fi
+    if [[ "$ALL" == "true" ]]; then
+      team_args+=(--all)
     fi
 
     # Fetch a deep candidate list; the review loop applies MAX_PRS to reviews

--- a/bin/run-pr-reviews.sh
+++ b/bin/run-pr-reviews.sh
@@ -770,8 +770,7 @@ main() {
   # Summarize from the in-memory session state: the on-disk SESSION_FILE
   # isn't written until the EXIT trap's save_session call, after this point.
   local final_reviewed final_failed
-  final_reviewed=$(echo "$SESSION" | jq '.reviewed | length')
-  final_failed=$(echo "$SESSION" | jq '.failed | length')
+  IFS=$'\t' read -r final_reviewed final_failed < <(echo "$SESSION" | jq -r '[(.reviewed | length), (.failed | length)] | @tsv')
   log_info "Total reviewed today: ${final_reviewed}"
   if [[ "$final_failed" -gt 0 ]]; then
     log_warn "Total failed today: ${final_failed}"

--- a/bin/run-pr-reviews.sh
+++ b/bin/run-pr-reviews.sh
@@ -753,15 +753,14 @@ main() {
   # Print summary
   log_section "Review Session Complete"
 
-  # Read final session state for summary
-  if [[ -f "$SESSION_FILE" ]]; then
-    local final_reviewed final_failed
-    final_reviewed=$(jq '.reviewed | length' < "$SESSION_FILE")
-    final_failed=$(jq '.failed | length' < "$SESSION_FILE")
-    log_info "Total reviewed today: ${final_reviewed}"
-    if [[ "$final_failed" -gt 0 ]]; then
-      log_warn "Total failed today: ${final_failed}"
-    fi
+  # Summarize from the in-memory session state: the on-disk SESSION_FILE
+  # isn't written until the EXIT trap's save_session call, after this point.
+  local final_reviewed final_failed
+  final_reviewed=$(echo "$SESSION" | jq '.reviewed | length')
+  final_failed=$(echo "$SESSION" | jq '.failed | length')
+  log_info "Total reviewed today: ${final_reviewed}"
+  if [[ "$final_failed" -gt 0 ]]; then
+    log_warn "Total failed today: ${final_failed}"
   fi
 
   log_info "Session state saved to: ${SESSION_FILE}"

--- a/macos/LaunchAgents/com.haacked.review-all-prs.plist
+++ b/macos/LaunchAgents/com.haacked.review-all-prs.plist
@@ -20,8 +20,11 @@ mkdir -p "$log_dir"
 
 # Run the review script with logging. No --max-prs cap: the session time
 # budget and Claude usage-limit detection decide when each tick stops.
+# --all widens discovery beyond review-requested PRs to every open PR
+# authored by a team-feature-flags member; it does not re-review PRs
+# already reviewed with no new commits since.
 exec "$HOME/.dotfiles/bin/run-pr-reviews.sh" --auto \
-    --team team-feature-flags --priority-team team-feature-flags \
+    --team team-feature-flags --priority-team team-feature-flags --all \
     >> "$log_dir/launchd.log" 2>&1
 ]]></string>
     </array>


### PR DESCRIPTION
- Add `--all` to the nightly automated review pipeline (`review-all-prs-service.sh` and the launchd plist) so it covers every open PR authored by a team-feature-flags member, not just PRs where the team or I were explicitly requested as reviewer.
- Decouple `--all` from `--include-reviewed` in `review-all-prs.sh`. The widened author query no longer resurfaces PRs already reviewed with no new commits since, so `--all` stays safe to run hourly without re-reviewing settled PRs.
- Fix the end-of-session summary in `run-pr-reviews.sh` reporting stale, often zero, counts. It read from the on-disk session file before the EXIT trap had written it; now it reads the in-memory session state, consolidated into a single jq call.

## Test plan
- Run `bin/review-all-prs.sh --all` and confirm PRs authored by team members without a review request appear, sorted into the top priority tier.
- Run `bin/review-all-prs.sh --all --include-reviewed` and confirm already-reviewed PRs with no new commits now show up too.
- Run `bin/run-pr-reviews.sh --auto --team team-feature-flags --priority-team team-feature-flags --all` and confirm the end-of-session summary shows correct reviewed/failed counts.