### PR TITLE
Treat forwarded agents that loop back to Secretive as local

### DIFF
--- a/bin/lib/test-ssh-agent-sync.sh
+++ b/bin/lib/test-ssh-agent-sync.sh
@@ -4,7 +4,8 @@
 # Usage: test-ssh-agent-sync.sh
 #
 # Builds a throwaway HOME with fake Secretive/forwarded sockets (real
-# AF_UNIX binds, since -S only recognizes actual sockets) and exercises the
+# AF_UNIX binds, since -S only recognizes actual sockets; real ssh-agents
+# where the loop detection needs comparable key lists) and exercises the
 # script's healing and classification logic against it.
 
 set -euo pipefail
@@ -20,7 +21,15 @@ BIN="$(cd "$SCRIPT_DIR/.." && pwd)/ssh-agent-sync"
 # hardcoded Secretive container path can otherwise exceed macOS's ~104-byte
 # AF_UNIX path limit.
 FAKE_HOME=$(cd "$(mktemp -d /tmp/t.XXXXXX)" && pwd -P)
-trap 'rm -rf "$FAKE_HOME"' EXIT
+agent_pids=()
+cleanup() {
+  local pid
+  for pid in "${agent_pids[@]:-}"; do
+    [[ -n "$pid" ]] && kill "$pid" 2>/dev/null || true
+  done
+  rm -rf "$FAKE_HOME"
+}
+trap cleanup EXIT
 SECRETIVE="$FAKE_HOME/Library/Containers/com.maxgoedjen.Secretive.SecretAgent/Data/socket.ssh"
 SOCK="$FAKE_HOME/.ssh/agent.sock"
 
@@ -70,6 +79,50 @@ rm -rf "$FAKE_HOME/.ssh" "$FAKE_HOME/Library"
 out=$(HOME="$FAKE_HOME" "$BIN")
 assert "nothing present prints none" test "$out" = "none"
 assert "no symlink is created" test ! -e "$SOCK"
+
+# ── Test: forwarded socket that loops back to the local agent ───────────────
+# An `ssh macbook` run on the Mac itself forwards the Mac's own agent, so
+# the "forwarded" socket offers exactly the same keys as Secretive. It must
+# be classified as local, not adopted: adopting it would route signing
+# approvals to a machine nobody is sitting at. Real agents both loaded with
+# the same key stand in for the loop.
+
+mkdir -p "$(dirname "$SECRETIVE")"
+agent_pids+=("$(start_agent "$SECRETIVE")")
+ssh-keygen -q -t ed25519 -N '' -f "$FAKE_HOME/shared_key" -C shared
+SSH_AUTH_SOCK="$SECRETIVE" ssh-add "$FAKE_HOME/shared_key" >/dev/null 2>&1
+
+LOOPED="$FAKE_HOME/looped.sock"
+agent_pids+=("$(start_agent "$LOOPED")")
+SSH_AUTH_SOCK="$LOOPED" ssh-add "$FAKE_HOME/shared_key" >/dev/null 2>&1
+
+out=$(HOME="$FAKE_HOME" "$BIN" "$LOOPED")
+assert "looped forwarded arg prints local" test "$out" = "local"
+assert "looped forwarded arg leaves the symlink on Secretive" test "$SOCK" -ef "$SECRETIVE"
+
+# ── Test: forwarded agent with different keys is genuinely remote ────────────
+
+GENUINE="$FAKE_HOME/genuine.sock"
+agent_pids+=("$(start_agent "$GENUINE")")
+ssh-keygen -q -t ed25519 -N '' -f "$FAKE_HOME/remote_key" -C remote
+SSH_AUTH_SOCK="$GENUINE" ssh-add "$FAKE_HOME/remote_key" >/dev/null 2>&1
+
+out=$(HOME="$FAKE_HOME" "$BIN" "$GENUINE")
+assert "distinct-key forwarded arg prints forwarded" test "$out" = "forwarded"
+assert "symlink points at the genuine forwarded socket" test "$SOCK" -ef "$GENUINE"
+
+# ── Test: empty forwarded agent is still adopted ─────────────────────────────
+# A live forwarded agent with no identities yet offers nothing to compare
+# against Secretive, so it can't be proven a loop; adopting it preserves
+# the pre-loop-check behavior (git-signing-key falls back to the local key
+# when the agent turns out to be empty at sign time).
+
+EMPTY="$FAKE_HOME/empty.sock"
+agent_pids+=("$(start_agent "$EMPTY")")
+
+out=$(HOME="$FAKE_HOME" "$BIN" "$EMPTY")
+assert "empty forwarded arg prints forwarded" test "$out" = "forwarded"
+assert "symlink points at the empty forwarded socket" test "$SOCK" -ef "$EMPTY"
 
 # ── Results ──────────────────────────────────────────────────────────────────
 

