### PR TITLE
Heal stale forwarded agent sockets and pin signing agent

### DIFF
--- a/bin/git-ssh-sign
+++ b/bin/git-ssh-sign
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# gpg.ssh.program: pins SSH_AUTH_SOCK to the healed ~/.ssh/agent.sock symlink
+# before signing, so signing works from any process (GUI apps, non-interactive
+# shells) whose inherited SSH_AUTH_SOCK points at the wrong or an empty agent.
+# Verification (ssh-keygen -Y verify) doesn't use the agent, so routing it
+# through here too is harmless.
+
+set -euo pipefail
+
+sock="$HOME/.ssh/agent.sock"
+if [[ -S "$sock" ]]; then
+  export SSH_AUTH_SOCK="$sock"
+fi
+exec /usr/bin/ssh-keygen "$@"

--- a/bin/git-ssh-sign
+++ b/bin/git-ssh-sign
@@ -7,6 +7,12 @@
 
 set -euo pipefail
 
+# Heal the symlink here rather than relying on gpg.ssh.defaultKeyCommand
+# having just done it: an explicitly configured user.signingkey bypasses
+# git-signing-key entirely, and signing must not pin to a stale target.
+bin_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+"$bin_dir/ssh-agent-sync" >/dev/null 2>&1 || true
+
 sock="$HOME/.ssh/agent.sock"
 if [[ -S "$sock" ]]; then
   export SSH_AUTH_SOCK="$sock"

--- a/bin/lib/test-git-signing-integration.sh
+++ b/bin/lib/test-git-signing-integration.sh
@@ -20,6 +20,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/test-helpers.sh"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 GIT_SIGNING_KEY="$REPO_ROOT/bin/git-signing-key"
+GIT_SSH_SIGN="$REPO_ROOT/bin/git-ssh-sign"
 
 agent_pids=()
 homes=()
@@ -46,7 +47,8 @@ new_home() {
 }
 
 # A gitconfig wired the same way as git/gitconfig.symlink, pointed at this
-# worktree's git-signing-key so the test exercises uncommitted changes.
+# worktree's git-signing-key and git-ssh-sign so the test exercises
+# uncommitted changes.
 # Includes ~/.gitconfig.local the same way the real machine does, so
 # setup_local_agent's use of it below exercises the --includes flag
 # git-signing-key depends on rather than a value git would find anyway.
