### PR TITLE
Post sprint status to #team-feature-flags on Fridays

### DIFF
--- a/bin/lib/claude-worker.sh
+++ b/bin/lib/claude-worker.sh
@@ -100,6 +100,38 @@ ${step}. Send ${content} as a Slack DM using
 EOF
 }
 
+# slack_channel_instructions <step-number> <content-description> <channel-id>
+# Emits the standard prompt step for posting the run's output directly to a
+# Slack channel: send via mcp__claude_ai_Slack__slack_send_message to
+# <channel-id>. Unlike slack_dm_instructions, the body carries no
+# resume-session footer — that's internal housekeeping that doesn't belong in
+# a message the whole channel sees. Reuses WORKER_DM_FAILED_SENTINEL: the
+# marker means "delivery failed," regardless of transport.
+slack_channel_instructions() {
+  local step="$1" content="$2" channel_id="$3"
+  cat <<EOF
+${step}. Post ${content} to Slack channel ${channel_id} using
+   mcp__claude_ai_Slack__slack_send_message (the channel_id argument is
+   ${channel_id}).
+
+   If the send fails, retry it inline a few times (up to 4 attempts total).
+   Do NOT start a background timer or wait for a completion notification to
+   fire a later retry: this is a non-interactive --print run with no further
+   turns, so nothing will ever wake you and the run would stall until it is
+   killed. Run the retries back to back, then stop.
+
+   If every attempt still fails (e.g. the Slack write path is down), give up
+   on delivery and, as the very LAST thing you output, print this marker on a
+   line by itself, exactly:
+
+     ${WORKER_DM_FAILED_SENTINEL}
+
+   then print the full message body you could not send, so it is captured in
+   the run log for recovery. Print the marker ONLY when the message was not
+   delivered; never print it after a successful send.
+EOF
+}
+
 # claude_worker_run <heartbeat-label> <prompt>
 # Runs claude headless with the standard guards and logs the outcome.
 # caffeinate -i blocks idle sleep so the timeout measures real wall-clock

--- a/bin/sprint-status-run
+++ b/bin/sprint-status-run
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-# sprint-status-run - Generate the Feature Flags sprint status and DM it.
+# sprint-status-run - Generate the Feature Flags sprint status and post it.
 #
 # Runs /sprint-planning --status in slack output mode (Slack markdown instead of
-# the rich-text clipboard; nobody is at the keyboard to paste) and DMs the
-# result to the recipient. The DM footer explains how to resume the session to
-# iterate.
+# the rich-text clipboard; nobody is at the keyboard to paste) and posts the
+# result directly to the #team-feature-flags channel — no draft/review step.
 #
 # Intended to be invoked by launchd (com.haacked.sprint-status.plist) or by
 # hand via bin/sprint-status-service.sh.
@@ -21,6 +20,9 @@ MAX_BUDGET_USD="${SPRINT_STATUS_MAX_BUDGET_USD:-5}"
 RUN_TIMEOUT_SECONDS="${SPRINT_STATUS_TIMEOUT_SECONDS:-900}"   # 15 min
 RUN_KILL_AFTER_SECONDS="${SPRINT_STATUS_KILL_AFTER_SECONDS:-60}"
 
+# #team-feature-flags: https://posthog.slack.com/archives/C07Q2U4BH4L
+SPRINT_STATUS_CHANNEL_ID="${SPRINT_STATUS_CHANNEL_ID:-C07Q2U4BH4L}"
+
 # Must match SERVICE_NAME in sprint-status-service.sh and log_dir in the plist;
 # the service's `logs` and `resume` commands read this state dir.
 claude_worker_init "sprint-status"
@@ -31,9 +33,10 @@ log_info "Budget cap:   \$${MAX_BUDGET_USD}"
 log_info "Working dir:  $WORKING_DIR"
 
 PROMPT=$(cat <<EOF
-You are generating the start-of-week sprint status for the PostHog Feature
-Flags team. This run was triggered by a launchd job. Your output goes to one
-Slack DM, not to the team channel.
+You are generating the end-of-week sprint status for the PostHog Feature
+Flags team. This run was triggered by a launchd job. Your output is posted
+directly to the #team-feature-flags Slack channel — no draft/review step, so
+get it right.
 
 Your session ID for this run is: ${SESSION_ID}
 
@@ -42,17 +45,17 @@ Do these steps in order.
 1. Invoke the /sprint-planning skill in status + slack output mode for the
    default Feature Flags team: "/sprint-planning --status slack"
 
-$(slack_dm_instructions 2 "the rendered sprint status from step 1" "To iterate on this status:")
+$(slack_channel_instructions 2 "the rendered sprint status from step 1, prefixed with a line noting it's an automated weekly update" "${SPRINT_STATUS_CHANNEL_ID}")
 
-3. After the DM is sent, print a one-line summary to stdout: sprint issue
-   number, members covered, done/total counts, and the DM channel ID.
+3. After the message is posted, print a one-line summary to stdout: sprint
+   issue number, members covered, done/total counts, and the channel ID.
 
 Hard constraints:
-- Do NOT post to any Slack channel. Only DM.
+- Do NOT DM anyone. Post only to #team-feature-flags (${SPRINT_STATUS_CHANNEL_ID}).
 - Do NOT post anything to GitHub.
 - Do NOT modify any files in the repo.
-- If a data-gathering step fails, still DM whatever partial status you have,
-  with a note about which step failed and why.
+- If a data-gathering step fails, still post whatever partial status you
+  have, with a note about which step failed and why.
 EOF
 )
 

--- a/bin/sprint-status-service.sh
+++ b/bin/sprint-status-service.sh
@@ -14,6 +14,6 @@ source "${SCRIPT_DIR}/lib/launchd-service.sh"
 
 SERVICE_NAME="sprint-status"
 WORKER="${SCRIPT_DIR}/sprint-status-run"
-SCHEDULE_DESC="Monday at 08:00 local time"
+SCHEDULE_DESC="Friday at 08:00 local time (PT), posted to #team-feature-flags"
 
 launchd_service_main "$@"

--- a/macos/LaunchAgents/com.haacked.sprint-status.plist
+++ b/macos/LaunchAgents/com.haacked.sprint-status.plist
@@ -21,15 +21,17 @@ exec "$HOME/.dotfiles/bin/sprint-status-run" >> "$log_dir/launchd.log" 2>&1
     </array>
 
     <!--
-        Fire Monday at 08:00 local time: start-of-sprint-week status check.
-        StartCalendarInterval uses the system's local time zone; Weekday
-        1=Monday.
+        Fire Friday at 08:00 local time, posted to #team-feature-flags as the
+        end-of-sprint-week status. StartCalendarInterval uses the system's
+        local time zone (America/Los_Angeles on this machine, i.e. PT);
+        Weekday 5=Friday. 15 min before standup's Friday 08:15 run so the two
+        headless Claude runs don't overlap.
     -->
     <key>StartCalendarInterval</key>
     <array>
         <dict>
             <key>Weekday</key>
-            <integer>1</integer>
+            <integer>5</integer>
             <key>Hour</key>
             <integer>8</integer>
             <key>Minute</key>


### PR DESCRIPTION
## Summary
- Move the sprint-status launchd job from Monday 8:00 AM to Friday 8:00 AM PT
- Post the generated status directly to #team-feature-flags instead of DMing it privately, with no draft/review step
- Add a slack_channel_instructions helper to claude-worker.sh for workers that post to a channel instead of DMing

## Test plan
- Reinstalled the LaunchAgent and confirmed launchctl list shows it loaded with the new Friday schedule
- Let the Friday run fire naturally and confirm the message lands in #team-feature-flags