--- a/bin/ssh-agent-sync
+++ b/bin/ssh-agent-sync
@@ -1,9 +1,17 @@
 #!/usr/bin/env bash
 # Points ~/.ssh/agent.sock at the right SSH agent socket: a live forwarded
 # agent when one is given and reachable, otherwise the local Secretive
-# agent. Safe to call repeatedly; only touches the symlink when it isn't
-# already pointing at the right target. Prints the resolved mode ("local",
-# "forwarded", or "none") so callers don't have to re-derive it themselves.
+# agent. A forwarded agent that offers exactly the local Secretive's keys
+# is a loop (an `ssh macbook` from the Mac to itself forwards the Mac's
+# own agent) and is treated as local: adopting it would route signing
+# approvals to a Touch ID prompt on a machine nobody is sitting at. Safe
+# to call repeatedly; only touches the symlink when it isn't already
+# pointing at the right target. The key-list comparison runs only while a
+# not-yet-adopted forwarded socket is offered; callers should stop passing
+# a socket once it resolves to "local" (zshrc's precmd hook does), since a
+# rejected or torn-down socket never becomes forwardable again. Prints the
+# resolved mode ("local", "forwarded", or "none") so callers don't have to
+# re-derive it themselves.
 #
 # Usage: ssh-agent-sync [forwarded-socket-path]
 
@@ -16,10 +24,22 @@ sock="$HOME/.ssh/agent.sock"
 secretive="$HOME/Library/Containers/com.maxgoedjen.Secretive.SecretAgent/Data/socket.ssh"
 forwarded="${1:-}"
 
+# Lists the keys an agent socket offers; empty when the agent is
+# unreachable or has none. Requiring a key-type prefix filters out
+# ssh-add's "The agent has no identities." sentence, which goes to stdout.
+agent_keys() {
+  SSH_AUTH_SOCK="$1" ssh-add -L 2>/dev/null | grep -E '^(ssh-|ecdsa-|sk-)' || true
+}
+
 [[ -d "$HOME/.ssh" ]] || mkdir -p -m 700 "$HOME/.ssh"
 
-if [[ -n "$forwarded" && -S "$forwarded" ]]; then
-  [[ "$sock" -ef "$forwarded" ]] || ln -sf "$forwarded" "$sock"
+if [[ -n "$forwarded" && -S "$forwarded" ]] && ! [[ "$sock" -ef "$forwarded" ]]; then
+  forwarded_keys=$(agent_keys "$forwarded")
+  if [[ -S "$secretive" && -n "$forwarded_keys" && "$forwarded_keys" == "$(agent_keys "$secretive")" ]]; then
+    [[ "$sock" -ef "$secretive" ]] || ln -sf "$secretive" "$sock"
+  else
+    ln -sf "$forwarded" "$sock"
+  fi
 elif [[ ! -S "$sock" ]] && [[ -S "$secretive" ]]; then
   ln -sf "$secretive" "$sock"
 fi

--- a/ssh/config
+++ b/ssh/config
@@ -3,6 +3,15 @@ Host github.com
 	ControlPath ~/.ssh/sockets/%r@%h-%p
 	ControlPersist 600
 