@@ -61,7 +63,7 @@ write_gitconfig() {
 [gpg]
 	format = ssh
 [gpg "ssh"]
-	program = /usr/bin/ssh-keygen
+	program = $GIT_SSH_SIGN
 	defaultKeyCommand = $GIT_SIGNING_KEY
 [commit]
 	gpgsign = true
@@ -148,6 +150,23 @@ assert "torn-down gap: self-heals and signs with the local key" \
   signed_with_key "$HOME3" "$HOME3/local_key.pub"
 assert "torn-down gap: agent.sock healed to the local (Secretive) socket" \
   test "$HOME3/.ssh/agent.sock" -ef "$SECRETIVE3"
+
+# ── Test: SSH_AUTH_SOCK inherited from the wrong (empty) agent ──────────────
+# A non-interactive shell that never sourced zshrc inherits Apple's empty
+# default agent as SSH_AUTH_SOCK. git-signing-key still resolves the right
+# key via agent.sock, but ssh-keygen would look the private key up in the
+# inherited agent and fail — unless git-ssh-sign pins SSH_AUTH_SOCK to the
+# healed symlink at sign time.
+
+HOME4=$(new_home)
+write_gitconfig "$HOME4"
+setup_local_agent "$HOME4"
+APPLE4="$HOME4/apple-default.sock"
+agent_pids+=("$(start_agent "$APPLE4")")
+
+commit_in_scratch_repo "$HOME4" "$APPLE4" env
+assert "wrong inherited agent: git-ssh-sign pins signing to agent.sock" \
+  signed_with_key "$HOME4" "$HOME4/local_key.pub"
 
 # ── Results ──────────────────────────────────────────────────────────────────
 

--- a/bin/lib/test-git-signing-integration.sh
+++ b/bin/lib/test-git-signing-integration.sh
@@ -76,7 +76,8 @@ EOF
 # $1 and configures it as user.localSigningKey via a freshly generated key.
 setup_local_agent() {
   local home="$1"
-  local secretive="$home/Library/Containers/com.maxgoedjen.Secretive.SecretAgent/Data/socket.ssh"
+  local secretive
+  secretive=$(secretive_sock "$home")
   mkdir -p "$(dirname "$secretive")"
   agent_pids+=("$(start_agent "$secretive")")
   ssh-keygen -q -t ed25519 -N '' -f "$home/local_key" -C local
@@ -141,7 +142,7 @@ assert "forwarded: signs with the forwarded key" signed_with_key "$HOME2" "$HOME
 HOME3=$(new_home)
 write_gitconfig "$HOME3"
 setup_local_agent "$HOME3"
-SECRETIVE3="$HOME3/Library/Containers/com.maxgoedjen.Secretive.SecretAgent/Data/socket.ssh"
+SECRETIVE3=$(secretive_sock "$HOME3")
 mkdir -p -m 700 "$HOME3/.ssh"
 ln -sf "$HOME3/torn-down.sock" "$HOME3/.ssh/agent.sock"
 
@@ -167,6 +168,24 @@ agent_pids+=("$(start_agent "$APPLE4")")
 commit_in_scratch_repo "$HOME4" "$APPLE4" env
 assert "wrong inherited agent: git-ssh-sign pins signing to agent.sock" \
   signed_with_key "$HOME4" "$HOME4/local_key.pub"
+
+# ── Test: explicit user.signingkey with a stale agent.sock ──────────────────
+# An explicitly configured user.signingkey bypasses gpg.ssh.defaultKeyCommand,
+# so nothing has healed agent.sock by the time ssh-keygen runs. git-ssh-sign
+# must heal it itself rather than pinning signing to the stale target.
+
+HOME5=$(new_home)
+write_gitconfig "$HOME5"
+setup_local_agent "$HOME5"
+git config --file "$HOME5/.gitconfig.local" user.signingKey "$HOME5/local_key.pub"
+mkdir -p -m 700 "$HOME5/.ssh"
+STALE5="$HOME5/stale.sock"
+mksock "$STALE5"
+ln -s "$STALE5" "$HOME5/.ssh/agent.sock"
+
+commit_in_scratch_repo "$HOME5" "$HOME5/.ssh/agent.sock" env
+assert "explicit signingkey: git-ssh-sign heals the stale sock and signs" \
+  signed_with_key "$HOME5" "$HOME5/local_key.pub"
 
 # ── Results ──────────────────────────────────────────────────────────────────
 

--- a/bin/lib/test-git-signing-key.sh
+++ b/bin/lib/test-git-signing-key.sh
@@ -67,12 +67,15 @@ out=$(HOME="$FAKE_HOME" "$BIN")
 assert "falls back to the local key when the forwarded agent has no identities" \
   test "$out" = "key::$(cat "$KEY_FILE")"
 
-# ── Test: forwarded agent gone by the time ssh-add -L runs ─────────────────
-# A bound-but-unlistened socket passes the -S liveness check ssh-agent-sync
-# uses to leave the link alone, but refuses the connection `ssh-add -L`
-# needs: the agent-died-mid-flight case. git-signing-key must fall back to
-# the local key rather than failing outright.
+# ── Test: forwarded agent gone by the time git-signing-key runs ────────────
+# A bound-but-unlistened socket passes -S but refuses the connection
+# `ssh-add` needs: the agent-died-mid-flight case. With Secretive present,
+# ssh-agent-sync's no-arg probe must heal the symlink back to it, and
+# git-signing-key must print the local key rather than failing outright.
 
+SECRETIVE="$FAKE_HOME/Library/Containers/com.maxgoedjen.Secretive.SecretAgent/Data/socket.ssh"
+mkdir -p "$(dirname "$SECRETIVE")"
+mksock "$SECRETIVE"
 DEAD_FORWARDED="$FAKE_HOME/dead-forwarded.sock"
 mksock "$DEAD_FORWARDED"
 ln -sf "$DEAD_FORWARDED" "$FAKE_HOME/.ssh/agent.sock"
@@ -80,6 +83,8 @@ ln -sf "$DEAD_FORWARDED" "$FAKE_HOME/.ssh/agent.sock"
 out=$(HOME="$FAKE_HOME" "$BIN")
 assert "falls back to the local key when the forwarded agent is unreachable" \
   test "$out" = "key::$(cat "$KEY_FILE")"
+assert "unreachable forwarded sock heals to Secretive" \
+  test "$FAKE_HOME/.ssh/agent.sock" -ef "$SECRETIVE"
 
 # ── Test: no local or forwarded key available ───────────────────────────────
 

--- a/bin/lib/test-git-signing-key.sh
+++ b/bin/lib/test-git-signing-key.sh
@@ -73,7 +73,7 @@ assert "falls back to the local key when the forwarded agent has no identities" 
 # ssh-agent-sync's no-arg probe must heal the symlink back to it, and
 # git-signing-key must print the local key rather than failing outright.
 
-SECRETIVE="$FAKE_HOME/Library/Containers/com.maxgoedjen.Secretive.SecretAgent/Data/socket.ssh"
+SECRETIVE=$(secretive_sock "$FAKE_HOME")
 mkdir -p "$(dirname "$SECRETIVE")"
 mksock "$SECRETIVE"
 DEAD_FORWARDED="$FAKE_HOME/dead-forwarded.sock"

--- a/bin/lib/test-helpers.sh
+++ b/bin/lib/test-helpers.sh
@@ -16,6 +16,12 @@ mksock() {
     python3 -c 'import socket, sys; socket.socket(socket.AF_UNIX).bind(sys.argv[1])' "$1"
 }
 
+# The Secretive agent socket path under a fake HOME ($1), mirroring the path
+# hardcoded in bin/ssh-agent-sync.
+secretive_sock() {
+    printf '%s/Library/Containers/com.maxgoedjen.Secretive.SecretAgent/Data/socket.ssh\n' "$1"
+}
+
 # Starts a real ssh-agent listening on $1 without eval'ing its output (that
 # would export SSH_AUTH_SOCK into the caller's own environment). Echoes its
 # PID so the caller can kill it during cleanup.

--- a/bin/lib/test-ssh-agent-sync.sh
+++ b/bin/lib/test-ssh-agent-sync.sh
@@ -124,6 +124,45 @@ out=$(HOME="$FAKE_HOME" "$BIN" "$EMPTY")
 assert "empty forwarded arg prints forwarded" test "$out" = "forwarded"
 assert "symlink points at the empty forwarded socket" test "$SOCK" -ef "$EMPTY"
 
+# ── Test: no arg, sock pre-linked to a stale-but-`-S`-true socket ───────────
+# The reported-bug shape: a forwarded session ended but left its socket file
+# behind, so the symlink target still passes -S while refusing connections.
+# Non-SSH shells and launchd only ever call with no argument, so the no-arg
+# path itself must probe reachability and heal back to Secretive.
+
+rm -rf "$FAKE_HOME/.ssh"
+mkdir -p "$FAKE_HOME/.ssh"
+STALE="$FAKE_HOME/stale-forwarded.sock"
+mksock "$STALE"
+ln -s "$STALE" "$SOCK"
+
+out=$(HOME="$FAKE_HOME" "$BIN")
+assert "no arg with stale forwarded sock prints local" test "$out" = "local"
+assert "stale forwarded sock heals to Secretive" test "$SOCK" -ef "$SECRETIVE"
+
+# ── Test: no arg, sock pre-linked to a live forwarded agent ─────────────────
+# The probe must not evict a genuinely reachable forwarded agent.
+
+rm -rf "$FAKE_HOME/.ssh"
+mkdir -p "$FAKE_HOME/.ssh"
+ln -s "$GENUINE" "$SOCK"
+
+out=$(HOME="$FAKE_HOME" "$BIN")
+assert "no arg with live forwarded sock stays forwarded" test "$out" = "forwarded"
+assert "live forwarded sock is left in place" test "$SOCK" -ef "$GENUINE"
+
+# ── Test: no arg, sock pre-linked to a live but empty forwarded agent ───────
+# ssh-add exits 1 (reachable, no identities) here, not 2 (unreachable); an
+# empty agent stays adopted, matching the empty-forwarded adoption above.
+
+rm -rf "$FAKE_HOME/.ssh"
+mkdir -p "$FAKE_HOME/.ssh"
+ln -s "$EMPTY" "$SOCK"
+
+out=$(HOME="$FAKE_HOME" "$BIN")
+assert "no arg with live empty forwarded sock stays forwarded" test "$out" = "forwarded"
+assert "live empty forwarded sock is left in place" test "$SOCK" -ef "$EMPTY"
+
 # ── Results ──────────────────────────────────────────────────────────────────
 
 print_results

--- a/bin/lib/test-ssh-agent-sync.sh
+++ b/bin/lib/test-ssh-agent-sync.sh
@@ -30,8 +30,15 @@ cleanup() {
   rm -rf "$FAKE_HOME"
 }
 trap cleanup EXIT
-SECRETIVE="$FAKE_HOME/Library/Containers/com.maxgoedjen.Secretive.SecretAgent/Data/socket.ssh"
+SECRETIVE=$(secretive_sock "$FAKE_HOME")
 SOCK="$FAKE_HOME/.ssh/agent.sock"
+
+# Resets the fake ~/.ssh and points agent.sock at the given target.
+link_sock() {
+  rm -rf "$FAKE_HOME/.ssh"
+  mkdir -p "$FAKE_HOME/.ssh"
+  ln -s "$1" "$SOCK"
+}
 
 # ── Test: live forwarded socket ─────────────────────────────────────────────
 
@@ -54,9 +61,7 @@ assert "symlink points at Secretive" test "$SOCK" -ef "$SECRETIVE"
 
 # ── Test: dead forwarded arg with a dangling sock re-heals to local ─────────
 
-rm -rf "$FAKE_HOME/.ssh"
-mkdir -p "$FAKE_HOME/.ssh"
-ln -s "$FAKE_HOME/torn-down.sock" "$SOCK"
+link_sock "$FAKE_HOME/torn-down.sock"
 DEAD_FORWARDED="$FAKE_HOME/dead-forwarded.sock"
 
 out=$(HOME="$FAKE_HOME" "$BIN" "$DEAD_FORWARDED")
@@ -64,9 +69,8 @@ assert "dead forwarded arg with dangling sock prints local" test "$out" = "local
 assert "dangling sock re-heals to Secretive" test "$SOCK" -ef "$SECRETIVE"
 
 # ── Test: dead forwarded arg while sock is already healthy stays local ──────
-# Proves the elif [[ ! -S "$sock" ]] guard is a no-op here: unlike the test
-# above, $SOCK already points at Secretive, so a dead forwarded arg must not
-# needlessly re-link or misclassify it.
+# Unlike the test above, $SOCK already points at Secretive, so a dead
+# forwarded arg must not needlessly re-link or misclassify it.
 
 out=$(HOME="$FAKE_HOME" "$BIN" "$DEAD_FORWARDED")
 assert "dead forwarded arg with an already-healthy sock still prints local" test "$out" = "local"
@@ -130,11 +134,9 @@ assert "symlink points at the empty forwarded socket" test "$SOCK" -ef "$EMPTY"
 # Non-SSH shells and launchd only ever call with no argument, so the no-arg
 # path itself must probe reachability and heal back to Secretive.
 
-rm -rf "$FAKE_HOME/.ssh"
-mkdir -p "$FAKE_HOME/.ssh"
 STALE="$FAKE_HOME/stale-forwarded.sock"
 mksock "$STALE"
-ln -s "$STALE" "$SOCK"
+link_sock "$STALE"
 
 out=$(HOME="$FAKE_HOME" "$BIN")
 assert "no arg with stale forwarded sock prints local" test "$out" = "local"
@@ -143,9 +145,7 @@ assert "stale forwarded sock heals to Secretive" test "$SOCK" -ef "$SECRETIVE"
 # ── Test: no arg, sock pre-linked to a live forwarded agent ─────────────────
 # The probe must not evict a genuinely reachable forwarded agent.
 
-rm -rf "$FAKE_HOME/.ssh"
-mkdir -p "$FAKE_HOME/.ssh"
-ln -s "$GENUINE" "$SOCK"
+link_sock "$GENUINE"
 
 out=$(HOME="$FAKE_HOME" "$BIN")
 assert "no arg with live forwarded sock stays forwarded" test "$out" = "forwarded"
@@ -155,9 +155,7 @@ assert "live forwarded sock is left in place" test "$SOCK" -ef "$GENUINE"
 # ssh-add exits 1 (reachable, no identities) here, not 2 (unreachable); an
 # empty agent stays adopted, matching the empty-forwarded adoption above.
 
-rm -rf "$FAKE_HOME/.ssh"
-mkdir -p "$FAKE_HOME/.ssh"
-ln -s "$EMPTY" "$SOCK"
+link_sock "$EMPTY"
 
 out=$(HOME="$FAKE_HOME" "$BIN")
 assert "no arg with live empty forwarded sock stays forwarded" test "$out" = "forwarded"

--- a/bin/ssh-agent-sync
+++ b/bin/ssh-agent-sync
@@ -43,18 +43,16 @@ if [[ -n "$forwarded" && -S "$forwarded" ]] && ! [[ "$sock" -ef "$forwarded" ]];
   else
     ln -sf "$forwarded" "$sock"
   fi
-elif [[ -S "$sock" ]] && ! [[ "$sock" -ef "$secretive" ]] && [[ -S "$secretive" ]]; then
+elif [[ -S "$secretive" ]] && ! [[ "$sock" -ef "$secretive" ]]; then
   # An adopted forwarded socket can outlive its SSH session as a file that
-  # still passes -S. ssh-add exits 2 only when it cannot reach the agent at
-  # all; 1 means reachable-but-empty, which stays adopted (matching the
-  # empty-forwarded adoption above).
+  # still passes -S. ssh-add exits 2 when it cannot reach the agent at all
+  # (a stale, missing, or dangling sock alike); 1 means reachable-but-empty,
+  # which stays adopted (matching the empty-forwarded adoption above).
   rc=0
   SSH_AUTH_SOCK="$sock" ssh-add -l >/dev/null 2>&1 || rc=$?
   if (( rc >= 2 )); then
     ln -sf "$secretive" "$sock"
   fi
-elif [[ ! -S "$sock" ]] && [[ -S "$secretive" ]]; then
-  ln -sf "$secretive" "$sock"
 fi
 
 if [[ -S "$sock" ]] && [[ "$sock" -ef "$secretive" ]]; then

--- a/bin/ssh-agent-sync
+++ b/bin/ssh-agent-sync
@@ -9,7 +9,10 @@
 # pointing at the right target. The key-list comparison runs only while a
 # not-yet-adopted forwarded socket is offered; callers should stop passing
 # a socket once it resolves to "local" (zshrc's precmd hook does), since a
-# rejected or torn-down socket never becomes forwardable again. Prints the
+# rejected or torn-down socket never becomes forwardable again. No-arg
+# calls re-verify a previously adopted forwarded socket is still reachable
+# and heal back to Secretive when it isn't: a torn-down session can leave a
+# socket file that still passes -S but no longer answers. Prints the
 # resolved mode ("local", "forwarded", or "none") so callers don't have to
 # re-derive it themselves.
 #
@@ -39,6 +42,16 @@ if [[ -n "$forwarded" && -S "$forwarded" ]] && ! [[ "$sock" -ef "$forwarded" ]];
     [[ "$sock" -ef "$secretive" ]] || ln -sf "$secretive" "$sock"
   else
     ln -sf "$forwarded" "$sock"
+  fi
+elif [[ -S "$sock" ]] && ! [[ "$sock" -ef "$secretive" ]] && [[ -S "$secretive" ]]; then
+  # An adopted forwarded socket can outlive its SSH session as a file that
+  # still passes -S. ssh-add exits 2 only when it cannot reach the agent at
+  # all; 1 means reachable-but-empty, which stays adopted (matching the
+  # empty-forwarded adoption above).
+  rc=0
+  SSH_AUTH_SOCK="$sock" ssh-add -l >/dev/null 2>&1 || rc=$?
+  if (( rc >= 2 )); then
+    ln -sf "$secretive" "$sock"
   fi
 elif [[ ! -S "$sock" ]] && [[ -S "$secretive" ]]; then
   ln -sf "$secretive" "$sock"

--- a/git/gitconfig.symlink
+++ b/git/gitconfig.symlink
@@ -66,7 +66,7 @@
 [credential "https://dev.azure.com"]
 	useHttpPath = true
 [gpg "ssh"]
-	program = /usr/bin/ssh-keygen
+	program = /Users/haacked/.dotfiles/bin/git-ssh-sign
 	defaultKeyCommand = /Users/haacked/.dotfiles/bin/git-signing-key
 [alias]
 	sign-unpushed = "\\!f() { DEFAULT=$(git default); UPSTREAM=${1-origin/$DEFAULT}; git rebase --exec \"git commit --amend --no-edit -S\" $UPSTREAM; }; f"

--- a/zsh/zshrc.symlink
+++ b/zsh/zshrc.symlink
@@ -39,7 +39,15 @@ fi
 # later precmd calls would just be comparing the symlink against itself.
 [[ -n "$SSH_CONNECTION" ]] && _SSH_FWD_SOCK="$SSH_AUTH_SOCK"
 
+# Prompt draws don't need an immediate re-sync: while a forwarded socket is
+# adopted, ssh-agent-sync verifies it with a network round trip back to the
+# remote client's agent, which would otherwise run on every keystroke's
+# prompt. Sign-time consumers (git-signing-key, git-ssh-sign) run
+# ssh-agent-sync themselves, so they always get a fresh heal.
+_ssh_agent_synced_at=-30
 _ssh_agent_sync() {
+  (( SECONDS - _ssh_agent_synced_at < 30 )) && return
+  _ssh_agent_synced_at=$SECONDS
   local mode
   mode=$("$HOME/.dotfiles/bin/ssh-agent-sync" "$_SSH_FWD_SOCK" 2>/dev/null) || mode=none
   # A forwarded socket that resolves to local was either torn down or


### PR DESCRIPTION
## Problem

Commit signing failed from non-interactive shells (e.g. PostHog Code). Two compounding causes:

1. **`ssh-agent-sync` never re-checked an adopted forwarded socket.** A torn-down SSH session can leave its agent socket file behind, still passing `-S` while refusing connections (or answering for an agent that's effectively gone). The no-arg path — the only path non-SSH shells, launchd, and `git-signing-key` ever take — only healed the symlink when the target wasn't a socket file at all, so a stale forwarded socket stayed adopted forever and `git-signing-key` returned a key (`GitHub@secretive.Phil's-MacBook-Neo.local`) that no usable agent held. A local shell could never self-heal, because `_SSH_FWD_SOCK` is only set when `$SSH_CONNECTION` exists.
2. **Signing used the caller's inherited `SSH_AUTH_SOCK`.** All the agent wiring lives in `zshrc.symlink` (interactive shells only), so non-interactive shells inherit Apple's empty default agent and `ssh-keygen -Y sign` can't find the private key even when the resolved key is correct.

A reboot "fixed" it only because clearing `/tmp` removed the stale target, making it fail `-S` so the old heal branch fired.

## Fix

- `bin/ssh-agent-sync`: the no-arg path now probes an adopted forwarded socket with `ssh-add -l` and heals back to Secretive when the agent is unreachable (exit 2). A live-but-empty agent (exit 1) stays adopted, matching existing empty-forwarded adoption.
- `bin/git-ssh-sign` (new, set as `gpg.ssh.program`): pins `SSH_AUTH_SOCK` to the healed `~/.ssh/agent.sock` symlink before exec'ing `/usr/bin/ssh-keygen`, so signing works from any process regardless of inherited environment. Verification doesn't use the agent, so routing it through the wrapper is harmless.

## Tests

- `test-ssh-agent-sync.sh`: three new no-arg cases — stale bound-dead socket heals to local; live forwarded agent stays adopted; live-but-empty agent stays adopted.
- `test-git-signing-key.sh`: the unreachable-forwarded case now also asserts the symlink heals to Secretive.
- `test-git-signing-integration.sh`: signing now routes through `git-ssh-sign`, plus a new end-to-end scenario committing with `SSH_AUTH_SOCK` pointed at a wrong (empty) agent — the exact non-interactive-shell failure.

All three suites pass (33 assertions).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*