+# On the main Mac itself, a nested `ssh macbook` would forward the Mac's
+# own Secretive agent back to itself; ssh-agent-sync would then adopt that
+# looped socket and route signing approvals to a machine nobody is sitting
+# at. Self-hops get no agent forwarding. originalhost matches the alias as
+# typed, before HostName substitution; the exec test keeps this block inert
+# on the other machines that share these dotfiles.
+Match originalhost phils-macbook-pro,macbook exec "test $(hostname -s) = Phils-MacBook-Pro"
+	ForwardAgent no
+
 Host phils-macbook-pro macbook
 	HostName 100.119.94.39
 	ForwardAgent yes

--- a/zsh/zshrc.symlink
+++ b/zsh/zshrc.symlink
@@ -40,7 +40,13 @@ fi
 [[ -n "$SSH_CONNECTION" ]] && _SSH_FWD_SOCK="$SSH_AUTH_SOCK"
 
 _ssh_agent_sync() {
-  "$HOME/.dotfiles/bin/ssh-agent-sync" "$_SSH_FWD_SOCK" >/dev/null
+  local mode
+  mode=$("$HOME/.dotfiles/bin/ssh-agent-sync" "$_SSH_FWD_SOCK" 2>/dev/null) || mode=none
+  # A forwarded socket that resolves to local was either torn down or
+  # rejected as a loop back to Secretive (an `ssh macbook` from the Mac
+  # itself). Neither comes back, so stop offering it: later precmds take
+  # the cheap no-arg path instead of re-running the key-list comparison.
+  [[ -n "$_SSH_FWD_SOCK" && "$mode" == "local" ]] && _SSH_FWD_SOCK=""
   [[ -S "$HOME/.ssh/agent.sock" ]] && export SSH_AUTH_SOCK="$HOME/.ssh/agent.sock"
 }
 _ssh_agent_sync


### PR DESCRIPTION
## Problem

Running `ssh macbook` from the main Mac itself (easy to do by accident inside tmux, where every pane looks alike) creates a nested SSH session whose "forwarded" agent is a loop back to the Mac's own Secretive. The nested session's precmd adopts that looped socket into `~/.ssh/agent.sock`, so every signature request on the machine — including ones from genuine remote sessions — routes to a local Touch ID prompt nobody is present to approve. Remote commit signing appears to break intermittently, depending on which session most recently owned the symlink.

Diagnosed live: the symlink pointed at a nested self-SSH session's socket whose `ssh-add -L` output was byte-identical to the local Secretive's, while the genuine session from MacBook Neo (whose socket correctly offered the Neo's enclave key) sat unused.

## Fix

Two independent defenses:

1. **Don't create the loop** — `ssh/config` gains a `Match originalhost … exec` block that disables `ForwardAgent` for self-hops, gated on the local hostname so it stays inert on the other machines sharing these dotfiles. Verified with `ssh -G macbook`: `forwardagent no` on the main Mac, unchanged elsewhere.
2. **Don't adopt a loop** — `ssh-agent-sync` compares a new forwarded socket's key list against the local Secretive's before adopting it; an exact match is classified as `local`. This covers paths the config rule can't see (e.g. multi-hop: Mac → other host → `ssh macbook`). The comparison only runs when adopting a not-yet-linked socket, and the zshrc hook clears `_SSH_FWD_SOCK` once a forwarded socket resolves to `local`, so steady-state prompts stay on the cheap no-arg path.

## Testing

- New tests in `bin/lib/test-ssh-agent-sync.sh` using real ssh-agents: a looped agent (same key as the fake Secretive) is rejected, a distinct-key agent is adopted, and an empty agent is still adopted (it can't be proven a loop; `git-signing-key` already falls back at sign time).
- All three suites pass: 16 + 5 + 4 assertions, zero failures.
- Test cleanup now tolerates already-dead agents (`kill … || true` in the EXIT trap, which `set -e` would otherwise abort).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*