### PR TITLE
Align skills with Claude 5 context-engineering guidance

### DIFF
--- a/ai/skills/address-pr-reviews/SKILL.md
+++ b/ai/skills/address-pr-reviews/SKILL.md
@@ -99,20 +99,12 @@ With user confirmation:
 **For not-legit comments, branch on who authored the comment:**
 
 - **Bots (`is_bot` true — Copilot, ReviewHog, Greptile, Graphite, or any other GitHub App):** Draft a concise, professional reply explaining why the code is correct, show the draft to the user and wait for explicit approval, then post it: `gh api "repos/<repo>/pulls/<pr_number>/comments/<comment_id>/replies" --method POST -f body='<reply>'`. Resolve the thread: `~/.dotfiles/bin/gh-resolve-threads "https://github.com/<repo>/pull/<pr_number>" --comment-id <comment_id>`.
-- **Human reviewers (`is_bot` false):** Do **not** post anything. Draft the reply and hold it for the user to review and post themselves (see Step 5). Leave the thread unresolved so the reviewer gets the last word.
-
-Never auto-post a reply to a human reviewer. The user reviews and posts those replies.
+- **Human reviewers (`is_bot` false):** Never post anything. Draft the reply and hold it for the user to review and post themselves (see Step 5). Leave the thread unresolved so the reviewer gets the last word.
 
 ### Step 5: Finalize
 
 1. Show a summary: N comments fixed, M comments dismissed
-2. **Present drafted replies to human reviewers for the user to post.** For each not-legit comment from a human reviewer, show the file:line, the comment quote, and your drafted reply. Write each reply to a file so it survives quotes and newlines, then give the user the exact command to post it:
-
-   ```bash
-   gh api "repos/<repo>/pulls/<pr_number>/comments/<comment_id>/replies" --method POST -F body=@<reply-file>
-   ```
-
-   The user reviews each reply and posts the ones they approve. Do not post them yourself.
+2. **Present drafted replies to human reviewers for the user to post.** For each not-legit comment from a human reviewer, show the file:line, the comment quote, and your drafted reply. Write each reply to a file so it survives quotes and newlines, then give the user the exact command to post it — the same replies endpoint as Step 4, with `-F body=@<reply-file>` in place of `-f body=`. The user reviews each reply and posts the ones they approve.
 3. If any files were changed, ask the user if they want to commit and push:
    - Commit message: "Address PR review feedback"
    - Push to the current branch

--- a/ai/skills/analyze-permissions/SKILL.md
+++ b/ai/skills/analyze-permissions/SKILL.md
@@ -50,8 +50,9 @@ For each entry in `settings.local.json`:
 
 4. **Assess safety** - Consider if the pattern is safe for auto-approval:
    - Read-only commands: Generally safe
-   - Commands with side effects: Flag for review
+   - Commands with side effects: Flag for review; consider keeping them per-project in local settings (e.g. `git push` for a personal repo)
    - Overly broad patterns: Warn about security implications
+   - Never suggest auto-approving `sudo`, permission-loosening patterns like `chmod 777`, or anything that could expose credentials or secrets
 
 ### Step 3: Present Analysis
 
@@ -114,32 +115,3 @@ When adding patterns to `configure-tool-permissions.sh`:
 4. Run cleanup to remove now-redundant entries from the current project's local settings: `~/.dotfiles/ai/skills/analyze-permissions/scripts/cleanup-settings-local.sh`
 
 **Important**: The configure script *merges* new entries into `settings.json` but never removes existing ones. This means `settings.json` also accumulates "don't ask again" entries over time. The cleanup script only cleans `settings.local.json`. To fully clean `settings.json`, you'd need to manually remove redundant entries or rebuild it from the script.
-
-## Pattern Safety Guidelines
-
-**Safe to auto-approve (commonly needed):**
-
-- `Bash(npx:*)`, `Bash(node:*)`, `Bash(npm:*)`, `Bash(pnpm:*)` - JS/Node tooling
-- `Bash(python:*)`, `Bash(python3:*)`, `Bash(pip:*)` - Python tooling
-- `Bash(cargo :*)`, `Bash(cd :* && cargo:*)` - Rust tooling
-- `Bash(docker compose:*)`, `Bash(docker ps:*)` - Docker
-- `Bash(kubectl get:*)`, `Bash(kubectl describe:*)` - K8s read operations
-- `Bash(git:*)` subcommands (add, commit, log, diff, etc.)
-- `Bash(gh:*)` read operations (pr view, issue list, api, etc.)
-- `Bash(chmod:*)`, `Bash(ln:*)`, `Bash(wc:*)`, `Bash(which:*)` - basic utilities
-- `Bash(ssh:*)`, `Bash(tmux:*)`, `Bash(bash:*)`, `Bash(zsh:*)` - shell/system
-- `WebFetch(domain:*)`, `WebSearch` - web access
-
-**Require review (side effects):**
-
-- `Bash(kubectl delete:*)`, `Bash(kubectl apply:*)`
-- `Bash(docker rm:*)`, `Bash(docker exec:*)`
-- `Bash(aws s3 rm:*)`
-- `Bash(rm:*)`, `Bash(mv:*)`
-- `Bash(git push:*)` - consider keeping per-project in local settings
-
-**Never auto-approve:**
-
-- `Bash(sudo:*)`
-- `Bash(chmod 777:*)`
-- Patterns that could leak secrets

--- a/ai/skills/ci-monitor/SKILL.md
+++ b/ai/skills/ci-monitor/SKILL.md
@@ -31,8 +31,6 @@ Monitor GitHub CI checks for the current PR, wait for completion, classify failu
 
 ## Implementation
 
-**CRITICAL:** Follow these steps in order. If any step fails, inform the user and stop.
-
 ### Step 1: Parse Arguments
 
 Extract the PR identifier and flags from `$ARGUMENTS`.

--- a/ai/skills/commit/SKILL.md
+++ b/ai/skills/commit/SKILL.md
@@ -41,7 +41,7 @@ If `git status` shows a clean working tree with nothing staged, tell the user th
 
 **Format:**
 
-```
+```text
 <imperative subject line, ≤72 characters>
 
 [optional body — include only when the subject alone does not tell a reader
@@ -52,15 +52,8 @@ If `git status` shows a clean working tree with nothing staged, tell the user th
 
 **Subject line rules:**
 
-- Start with an imperative verb: "Add", "Fix", "Remove", "Update", "Refactor", etc.
-- No period at the end
-- Describe the final state — what the code does now, not what it replaced
+- Follow the commit-message conventions in CLAUDE.md (imperative verb, final state not the journey, no AI attribution); no period at the end
 - If `message_hint` is non-empty, use it verbatim as the subject line (trim whitespace; do not rephrase)
-
-**Attribution rules (non-negotiable):**
-
-- Never mention AI, Claude, or LLMs anywhere in the message
-- Never add co-authorship lines
 
 ### 3. Show Preview and Confirm
 
@@ -68,7 +61,7 @@ If `force` is true, skip to Step 4 immediately — do not show a preview or ask 
 
 Otherwise, display the proposed commit exactly as shown below, then stop and wait for the user to reply:
 
-```
+```text
 Files to commit:
   staged:    <list, or "(none)">
   unstaged:  <list, or "(none)">

--- a/ai/skills/create-pr/SKILL.md
+++ b/ai/skills/create-pr/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: create-pr
-description: Create or update a GitHub PR with automatic template detection and filling
+description: Create or update a GitHub PR with automatic template detection and filling, enforcing a plain staff-engineer writing voice in the PR body
 argument-hint: "[--ready] [--force] [<title>]"
 model: sonnet
 ---
@@ -21,13 +21,11 @@ Three things immediately signal AI authorship. Never produce any of them:
 
 For everything else: plain verbs ("is" not "serves as"), Sentence case headings, short paragraphs. No inflation words (critical, pivotal, robust, seamless, leverage, utilize, ensure, facilitate). No hedging meta-commentary ("I'm an agent", "I have not verified"). No closers. No emoji.
 
-How it sounds:
+How it sounds (cause and effect in one sentence, caveats as plain declarative sentences with no label):
 
 > The workflow calls `getMembershipForUserInOrg()` with the default `GITHUB_TOKEN`, which only has repo scope and can't read org-private team memberships. The API returns `404` (not `403`) when it can't see the membership, producing the misleading error.
 >
 > If the app doesn't have Organization > Members > Read permission, the same error will recur.
-
-Notice two things about that example: the cause and effect are in one sentence connected by a comma, and the caveat is a plain declarative sentence with no label.
 
 ## Arguments
 
@@ -181,7 +179,7 @@ Notes:
 
 ### 6. Verify voice before preview
 
-Read the composed body once. If any sentence contains an em dash, bold text outside a line-start label, or a bolded pseudo-label, rewrite that sentence now. Then ask yourself: would a staff engineer write this sentence verbatim in a Slack message to a teammate? If not, simplify it.
+Re-read the composed body against the Writing voice rules and rewrite any violating sentence. Then ask yourself: would a staff engineer write this sentence verbatim in a Slack message to a teammate? If not, simplify it.
 
 ### 7. Show Preview and Confirm
 

--- a/ai/skills/explain-open/SKILL.md
+++ b/ai/skills/explain-open/SKILL.md
@@ -16,13 +16,6 @@ Code reviews leave two kinds of loose ends: items explicitly flagged as open que
 - `<branch>` — look up that branch's review artifacts.
 - `<file>` — read a specific review file directly (e.g. a saved `/review-code` output or `.notes/review-skipped.md`).
 
-Example invocations:
-
-- `/explain-open` — explain the open/skipped items from the review just discussed
-- `/explain-open 456` — explain open/skipped items for PR #456
-- `/explain-open feature-branch` — explain open/skipped items for that branch's review
-- `/explain-open .notes/review-skipped.md` — explain items from a specific file
-
 ## Step 1: Gather the Open and Skipped Items
 
 ### If no argument was given
@@ -110,10 +103,8 @@ Group items under two headings, each numbered from 1. Omit a heading entirely if
 
 Guidelines:
 
-- Write "What it means" for a reader without the diff in front of them. Translate the technical finding; don't restate it.
 - Make both impact lines concrete, not generic — "could cause a subtle bug under concurrent writes" beats "could be risky." If a side genuinely has no downside, say so plainly instead of padding it.
 - Default to a real recommendation. Use "Your call" only when the tradeoff is genuinely balanced (e.g., two valid style preferences, unclear product intent), and say why it's a toss-up.
-- Keep each block tight: a few sentences total, not a wall of text.
 
 ## Step 3: Summarize
 

--- a/ai/skills/handoff/SKILL.md
+++ b/ai/skills/handoff/SKILL.md
@@ -64,8 +64,7 @@ Then stop. Do not write a placeholder handoff.
 Do not write the handoff from memory of the conversation. Memory produces narrative; state produces handoffs. Before filling any section, gather concrete state:
 
 - Run `git diff HEAD --stat` and `git status` to get an overview of what changed.
-- For files central to the handoff, read them directly with the Read tool (or run `git diff HEAD -- <path>` for a focused diff). Do not load the full unbounded diff.
-- Read the files you've been working in (don't trust your recall of their current contents).
+- Read the files central to the handoff directly with the Read tool (or run `git diff HEAD -- <path>` for a focused diff); don't trust your recall of their current contents, and don't load the full unbounded diff.
 - Re-run failing tests or commands you've mentioned, so the verification section reflects reality.
 
 Then capture the git snapshot for embedding:
@@ -78,7 +77,7 @@ This emits a markdown block with branch, HEAD, upstream, and the dirty working t
 
 ### Step 4: Fill the template
 
-Start from `~/.claude/skills/handoff/templates/handoff.md`. Fill every section from the state you just gathered, not from conversation memory. Optimize for *the next Claude session* specifically:
+Start from `~/.claude/skills/handoff/templates/handoff.md`. Fill every section from the state you just gathered. Optimize for *the next Claude session* specifically:
 
 - **Pointers over prose.** Cite `file.ts:42` instead of paraphrasing code. The next session can read.
 - **Decisions over events.** Don't narrate the session ("first I tried X, then Y"). Record outcomes: what we chose, why, what was ruled out.

--- a/ai/skills/metabase-prod-query/SKILL.md
+++ b/ai/skills/metabase-prod-query/SKILL.md
@@ -78,7 +78,7 @@ For ClickHouse-flavored questions, use ClickHouse SQL (no `interval '1 day'` Pos
 
 Display to the user, exactly:
 
-```
+```text
 Region:      <us|eu|both>
 Database:    <name> (id <N>)
 Save to:     /tmp/metabase-<slug>-<region>.<tsv|json>
@@ -120,8 +120,6 @@ Report to the user:
 - Row count
 - Top N rows (or summary stats — sums, distributions — depending on the question)
 - Anomalies worth flagging
-
-Do not paste the full result file into the chat unless the user asks for it.
 
 ### 8. Clean up (optional)
 

--- a/ai/skills/ops-report/SKILL.md
+++ b/ai/skills/ops-report/SKILL.md
@@ -31,7 +31,7 @@ Example invocations:
 | us | `mcp__grafana__*` | `grafana.prod-us.posthog.dev` |
 | eu | `mcp__grafana-eu__*` | `grafana.prod-eu.posthog.dev` |
 
-When `--region both` (the default), run all data-gathering steps in parallel for both regions. Tag every metric, anomaly, and dashboard link with its region (`[US]` / `[EU]`) throughout.
+**Regional parallelism:** wherever a step says "for each active region", fire the region-specific MCP calls in parallel. Query examples in this skill show the US form only; for EU, use the `mcp__grafana-eu__*` equivalent with the EU datasource UID. Tag every metric, anomaly, and dashboard link with its region (`[US]` / `[EU]`) throughout.
 
 ## Your Task
 
@@ -92,11 +92,10 @@ Store the output plus one as `{token_baseline_line}` (i.e., `line_count + 1`) so
 
 ### Step 2: Discover Dashboards
 
-Search Grafana for dashboards related to the service. For each active region, run in parallel:
+Search Grafana for dashboards related to the service, for each active region:
 
 ```text
-mcp__grafana__search_dashboards(query="{service}")        # prod-us
-mcp__grafana-eu__search_dashboards(query="{service}")     # prod-eu
+mcp__grafana__search_dashboards(query="{service}")
 ```
 
 Filter results to dashboards tagged with the service name or whose title contains the service name. Record each dashboard's UID, title, description, and region. Dashboard UIDs are often the same across regions; query both independently.
@@ -105,18 +104,11 @@ If no dashboards are found in either region, tell the user and stop.
 
 ### Step 3: Discover Datasources
 
-For each active region, run in parallel:
+For each active region, discover the Prometheus datasources and the Loki datasources (needed for log queries in Step 8):
 
 ```text
-mcp__grafana__list_datasources(type="prometheus")        # prod-us
-mcp__grafana-eu__list_datasources(type="prometheus")     # prod-eu
-```
-
-Also discover the Loki datasources for each region (needed for log queries in Step 8):
-
-```text
-mcp__grafana__list_datasources(type="loki")        # prod-us
-mcp__grafana-eu__list_datasources(type="loki")     # prod-eu
+mcp__grafana__list_datasources(type="prometheus")
+mcp__grafana__list_datasources(type="loki")
 ```
 
 For each region, use the datasource named "VictoriaMetrics" (or the default Prometheus datasource). Record each region's Prometheus UID and Loki UID separately. Do not hardcode UIDs; discover them here.
@@ -125,11 +117,10 @@ The US Loki datasource is typically named `Loki-logs` (uid `P44D702D3E93867EC`),
 
 ### Step 4: Extract Key Queries from Dashboards
 
-For the most important dashboards (the "general" or overview dashboard first, then latency, cache, and pods dashboards), extract panel queries from each active region in parallel:
+For the most important dashboards (the "general" or overview dashboard first, then latency, cache, and pods dashboards), extract panel queries for each active region:
 
 ```text
-mcp__grafana__get_dashboard_panel_queries(uid="{dashboard_uid}")        # prod-us
-mcp__grafana-eu__get_dashboard_panel_queries(uid="{dashboard_uid}")     # prod-eu
+mcp__grafana__get_dashboard_panel_queries(uid="{dashboard_uid}")
 ```
 
 If dashboards share the same UID across regions, the panel structure will be identical, so you only need to extract queries once and reuse them for both regions' metric queries in Step 5.
@@ -146,245 +137,18 @@ Identify the key metrics to query. Prioritize these categories:
 
 ### Step 5: Query Metrics
 
-Run PromQL queries against each active region's Prometheus datasource. Use range queries with the step size from the window table above:
+Run PromQL range queries against each active region's Prometheus datasource, storing results separately per region so they can be compared in the report:
 
 - Use the absolute `{window_start}` and `{window_end}` timestamps computed in Step 1 as the query `startTime`/`endTime` parameters, never `now-{hours}h` or `now`
 - Step size: use the value from the window mapping (300s for day, 1800s for week, 7200s for month)
 
 **Note:** The ban on relative expressions applies to the query's `startTime`/`endTime` parameters. PromQL duration expressions *inside* the query (range selectors like `[5m]`, `[{window_hours}h]`, and subquery windows) remain as durations. These are lookback windows within PromQL, not the time range of the query itself.
 
-For `region=both`, fire all queries for US and EU in parallel using their respective MCP servers and datasource UIDs:
-
-```text
-mcp__grafana__query_prometheus(datasourceUid="{us_prom_uid}", ...)      # prod-us
-mcp__grafana-eu__query_prometheus(datasourceUid="{eu_prom_uid}", ...)   # prod-eu
-```
-
-Store results separately per region so they can be compared in the report.
-
 **Important:** Replace any `$__rate_interval` or `$__interval` template variables with appropriate values. For `day` use `5m`/`1m`, for `week` use `30m`/`5m`, for `month` use `2h`/`30m`.
 
 ### Step 5b: Service-Specific Capacity Checks
 
-For certain services, query additional capacity metrics that indicate approaching limits. Run all queries for both regions in parallel using each region's respective MCP server and datasource UID.
-
-#### Feature Flags
-
-Query the number of feature flags per team to identify teams nearing the maximum allowed count. Look for relevant metrics or dashboard panels that track:
-
-- Total flag count per team/organization
-- Teams approaching the configured maximum (e.g., >80% of the limit)
-- Recent growth rate in flag creation
-
-If a direct metric isn't available, check whether the dashboard panels show this data and note any teams that appear to be nearing capacity. Flag this as an action item if any team is above 80% of the maximum.
-
-#### Scheduled Task Performance
-
-Query scheduled Celery task duration and verification fix counts from the cache dashboard. These tasks run periodically to maintain cache consistency.
-
-**Task duration** (average per run, sampled over the window):
-
-```promql
-increase(posthog_celery_task_duration_seconds_sum{task_name=~"posthog\\.tasks\\.hypercache_verification\\..*|posthog\\.tasks\\.feature_flags\\.(refresh_expiring_flags_cache_entries|cleanup_stale_flags_expiry_tracking_task)|posthog\\.tasks\\.team_metadata\\.(refresh_expiring_team_metadata_cache_entries|cleanup_stale_expiry_tracking_task)|posthog\\.tasks\\.team_access_cache_tasks\\.warm_all_team_access_caches_task"}[$__rate_interval])
-/
-increase(posthog_celery_task_duration_seconds_count{task_name=~"posthog\\.tasks\\.hypercache_verification\\..*|posthog\\.tasks\\.feature_flags\\.(refresh_expiring_flags_cache_entries|cleanup_stale_flags_expiry_tracking_task)|posthog\\.tasks\\.team_metadata\\.(refresh_expiring_team_metadata_cache_entries|cleanup_stale_expiry_tracking_task)|posthog\\.tasks\\.team_access_cache_tasks\\.warm_all_team_access_caches_task"}[$__rate_interval])
-```
-
-Replace `$__rate_interval` per the window mapping. Query this as a range query to get a time series, then compute min, max, and average duration across the window for each `task_name`. Convert seconds to human-readable format (e.g., `~690s (11.5 min)`).
-
-**Verification fix counts** (total fixes applied over the window):
-
-```promql
-sum by(cache_type, issue_type) (increase(posthog_hypercache_verify_fixes_total[{window_hours}h]))
-```
-
-This tracks how many cache inconsistencies the verification tasks detected and fixed. Group by `cache_type` (e.g., `feature_flags`, `team_metadata`) and `issue_type` (e.g., `cache_mismatch`, `missing_entry`). A non-zero count is not necessarily alarming (self-healing is working), but sustained high counts or a sudden increase warrants investigation.
-
-**Task failure counts** (over the window):
-
-```promql
-sum by(task_name) (increase(posthog_celery_task_failure_total{task_name=~"posthog\\.tasks\\.hypercache_verification\\..*|posthog\\.tasks\\.feature_flags\\..*|posthog\\.tasks\\.team_metadata\\..*"}[{window_hours}h]))
-```
-
-Any task failures should be flagged as an action item.
-
-**Task execution count** (total runs over the window, reuses the duration count metric):
-
-```promql
-sum by(task_name) (increase(posthog_celery_task_duration_seconds_count{task_name=~"posthog\\.tasks\\.hypercache_verification\\..*|posthog\\.tasks\\.feature_flags\\.(refresh_expiring_flags_cache_entries|cleanup_stale_flags_expiry_tracking_task)|posthog\\.tasks\\.team_metadata\\.(refresh_expiring_team_metadata_cache_entries|cleanup_stale_expiry_tracking_task)|posthog\\.tasks\\.team_access_cache_tasks\\.warm_all_team_access_caches_task"}[{window_hours}h]))
-```
-
-This gives the total number of executions per task in the window. Include this as the "Runs" column in the scheduled tasks table to contextualize duration statistics.
-
-**Task retry counts** (retries over the window):
-
-```promql
-sum by(task_name) (increase(posthog_celery_task_retry_total{task_name=~"posthog\\.tasks\\.hypercache_verification\\..*|posthog\\.tasks\\.feature_flags\\..*|posthog\\.tasks\\.team_metadata\\..*"}[{window_hours}h]))
-```
-
-Retries are typically zero. Only include them in the report when non-zero, rendered as a footnote beneath the scheduled tasks table rather than a dedicated column.
-
-**Queue health** (queue depth stats and trend for feature flag queues):
-
-Average depth over the window:
-
-```promql
-avg_over_time(posthog_celery_queue_depth{queue=~"feature_flags|feature_flags_long_running"}[{window_hours}h])
-```
-
-Maximum depth over the window:
-
-```promql
-max_over_time(posthog_celery_queue_depth{queue=~"feature_flags|feature_flags_long_running"}[{window_hours}h])
-```
-
-Trend (positive = growing, negative = draining, near-zero = stable):
-
-```promql
-deriv(posthog_celery_queue_depth{queue=~"feature_flags|feature_flags_long_running"}[{window_hours}h])
-```
-
-Classify the trend: `deriv > 0.1` = "Growing", `deriv < -0.1` = "Draining", otherwise "Stable". Queue depth is a queue-level metric, not per-task, so render it as a separate sub-section after the scheduled tasks table.
-
-**Batch refresh coverage** (teams processed by the hourly batch refresh):
-
-```promql
-posthog_hypercache_teams_processed_last_run{namespace=~"feature_flags|team_metadata"}
-```
-
-Query this as an instant query. It shows how many teams the most recent batch refresh processed, broken down by `namespace` and `status` (success/failure). If any failures are present, flag them as an action item.
-
-**Fallback guidance:** If any of the standard Celery task metrics return no data, omit that sub-section from the report rather than reporting zeros.
-
-#### Sync Task Health (`sync_feature_flag_last_called`)
-
-This task uses custom Prometheus metrics rather than the standard Celery task instrumentation, so it requires separate queries.
-
-**Success rate** (averaged over the window):
-
-```promql
-avg_over_time(posthog_celery_sync_feature_flag_last_called_success[{window_hours}h])
-```
-
-Returns a 0–1 value. Multiply by 100 and report as a percentage. Values below 100% indicate failures during the window.
-
-**Duration** (range query for time series):
-
-```promql
-posthog_celery_sync_feature_flag_last_called_duration_seconds
-```
-
-Query as a range query. Compute min, max, and average across the window. Report the average in the Avg Duration column; use min/max to inform the Assessment (e.g., flag high variance or an increasing trend). Convert to human-readable format following the same convention as other tasks (`~Xs` under 60s, `~Y.Z min` over 60s).
-
-**Execution count** (total runs in the window):
-
-```promql
-changes(posthog_celery_sync_feature_flag_last_called_duration_seconds[{window_hours}h])
-```
-
-Counts how many times the duration gauge changed, which corresponds to task executions. This is an approximation: if two consecutive runs produce the exact same duration, one execution may be missed.
-
-**Interpretation thresholds:**
-
-- Success rate < 100%: action item. < 90% = Warning priority, < 50% = Critical priority
-- Zero executions in the window: action item (task not running)
-- Duration increasing trend: note in the report for monitoring
-
-#### HPA Scaling Efficiency
-
-Query these three metrics to assess whether the HPA is tuned correctly.
-
-**% time at max replicas** (fraction of the window where desired replicas hit the max):
-
-```promql
-count_over_time((kube_horizontalpodautoscaler_status_desired_replicas{horizontalpodautoscaler="posthog-feature-flags"} >= kube_horizontalpodautoscaler_spec_max_replicas{horizontalpodautoscaler="posthog-feature-flags"})[{window_hours}h:5m])
-/ count_over_time(kube_horizontalpodautoscaler_status_desired_replicas{horizontalpodautoscaler="posthog-feature-flags"}[{window_hours}h:5m])
-```
-
-**CPU headroom ratio** (range query, how close the hottest pod is to the HPA target):
-
-```promql
-max(sum by (pod)(rate(container_cpu_usage_seconds_total{namespace="posthog", container="posthog-feature-flags"}[5m])) / on(pod) sum by (pod)(kube_pod_container_resource_requests{resource="cpu", namespace="posthog", container="posthog-feature-flags"})) / 0.70
-```
-
-**Scaling events** (number of HPA replica changes in the window):
-
-```promql
-changes(kube_horizontalpodautoscaler_status_desired_replicas{horizontalpodautoscaler="posthog-feature-flags"}[{window_hours}h])
-```
-
-**Interpretation thresholds:**
-
-- % at max > 20% → action item (raise maxPods or lower CPU target)
-- Headroom ratio peak > 0.9 → HPA being pushed close to scaling
-- Headroom ratio peak < 0.5 → CPU target may be too conservative
-
-**Fallback:** If any of these metrics return no data, omit the HPA Scaling Efficiency section from the report.
-
-#### Billing Aggregator
-
-The billing aggregator is the sole authoritative writer for flag billing counts. A silent failure here under-bills usage with no immediate symptom in latency or error rate, so it gets its own health check.
-
-Run all queries below in parallel for each active region against that region's Prometheus datasource.
-
-**Stale-flush watchdog** (instant, max across pods):
-
-```promql
-max(flags_billing_seconds_since_successful_flush)
-```
-
-Default flush interval is 10 seconds. Healthy pods sit well under 30s; treat anything sustained over 60s as a real problem.
-
-**Unflushed requests by cause** (total over the window — this is the revenue-loss signal):
-
-```promql
-sum by(cause) (increase(flags_billing_unflushed_requests_total[{window_hours}h]))
-```
-
-Causes: `cap_drop` (memory-pressure shed at record-time), `redis_error` (chunk failed mid-flush; even though the requeue may succeed, the request count is booked here so the total reflects everything blocked), `flush_dropped_on_error` (best-effort shutdown gave up on a chunk), `shutdown_drop` (process exited before draining in-memory state). Any sustained non-zero total is an action item.
-
-**Flush errors by type** (total over the window):
-
-```promql
-sum by(error_type) (increase(flags_billing_flush_errors_total[{window_hours}h]))
-```
-
-A non-zero count that does not pair with `unflushed_requests_total` growth means flushes are retrying successfully; pair this query with the one above before deciding severity.
-
-**Pending queue depth** (max over the window):
-
-```promql
-max_over_time(sum(flags_billing_pending_records)[{window_hours}h:])
-```
-
-In-memory records waiting to be flushed. Should drop to ~0 each tick. Sustained growth is a leading indicator that `cap_drop` is imminent.
-
-**Throughput** (input vs flushed-out rate, range query):
-
-```promql
-sum(rate(flags_billing_records_total[$__rate_interval]))
-sum(rate(flags_billing_entries_flushed_total[$__rate_interval]))
-```
-
-Over a stable window the two rates should match. A widening gap (records-in > entries-flushed) means the buffer is filling faster than it drains.
-
-**Flush latency** (p99 over the window):
-
-```promql
-histogram_quantile(0.99, sum by(le) (rate(flags_billing_flush_duration_ms_bucket[$__rate_interval])))
-```
-
-p99 trending toward the 10s tick interval means flushes risk overlapping the next tick. Pair with Pending Queue Depth — rising p99 + rising depth points at Redis as the bottleneck.
-
-**Interpretation thresholds:**
-
-- Stale-flush > 60s sustained → action item (Warning). > 120s → Critical
-- Any non-zero `unflushed_requests_total` over the window → action item. `cap_drop` or `shutdown_drop` totals > 0 are Critical (records definitely lost). `redis_error` and `flush_dropped_on_error` are Warning by default; promote to Critical if paired with stale-flush or sustained pending growth
-- Pending records depth growing trend over the window → Warning (lead time before cap_drop fires)
-- Records-in / entries-flushed ratio drifting from 1.0 across the window → Warning
-- Flush p99 > 5000ms sustained → Warning (half the tick interval). > 9000ms → Critical
-
-**Fallback:** If `flags_billing_records_total` returns no data (the service may not have rolled out the aggregator yet), omit the Billing Aggregator section from the report.
+Read `~/.claude/skills/ops-report/references/capacity-checks.md` and run the checks that apply to the service, for each active region. Currently all checks target `feature-flags`; skip this step if the file has no entries for the service.
 
 ### Step 6: Analyze Results
 
@@ -449,18 +213,10 @@ For each anomaly, attempt to investigate the cause by querying additional metric
 
 ### Step 7: Generate Dashboard Links
 
-For each dashboard used, generate deep links with the time range for each active region in parallel. Dashboard links use relative time ranges (`now-{window_hours}h`) so they open correctly in the browser. This is the only place relative expressions are used:
+For each dashboard used, generate deep links with the time range for each active region. Dashboard links use relative time ranges (`now-{window_hours}h`) so they open correctly in the browser. This is the only place relative expressions are used:
 
 ```text
-# prod-us
 mcp__grafana__generate_deeplink(
-  resourceType="dashboard",
-  dashboardUid="{uid}",
-  timeRange={"from": "now-{window_hours}h", "to": "now"}
-)
-
-# prod-eu
-mcp__grafana-eu__generate_deeplink(
   resourceType="dashboard",
   dashboardUid="{uid}",
   timeRange={"from": "now-{window_hours}h", "to": "now"}
@@ -479,7 +235,7 @@ Replace `localhost:13000` in the generated URLs with the appropriate public Graf
 
 When anomalies are detected in Step 6 (e.g., 5xx error spikes, latency spikes), query Loki access logs to investigate root causes before writing the report. This transforms "check the logs" from a next step into an already-completed investigation.
 
-Query each region where an anomaly was detected in parallel using that region's Loki datasource UID (discovered in Step 3, not hardcoded).
+Query each region where an anomaly was detected using that region's Loki datasource UID (discovered in Step 3, not hardcoded).
 
 **Use `{spike_peak_utc}` from Step 6 (the actual Prometheus data point timestamp) as the centre of the Loki query window.** Never substitute a time from a log message or a guess. The goal is to look at logs *at the moment the metric spike occurred*, not at the moment of a correlated (but possibly unrelated) log entry. Set `{spike_start}` = `{spike_peak_utc}` − 15 min and `{spike_end}` = `{spike_peak_utc}` + 15 min (or wider for week/month windows).
 
@@ -498,18 +254,8 @@ Application logs use `app="posthog-feature-flags"` (or the service name).
 For each error spike, query the access logs in the affected region:
 
 ```text
-# prod-us
 mcp__grafana__query_loki_logs(
-  datasourceUid="{us_loki_uid}",
-  logql='{app="contour", response_code=~"5..", upstream_cluster="posthog_posthog-feature-flags_3001"}',
-  startRfc3339="{spike_start}",
-  endRfc3339="{spike_end}",
-  limit=20
-)
-
-# prod-eu
-mcp__grafana-eu__query_loki_logs(
-  datasourceUid="{eu_loki_uid}",
+  datasourceUid="{loki_uid}",
   logql='{app="contour", response_code=~"5..", upstream_cluster="posthog_posthog-feature-flags_3001"}',
   startRfc3339="{spike_start}",
   endRfc3339="{spike_end}",
@@ -530,18 +276,8 @@ Also check `x_forwarded_host` to identify if errors are concentrated on a single
 Check whether the application itself is logging errors for each affected region:
 
 ```text
-# prod-us
 mcp__grafana__query_loki_logs(
-  datasourceUid="{us_loki_uid}",
-  logql='{app="posthog-feature-flags"} |~ "(?i)error"',
-  startRfc3339="{spike_start}",
-  endRfc3339="{spike_end}",
-  limit=20
-)
-
-# prod-eu
-mcp__grafana-eu__query_loki_logs(
-  datasourceUid="{eu_loki_uid}",
+  datasourceUid="{loki_uid}",
   logql='{app="posthog-feature-flags"} |~ "(?i)error"',
   startRfc3339="{spike_start}",
   endRfc3339="{spike_end}",
@@ -551,39 +287,21 @@ mcp__grafana-eu__query_loki_logs(
 
 #### Broad log scan for warnings and errors (full window)
 
-Regardless of whether anomalies were detected in Step 6, scan the application logs across the **entire reporting window** for warnings and errors. Run both regions in parallel:
+Regardless of whether anomalies were detected in Step 6, scan the application logs across the **entire reporting window** for warnings and errors, for each active region:
 
 ```text
-# prod-us errors
+# errors
 mcp__grafana__query_loki_logs(
-  datasourceUid="{us_loki_uid}",
+  datasourceUid="{loki_uid}",
   logql='{app="{service}"} | json | level =~ "(?i)(error|err)"',
   startRfc3339="{window_start}",
   endRfc3339="{window_end}",
   limit=50
 )
 
-# prod-us warnings
+# warnings
 mcp__grafana__query_loki_logs(
-  datasourceUid="{us_loki_uid}",
-  logql='{app="{service}"} | json | level =~ "(?i)(warn|warning)"',
-  startRfc3339="{window_start}",
-  endRfc3339="{window_end}",
-  limit=50
-)
-
-# prod-eu errors
-mcp__grafana-eu__query_loki_logs(
-  datasourceUid="{eu_loki_uid}",
-  logql='{app="{service}"} | json | level =~ "(?i)(error|err)"',
-  startRfc3339="{window_start}",
-  endRfc3339="{window_end}",
-  limit=50
-)
-
-# prod-eu warnings
-mcp__grafana-eu__query_loki_logs(
-  datasourceUid="{eu_loki_uid}",
+  datasourceUid="{loki_uid}",
   logql='{app="{service}"} | json | level =~ "(?i)(warn|warning)"',
   startRfc3339="{window_start}",
   endRfc3339="{window_end}",
@@ -611,7 +329,7 @@ Regardless of whether anomalies were detected, scan the worker logs across the *
 - **App label:** `{app="posthog-worker-django"}` instead of `{app="{service}"}`
 - **Line filter:** Add `|= "{service_keyword}"` to scope results to the service, where `service_keyword` is derived from `service` by lowercasing and replacing hyphens with underscores (e.g., `feature-flags` → `feature_flags`, `ingestion` → `ingestion`)
 
-Run errors and warnings for both regions in parallel (4 queries total), with `limit=50`, using the same `{window_start}`/`{window_end}` range. Apply the same `json` parser with level filter, and the same unstructured-log fallback pattern if `json` doesn't match.
+Run errors and warnings for each active region, with `limit=50`, using the same `{window_start}`/`{window_end}` range. Apply the same `json` parser with level filter, and the same unstructured-log fallback pattern if `json` doesn't match.
 
 Group results by message pattern and identify the **top 5 most frequent** error and warning patterns, same as the broad scan. Deduplicate against the `{app="{service}"}` scan: if a pattern already appeared there, do not repeat it. Cross-reference worker error patterns with the `sync_feature_flag_last_called` success rate from Step 5b; if error logs correlate with a low success rate, note the correlation.
 
@@ -627,197 +345,7 @@ For `day` window, the filename can omit the suffix (e.g., `feature-flags.md`). F
 
 If a report already exists at that path, tell the user and offer to overwrite it. Do not overwrite without confirmation.
 
-Create the directory if it doesn't exist.
-
-Use this structure for the report. The report leads with action items so the reader immediately knows what needs attention:
-
-```markdown
-# {Service Name} - {Window Label} Health Report
-
-**Date:** {YYYY-MM-DD}
-**Regions:** {US (prod-us) | EU (prod-eu) | US + EU (prod-us, prod-eu)}
-**Report window:** {start} to {end} UTC
-
-## Overall Status: {Healthy | Degraded | Unhealthy}
-
-{1-2 sentence executive summary}
-
-## Action Items
-
-{This section appears first so the reader immediately knows what needs attention. Each item should describe the anomaly, what investigation was already performed during report generation, and concrete next steps. If no action items exist, write "No action items. All metrics are within normal ranges."}
-
-### {Priority}: {Action title}
-
-- **What:** {Brief description of the anomaly or concern}
-- **Evidence:** {Specific metric values, timestamps, and correlated signals}
-- **Investigation so far:** {What was checked during report generation, e.g., "Correlated with deploy times - no deploys in this window" or "Error logs show timeout to downstream service X"}
-- **Next steps:** {Concrete actions, e.g., "Check service X health", "Review recent deploy for regression", "Monitor for recurrence over next 24h"}
-
-## Key Metrics Summary
-
-When reporting on both regions, use US and EU columns so the reader can compare at a glance:
-
-| Metric | US Current | US Range | EU Current | EU Range | Assessment |
-| ------ | ---------- | -------- | ---------- | -------- | ---------- |
-| ... | ... | ... | ... | ... | ... |
-
-For single-region reports, collapse to the standard four-column format:
-
-| Metric | Current | Range | Assessment |
-| ------ | ------- | ----- | ---------- |
-| ... | ... | ... | ... |
-
-{Include an "Error spikes (5xx > 50/5min)" row after the error rate row, showing the spike count and severity breakdown. Include a "Latency spikes (P99 > {threshold}ms)" row after the P50 latency row. For dual-region, show the spike count and severity breakdown for each region separately in their respective columns. The latency {threshold} value is max(2 × median P99, 200).}
-
-## Anomalies and Notable Events
-
-### 1. {Event title}
-
-{Description with timestamps and correlated metrics}
-
-## What's Working Well
-
-- {Bullet points of positive signals}
-
-## Scheduled Tasks
-
-When reporting on both regions, render a separate sub-section for each region:
-
-### US (prod-us)
-
-| Task | Runs | Min | Max | Avg | Fixes ({window}) |
-|------|------|-----|-----|-----|------------------|
-| `task_short_name` | N | ~11.5 min | ~12.1 min | ~11.8 min | 0 |
-
-### EU (prod-eu)
-
-| Task | Runs | Min | Max | Avg | Fixes ({window}) |
-|------|------|-----|-----|-----|------------------|
-| `task_short_name` | N | ~11.5 min | ~12.1 min | ~11.8 min | 0 |
-
-{Use the short task name (e.g., `verify_and_fix_flags_cache_task`) rather than the full dotted path. For durations, use `~Xs` for values under 60s and `~Y.Z min` for values over 60s. For the Fixes column, show the total count and bold it if non-zero, appending the issue types in parentheses (e.g., **3** (cache_mismatch)). If a task had failures, note them in a row below or as a footnote. Omit tasks that had zero runs in the window. If any tasks had retries during the window, annotate the task name with an asterisk and add a footnote below the table (e.g., `*3 retries during the window`). Omit the footnote entirely when all retry counts are zero. For single-region reports, omit the sub-section headers.}
-
-### Sync Task Health (`sync_feature_flag_last_called`)
-
-This task uses custom metrics (not standard Celery task instrumentation).
-
-When reporting on both regions:
-
-| Region | Runs | Avg Duration | Success Rate | Assessment |
-|--------|------|-------------|-------------|------------|
-| US | N | ~Xs | XX% | Healthy / Degraded / Not Running |
-| EU | N | ~Xs | XX% | Healthy / Degraded / Not Running |
-
-{Report 0 runs as "Not Running" with a warning. Success rate < 100% should be flagged as an action item. For single-region reports, omit the Region column. Omit this sub-section entirely if the custom metrics return no data for both regions.}
-
-### Queue Health
-
-When reporting on both regions, show US and EU in the same table with a Region column:
-
-| Region | Queue | Avg Depth | Max Depth | Trend |
-|--------|-------|-----------|-----------|-------|
-| US | `feature_flags` | N | N | Stable/Growing/Draining |
-| US | `feature_flags_long_running` | N | N | Stable/Growing/Draining |
-| EU | `feature_flags` | N | N | Stable/Growing/Draining |
-| EU | `feature_flags_long_running` | N | N | Stable/Growing/Draining |
-
-{Show average and maximum queue depth over the window, plus the trend derived from `deriv()`. Classify trend as "Growing" (deriv > 0.1), "Draining" (deriv < -0.1), or "Stable" (near zero). A growing queue paired with increasing task durations warrants investigation. Omit this section if queue depth metrics return no data for both regions.}
-
-### Batch Refresh Coverage
-
-{One-line summary per region of `posthog_hypercache_teams_processed_last_run` results, e.g., "**US:** Batch refresh processed N teams (feature_flags) and M teams (team_metadata) with no failures. **EU:** ..." If any failures are present, bold the failure count and flag as an action item. Omit this section if the metric returns no data for either region.}
-
-## Billing Aggregator
-
-The aggregator is the sole authoritative writer for flag billing counts; a silent failure under-bills usage without showing up in latency or error metrics.
-
-When reporting on both regions, show US and EU in the same table with a Region column:
-
-| Region | Signal | Value | Assessment |
-|--------|--------|-------|------------|
-| US | Seconds since last successful flush (max pod) | Xs | Healthy / Drifting / Stale |
-| US | Unflushed requests ({window}) | N total ({cause breakdown}) | None / Warning / Critical |
-| US | Flush errors ({window}) | N ({error_type breakdown}) | None / Transient / Sustained |
-| US | Pending records (max / trend) | N max, Stable/Growing | Healthy / Backing up |
-| US | Records-in vs entries-flushed | X.XX ratio | Matched / Diverging |
-| US | Flush p99 | Xms | Healthy / Tight / At-tick |
-| EU | … | … | … |
-
-{Classify Seconds since last flush: Healthy (<30s), Drifting (30–60s), Stale (>60s). Unflushed requests: None (0), Warning (any non-zero with cause = redis_error / flush_dropped_on_error), Critical (any non-zero with cause = cap_drop / shutdown_drop — these are confirmed lost). Pending records: Healthy (drains to ~0 each tick, no trend), Backing up (sustained growth across the window). Records vs flushed ratio: Matched (0.95–1.05), Diverging (outside that band sustained). Flush p99: Healthy (<5s), Tight (5–9s), At-tick (>9s, risks overlapping next tick).}
-
-{If any signal lands in a non-healthy band, add a corresponding action item to the top of the report describing the signal, the cause/error_type breakdown, and the next step (typically: check Redis health, then inspect aggregator pod logs at the spike time).}
-
-{Omit this entire section if `flags_billing_records_total` returned no data for both regions.}
-
-## HPA Scaling Efficiency
-
-When reporting on both regions, show US and EU in the same table with a Region column:
-
-| Region | Metric | Value | Assessment |
-|--------|--------|-------|------------|
-| US | Time at max replicas | X% | OK / Elevated / Critical |
-| US | CPU headroom (max pod / target) | X.XX avg, X.XX peak | Comfortable / Tight / Over-target |
-| US | Scaling events | N | Stable / Moderate / Volatile |
-| EU | Time at max replicas | X% | OK / Elevated / Critical |
-| EU | CPU headroom (max pod / target) | X.XX avg, X.XX peak | Comfortable / Tight / Over-target |
-| EU | Scaling events | N | Stable / Moderate / Volatile |
-
-## Warning and Error Logs
-
-Summary of warning and error log messages observed across the full reporting window.
-
-### Errors
-
-When reporting on both regions, use sub-sections per region. For each region, list the top recurring error patterns in a table:
-
-| Count | Message Pattern | First Seen | Last Seen |
-|-------|----------------|------------|-----------|
-| N | `short description of the error pattern` | HH:MM UTC | HH:MM UTC |
-
-If no errors were logged, write: "No error-level log messages observed in this window."
-
-### Warnings
-
-| Count | Message Pattern | First Seen | Last Seen |
-|-------|----------------|------------|-----------|
-| N | `short description of the warning pattern` | HH:MM UTC | HH:MM UTC |
-
-If no warnings were logged, write: "No warning-level log messages observed in this window."
-
-{Cross-reference any log patterns against the anomalies identified in Step 6. If a log pattern correlates with a metric spike, note it here and link to the relevant anomaly section. Promote recurring or high-volume error patterns to the Action Items section if they warrant investigation.}
-
-### Worker Task Logs
-
-Summary of service-related error and warning messages from `posthog-worker-django` across the full reporting window. When reporting on both regions, use sub-sections per region (same as Errors and Warnings above).
-
-| Count | Message Pattern | First Seen | Last Seen |
-|-------|----------------|------------|-----------|
-| N | `short description of the worker error pattern` | HH:MM UTC | HH:MM UTC |
-
-If no worker task errors or warnings were logged, write: "No service-related worker task log messages observed in this window."
-
-{Cross-reference worker error patterns against the `sync_feature_flag_last_called` success rate from the Scheduled Tasks section. If a worker error pattern correlates with a low success rate, note it and link to the relevant section. Promote high-volume worker errors to Action Items if they indicate a systemic issue. Only omit this sub-section if worker log queries could not be run or no worker log datasource is available for both regions; if queries ran successfully but returned no messages, include this sub-section with the "No service-related worker task log messages observed in this window." sentence.}
-
-## {Service-specific sections as appropriate}
-
-{e.g., Cache Performance, DB Connection Pool, Capacity/Limits, etc.}
-
-## Dashboard Links
-
-These links require VPN access and Cognito authentication:
-
-### US (prod-us)
-
-- [Dashboard Name](grafana.prod-us.posthog.dev/...)
-
-### EU (prod-eu)
-
-- [Dashboard Name](grafana.prod-eu.posthog.dev/...)
-
-## Data Sources
-
-{Brief description of how the data was collected}
-```
+Read `~/.claude/skills/ops-report/templates/report-template.md` and follow its structure. Braced text in the template is authoring instruction, not literal content. The report leads with action items so the reader immediately knows what needs attention.
 
 ### Step 10: Token Usage, Lint, and Confirm
 
@@ -906,6 +434,7 @@ Use these thresholds to determine the overall status:
 
 - Be factual and specific with numbers and timestamps
 - Distinguish between transient blips (single data points) and sustained issues
+- Don't alarm on known benign patterns (e.g., diurnal traffic drops)
 - Note boundary artifacts (e.g., `increase()` at query range boundaries producing inflated first values)
 - Cross-reference metrics to establish causation, not just correlation
 - Lead with action items; the reader should know within 10 seconds whether the report needs their attention
@@ -913,12 +442,3 @@ Use these thresholds to determine the overall status:
 - Keep next steps actionable and tied to specific observations
 - Use UTC timestamps throughout
 - Never use em dashes. Use commas, colons, parentheses, or periods instead
-
-## What You Do NOT Do
-
-- Guess at metric values without querying
-- Report a metric spike at a timestamp read from a log entry instead of from the Prometheus data point
-- Report on dashboards that don't exist for the service
-- Create empty directories
-- Use localhost URLs in the report
-- Alarm on known benign patterns (e.g., diurnal traffic drops)

--- a/ai/skills/ops-report/references/capacity-checks.md
+++ b/ai/skills/ops-report/references/capacity-checks.md
@@ -1,0 +1,179 @@
+# Service-Specific Capacity Checks
+
+Capacity metrics that indicate approaching limits. All checks currently target the `feature-flags` service; other services have no entries yet. Run every query for each active region in parallel against that region's Prometheus datasource UID.
+
+## Feature Flag Count Capacity
+
+Query the number of feature flags per team to identify teams nearing the maximum allowed count:
+
+- Total flag count per team/organization
+- Teams approaching the configured maximum (e.g., >80% of the limit)
+- Recent growth rate in flag creation
+
+If a direct metric isn't available, check whether the dashboard panels show this data. Flag as an action item if any team is above 80% of the maximum.
+
+## Scheduled Task Performance
+
+Scheduled Celery task duration and verification fix counts from the cache dashboard. These tasks run periodically to maintain cache consistency.
+
+**Task duration** (range query; compute min/max/avg per `task_name`; convert to human-readable, e.g. `~690s (11.5 min)`; replace `$__rate_interval` per the window mapping):
+
+```promql
+increase(posthog_celery_task_duration_seconds_sum{task_name=~"posthog\\.tasks\\.hypercache_verification\\..*|posthog\\.tasks\\.feature_flags\\.(refresh_expiring_flags_cache_entries|cleanup_stale_flags_expiry_tracking_task)|posthog\\.tasks\\.team_metadata\\.(refresh_expiring_team_metadata_cache_entries|cleanup_stale_expiry_tracking_task)|posthog\\.tasks\\.team_access_cache_tasks\\.warm_all_team_access_caches_task"}[$__rate_interval])
+/
+increase(posthog_celery_task_duration_seconds_count{task_name=~"posthog\\.tasks\\.hypercache_verification\\..*|posthog\\.tasks\\.feature_flags\\.(refresh_expiring_flags_cache_entries|cleanup_stale_flags_expiry_tracking_task)|posthog\\.tasks\\.team_metadata\\.(refresh_expiring_team_metadata_cache_entries|cleanup_stale_expiry_tracking_task)|posthog\\.tasks\\.team_access_cache_tasks\\.warm_all_team_access_caches_task"}[$__rate_interval])
+```
+
+**Verification fix counts** (cache inconsistencies detected and fixed; a non-zero count means self-healing is working, but sustained high counts or a sudden increase warrants investigation):
+
+```promql
+sum by(cache_type, issue_type) (increase(posthog_hypercache_verify_fixes_total[{window_hours}h]))
+```
+
+**Task failure counts** (any failures → action item):
+
+```promql
+sum by(task_name) (increase(posthog_celery_task_failure_total{task_name=~"posthog\\.tasks\\.hypercache_verification\\..*|posthog\\.tasks\\.feature_flags\\..*|posthog\\.tasks\\.team_metadata\\..*"}[{window_hours}h]))
+```
+
+**Task execution count** (the "Runs" column in the scheduled tasks table):
+
+```promql
+sum by(task_name) (increase(posthog_celery_task_duration_seconds_count{task_name=~"posthog\\.tasks\\.hypercache_verification\\..*|posthog\\.tasks\\.feature_flags\\.(refresh_expiring_flags_cache_entries|cleanup_stale_flags_expiry_tracking_task)|posthog\\.tasks\\.team_metadata\\.(refresh_expiring_team_metadata_cache_entries|cleanup_stale_expiry_tracking_task)|posthog\\.tasks\\.team_access_cache_tasks\\.warm_all_team_access_caches_task"}[{window_hours}h]))
+```
+
+**Task retry counts** (typically zero; include only when non-zero, as a footnote beneath the scheduled tasks table, not a column):
+
+```promql
+sum by(task_name) (increase(posthog_celery_task_retry_total{task_name=~"posthog\\.tasks\\.hypercache_verification\\..*|posthog\\.tasks\\.feature_flags\\..*|posthog\\.tasks\\.team_metadata\\..*"}[{window_hours}h]))
+```
+
+**Queue health** (queue-level, not per-task; render as a separate sub-section after the scheduled tasks table):
+
+```promql
+avg_over_time(posthog_celery_queue_depth{queue=~"feature_flags|feature_flags_long_running"}[{window_hours}h])
+max_over_time(posthog_celery_queue_depth{queue=~"feature_flags|feature_flags_long_running"}[{window_hours}h])
+deriv(posthog_celery_queue_depth{queue=~"feature_flags|feature_flags_long_running"}[{window_hours}h])
+```
+
+Classify the trend from `deriv`: `> 0.1` = "Growing", `< -0.1` = "Draining", otherwise "Stable".
+
+**Batch refresh coverage** (instant query; teams processed by the most recent batch refresh, broken down by `namespace` and `status`; any failures → action item):
+
+```promql
+posthog_hypercache_teams_processed_last_run{namespace=~"feature_flags|team_metadata"}
+```
+
+**Fallback:** if any of the standard Celery task metrics return no data, omit that sub-section from the report rather than reporting zeros.
+
+## Sync Task Health (`sync_feature_flag_last_called`)
+
+This task uses custom Prometheus metrics rather than the standard Celery task instrumentation, so it requires separate queries.
+
+**Success rate** (0–1 value; multiply by 100 and report as a percentage):
+
+```promql
+avg_over_time(posthog_celery_sync_feature_flag_last_called_success[{window_hours}h])
+```
+
+**Duration** (range query; compute min/max/avg; report the average in the Avg Duration column and use min/max to inform the Assessment, e.g. high variance or an increasing trend; format as `~Xs` under 60s, `~Y.Z min` over):
+
+```promql
+posthog_celery_sync_feature_flag_last_called_duration_seconds
+```
+
+**Execution count** (counts duration-gauge changes as a proxy for runs; approximate — two consecutive runs with identical durations may miss one execution):
+
+```promql
+changes(posthog_celery_sync_feature_flag_last_called_duration_seconds[{window_hours}h])
+```
+
+**Interpretation thresholds:**
+
+- Success rate < 100%: action item. < 90% = Warning priority, < 50% = Critical priority
+- Zero executions in the window: action item (task not running)
+- Duration increasing trend: note in the report for monitoring
+
+## HPA Scaling Efficiency
+
+Three metrics to assess whether the HPA is tuned correctly.
+
+**% time at max replicas:**
+
+```promql
+count_over_time((kube_horizontalpodautoscaler_status_desired_replicas{horizontalpodautoscaler="posthog-feature-flags"} >= kube_horizontalpodautoscaler_spec_max_replicas{horizontalpodautoscaler="posthog-feature-flags"})[{window_hours}h:5m])
+/ count_over_time(kube_horizontalpodautoscaler_status_desired_replicas{horizontalpodautoscaler="posthog-feature-flags"}[{window_hours}h:5m])
+```
+
+**CPU headroom ratio** (range query; how close the hottest pod is to the HPA target):
+
+```promql
+max(sum by (pod)(rate(container_cpu_usage_seconds_total{namespace="posthog", container="posthog-feature-flags"}[5m])) / on(pod) sum by (pod)(kube_pod_container_resource_requests{resource="cpu", namespace="posthog", container="posthog-feature-flags"})) / 0.70
+```
+
+**Scaling events** (HPA replica changes in the window):
+
+```promql
+changes(kube_horizontalpodautoscaler_status_desired_replicas{horizontalpodautoscaler="posthog-feature-flags"}[{window_hours}h])
+```
+
+**Interpretation thresholds:**
+
+- % at max > 20% → action item (raise maxPods or lower CPU target)
+- Headroom ratio peak > 0.9 → HPA being pushed close to scaling
+- Headroom ratio peak < 0.5 → CPU target may be too conservative
+
+**Fallback:** if any of these metrics return no data, omit the HPA Scaling Efficiency section from the report.
+
+## Billing Aggregator
+
+The billing aggregator is the sole authoritative writer for flag billing counts. A silent failure here under-bills usage with no immediate symptom in latency or error rate, so it gets its own health check.
+
+**Stale-flush watchdog** (instant, max across pods; default flush interval is 10 seconds — healthy pods sit well under 30s, sustained over 60s is a real problem):
+
+```promql
+max(flags_billing_seconds_since_successful_flush)
+```
+
+**Unflushed requests by cause** (the revenue-loss signal; any sustained non-zero total is an action item):
+
+```promql
+sum by(cause) (increase(flags_billing_unflushed_requests_total[{window_hours}h]))
+```
+
+Causes: `cap_drop` (memory-pressure shed at record-time), `redis_error` (chunk failed mid-flush; even though the requeue may succeed, the request count is booked here so the total reflects everything blocked), `flush_dropped_on_error` (best-effort shutdown gave up on a chunk), `shutdown_drop` (process exited before draining in-memory state).
+
+**Flush errors by type** (a non-zero count that does not pair with `unflushed_requests_total` growth means flushes are retrying successfully; pair with the query above before deciding severity):
+
+```promql
+sum by(error_type) (increase(flags_billing_flush_errors_total[{window_hours}h]))
+```
+
+**Pending queue depth** (in-memory records waiting to flush; should drop to ~0 each tick — sustained growth is a leading indicator that `cap_drop` is imminent):
+
+```promql
+max_over_time(sum(flags_billing_pending_records)[{window_hours}h:])
+```
+
+**Throughput** (input vs flushed-out rate; over a stable window the two rates should match — a widening gap means the buffer is filling faster than it drains):
+
+```promql
+sum(rate(flags_billing_records_total[$__rate_interval]))
+sum(rate(flags_billing_entries_flushed_total[$__rate_interval]))
+```
+
+**Flush latency** (p99 trending toward the 10s tick interval means flushes risk overlapping the next tick; rising p99 + rising pending depth points at Redis as the bottleneck):
+
+```promql
+histogram_quantile(0.99, sum by(le) (rate(flags_billing_flush_duration_ms_bucket[$__rate_interval])))
+```
+
+**Interpretation thresholds:**
+
+- Stale-flush > 60s sustained → action item (Warning). > 120s → Critical
+- Any non-zero `unflushed_requests_total` over the window → action item. `cap_drop` or `shutdown_drop` totals > 0 are Critical (records definitely lost). `redis_error` and `flush_dropped_on_error` are Warning by default; promote to Critical if paired with stale-flush or sustained pending growth
+- Pending records depth growing trend over the window → Warning (lead time before cap_drop fires)
+- Records-in / entries-flushed ratio drifting from 1.0 across the window → Warning
+- Flush p99 > 5000ms sustained → Warning (half the tick interval). > 9000ms → Critical
+
+**Fallback:** if `flags_billing_records_total` returns no data (the service may not have rolled out the aggregator yet), omit the Billing Aggregator section from the report.

--- a/ai/skills/ops-report/templates/report-template.md
+++ b/ai/skills/ops-report/templates/report-template.md
@@ -1,0 +1,150 @@
+# {Service Name} - {Window Label} Health Report
+
+**Date:** {YYYY-MM-DD}
+**Regions:** {US (prod-us) | EU (prod-eu) | US + EU (prod-us, prod-eu)}
+**Report window:** {start} to {end} UTC
+
+## Overall Status: {Healthy | Degraded | Unhealthy}
+
+{1-2 sentence executive summary}
+
+## Action Items
+
+{This section appears first so the reader immediately knows what needs attention. Each item describes the anomaly, what investigation was already performed during report generation, and concrete next steps. If no action items exist, write "No action items. All metrics are within normal ranges."}
+
+### {Priority}: {Action title}
+
+- **What:** {Brief description of the anomaly or concern}
+- **Evidence:** {Specific metric values, timestamps, and correlated signals}
+- **Investigation so far:** {What was checked during report generation, e.g., "Correlated with deploy times - no deploys in this window" or "Error logs show timeout to downstream service X"}
+- **Next steps:** {Concrete actions, e.g., "Check service X health", "Review recent deploy for regression", "Monitor for recurrence over next 24h"}
+
+## Key Metrics Summary
+
+{When reporting on both regions, use US and EU columns so the reader can compare at a glance. For single-region reports, collapse to Metric | Current | Range | Assessment.}
+
+| Metric | US Current | US Range | EU Current | EU Range | Assessment |
+| --- | --- | --- | --- | --- | --- |
+| {metric} | {value} | {min–max} | {value} | {min–max} | {assessment} |
+
+{Include an "Error spikes (5xx > 50/5min)" row after the error rate row, showing the spike count and severity breakdown. Include a "Latency spikes (P99 > {threshold}ms)" row after the P50 latency row. For dual-region, show the spike count and severity breakdown for each region separately in their respective columns. The latency {threshold} value is max(2 × median P99, 200).}
+
+## Anomalies and Notable Events
+
+### 1. {Event title}
+
+{Description with timestamps and correlated metrics}
+
+## What's Working Well
+
+- {Bullet points of positive signals}
+
+## Scheduled Tasks
+
+{When reporting on both regions, render a separate sub-section for each region; for single-region reports, omit the sub-section headers.}
+
+### US (prod-us)
+
+| Task | Runs | Min | Max | Avg | Fixes ({window}) |
+| --- | --- | --- | --- | --- | --- |
+| `{task_short_name}` | {N} | {~X.X min} | {~X.X min} | {~X.X min} | {N} |
+
+### EU (prod-eu)
+
+{Same table shape as US.}
+
+{Use the short task name (e.g., `verify_and_fix_flags_cache_task`) rather than the full dotted path. For durations, use `~Xs` for values under 60s and `~Y.Z min` for values over 60s. For the Fixes column, show the total count and bold it if non-zero, appending the issue types in parentheses (e.g., **3** (cache_mismatch)). If a task had failures, note them in a row below or as a footnote. Omit tasks that had zero runs in the window. If any tasks had retries during the window, annotate the task name with an asterisk and add a footnote below the table (e.g., `*3 retries during the window`). Omit the footnote entirely when all retry counts are zero.}
+
+### Sync Task Health (`sync_feature_flag_last_called`)
+
+This task uses custom metrics (not standard Celery task instrumentation).
+
+| Region | Runs | Avg Duration | Success Rate | Assessment |
+| --- | --- | --- | --- | --- |
+| US | {N} | {~Xs} | {XX%} | {Healthy / Degraded / Not Running} |
+| EU | {N} | {~Xs} | {XX%} | {Healthy / Degraded / Not Running} |
+
+{Report 0 runs as "Not Running" with a warning. Success rate < 100% should be flagged as an action item. For single-region reports, omit the Region column. Omit this sub-section entirely if the custom metrics return no data for both regions.}
+
+### Queue Health
+
+| Region | Queue | Avg Depth | Max Depth | Trend |
+| --- | --- | --- | --- | --- |
+| {US/EU} | `{queue_name}` | {N} | {N} | {Stable/Growing/Draining} |
+
+{Show average and maximum queue depth over the window, plus the trend derived from `deriv()`: "Growing" (deriv > 0.1), "Draining" (deriv < -0.1), or "Stable" (near zero). A growing queue paired with increasing task durations warrants investigation. Omit this section if queue depth metrics return no data for both regions.}
+
+### Batch Refresh Coverage
+
+{One-line summary per region of `posthog_hypercache_teams_processed_last_run` results, e.g., "**US:** Batch refresh processed N teams (feature_flags) and M teams (team_metadata) with no failures. **EU:** ..." If any failures are present, bold the failure count and flag as an action item. Omit this section if the metric returns no data for either region.}
+
+## Billing Aggregator
+
+The aggregator is the sole authoritative writer for flag billing counts; a silent failure under-bills usage without showing up in latency or error metrics.
+
+| Region | Signal | Value | Assessment |
+| --- | --- | --- | --- |
+| {US/EU} | Seconds since last successful flush (max pod) | {Xs} | {Healthy / Drifting / Stale} |
+| {US/EU} | Unflushed requests ({window}) | {N total (cause breakdown)} | {None / Warning / Critical} |
+| {US/EU} | Flush errors ({window}) | {N (error_type breakdown)} | {None / Transient / Sustained} |
+| {US/EU} | Pending records (max / trend) | {N max, Stable/Growing} | {Healthy / Backing up} |
+| {US/EU} | Records-in vs entries-flushed | {X.XX ratio} | {Matched / Diverging} |
+| {US/EU} | Flush p99 | {Xms} | {Healthy / Tight / At-tick} |
+
+{Classify Seconds since last flush: Healthy (<30s), Drifting (30–60s), Stale (>60s). Unflushed requests: None (0), Warning (any non-zero with cause = redis_error / flush_dropped_on_error), Critical (any non-zero with cause = cap_drop / shutdown_drop — these are confirmed lost). Pending records: Healthy (drains to ~0 each tick, no trend), Backing up (sustained growth across the window). Records vs flushed ratio: Matched (0.95–1.05), Diverging (outside that band sustained). Flush p99: Healthy (<5s), Tight (5–9s), At-tick (>9s, risks overlapping next tick).}
+
+{If any signal lands in a non-healthy band, add a corresponding action item to the top of the report describing the signal, the cause/error_type breakdown, and the next step (typically: check Redis health, then inspect aggregator pod logs at the spike time).}
+
+{Omit this entire section if `flags_billing_records_total` returned no data for both regions.}
+
+## HPA Scaling Efficiency
+
+| Region | Metric | Value | Assessment |
+| --- | --- | --- | --- |
+| {US/EU} | Time at max replicas | {X%} | {OK / Elevated / Critical} |
+| {US/EU} | CPU headroom (max pod / target) | {X.XX avg, X.XX peak} | {Comfortable / Tight / Over-target} |
+| {US/EU} | Scaling events | {N} | {Stable / Moderate / Volatile} |
+
+## Warning and Error Logs
+
+Summary of warning and error log messages observed across the full reporting window.
+
+### Errors
+
+{When reporting on both regions, use sub-sections per region. For each region, list the top recurring error patterns. If no errors were logged, write: "No error-level log messages observed in this window."}
+
+| Count | Message Pattern | First Seen | Last Seen |
+| --- | --- | --- | --- |
+| {N} | `{short description of the error pattern}` | {HH:MM} UTC | {HH:MM} UTC |
+
+### Warnings
+
+{Same table shape as Errors. If no warnings were logged, write: "No warning-level log messages observed in this window."}
+
+{Cross-reference any log patterns against the anomalies identified during analysis. If a log pattern correlates with a metric spike, note it here and link to the relevant anomaly section. Promote recurring or high-volume error patterns to the Action Items section if they warrant investigation.}
+
+### Worker Task Logs
+
+{Summary of service-related error and warning messages from `posthog-worker-django` across the full reporting window, same table shape as Errors, with sub-sections per region for dual-region reports. If no worker task errors or warnings were logged, write: "No service-related worker task log messages observed in this window." Only omit this sub-section if worker log queries could not be run or no worker log datasource is available for both regions.}
+
+{Cross-reference worker error patterns against the `sync_feature_flag_last_called` success rate from the Scheduled Tasks section. If a worker error pattern correlates with a low success rate, note it and link to the relevant section. Promote high-volume worker errors to Action Items if they indicate a systemic issue.}
+
+## {Service-specific sections as appropriate}
+
+{e.g., Cache Performance, DB Connection Pool, Capacity/Limits, etc.}
+
+## Dashboard Links
+
+These links require VPN access and Cognito authentication:
+
+### US dashboards (prod-us)
+
+- [{Dashboard Name}](grafana.prod-us.posthog.dev/...)
+
+### EU dashboards (prod-eu)
+
+- [{Dashboard Name}](grafana.prod-eu.posthog.dev/...)
+
+## Data Sources
+
+{Brief description of how the data was collected}

--- a/ai/skills/quarterly-planning/SKILL.md
+++ b/ai/skills/quarterly-planning/SKILL.md
@@ -200,5 +200,3 @@ If the user confirms, write the markdown there (create the directory if needed).
 ## Notes
 
 - **Issues, not the project board.** This skill plans _new_ objectives from the issue backlog. For tracking in-flight sprint work, use `/sprint-planning` instead.
-- **Labels are configurable and fault-tolerant.** A label that doesn't exist is reported and skipped, never fatal. If `feature/feature-management` (or any label) reports `not found`, surface it — the label may have been renamed or may not exist yet.
-- **Never invent last quarter's goals.** If the page won't load, ask.

--- a/ai/skills/sprint-planning/SKILL.md
+++ b/ai/skills/sprint-planning/SKILL.md
@@ -148,16 +148,10 @@ Each item's `url` field contains the issue or PR URL. Preserve these for linking
 
 ### Step 6: First Prompt - Context
 
-Now that you have all the automated data, ask the user:
+Now that you have all the automated data, tell the user which sprint you're writing for (`{current_title}` / #{current_number}) and the team members found, then ask:
 
-> I'm writing the sprint planning update for **{current_title}** (#{current_number}).
->
-> Team members: {list from Step 2}
->
-> Quick questions before I build the draft:
->
-> 1. Who are the two support heroes this sprint? (Week 1: {sprint_start Mon-Fri}, Week 2: {following Mon-Fri})
-> 2. Is anyone off during the sprint?
+1. Who are the two support heroes this sprint? (Show the Week 1 and Week 2 Mon–Fri date ranges.)
+2. Is anyone off during the sprint?
 
 Wait for the user's response before continuing.
 
@@ -187,65 +181,26 @@ Build the retro entirely from merged PRs and project board "Done" items. Group e
 
 ### Step 8: Second Prompt - Retro Review
 
-If previous plan exists (Path A), present the reconciled retro per person:
+If previous plan exists (Path A), present the reconciled retro per person: each planned item marked ✅ with its matching PR link, or ❓ when no matching PR was found, followed by an "Unmatched PRs (side quests?)" list. Then ask:
 
-> Here's what I've reconstructed from last sprint's plan vs. what shipped:
->
-> **@member1**
->
-> - ✅ Planned item 1 → [PR title](url)
-> - ✅ Planned item 2 → [PR title](url)
-> - ❓ Planned item 3 → no matching PR found
->
-> **Unmatched PRs (side quests?):**
->
-> - [PR title](url)
->
-> Questions:
->
-> 1. For items marked ❓, what's the status? (done, in progress, blocked, cancelled)
-> 2. Which unmatched PRs should I include as side quests?
-> 3. Anything else to add or correct?
+1. For items marked ❓, what's the status? (done, in progress, blocked, cancelled)
+2. Which unmatched PRs should I include as side quests?
+3. Anything else to add or correct?
 
-If no previous plan (Path B), present merged PRs grouped by person and theme:
+If no previous plan (Path B), present merged PRs grouped by person and theme, then ask:
 
-> Here's what I found shipped during the sprint:
->
-> **@member1**
->
-> - [PR title](url)
-> - [PR title](url)
->
-> **@member2**
->
-> - [PR title](url)
->
-> Questions:
->
-> 1. Are these groupings and themes accurate?
-> 2. Anything missing that didn't result in PRs?
-> 3. Anything to exclude?
+1. Are these groupings and themes accurate?
+2. Anything missing that didn't result in PRs?
+3. Anything to exclude?
 
 Wait for the user's response.
 
 ### Step 9: Third Prompt - Plan and Objectives
 
-Present project board items as a draft plan:
+Present the project board items as a draft plan, grouped into **High priority** (per member) and **Side quests**. Then ask:
 
-> Here's the plan I've drafted from the project board:
->
-> **High priority:**
-> @member1 - item1, item2
-> @member2 - item3
->
-> **Side quests:**
->
-> - item4
->
-> Questions:
->
-> 1. Any adjustments to the plan?
-> 2. Any changes to quarter goal statuses?
+1. Any adjustments to the plan?
+2. Any changes to quarter goal statuses?
 
 Wait for the user's response.
 
@@ -273,9 +228,8 @@ Use this exact format:
 
 [Link to goals]({SPRINT_GOALS_URL})
 
-1. First quarter objective 🟡
-2. Second quarter objective ⚪
-3. … (carry the goals and statuses forward from Step 3)
+1. {Quarter objective} {status emoji}
+2. … (carry the goals and statuses forward from Step 3)
 
 <details>
 ⚪ = Not Started
@@ -287,23 +241,18 @@ Use this exact format:
 
 ## Retro
 
-Narrative summary paragraph describing the team's key accomplishments and themes from the sprint.
+{Narrative summary paragraph describing the team's key accomplishments and themes from the sprint.}
 
 <details>
 
-@member1
+@{member}
 
-**Theme name:**
-- [exact PR title](url)
-- [exact PR title](url)
+**{Theme name}:**
+- [{exact PR title}]({url})
+- [{exact PR title}]({url})
 
-**Another theme:**
-- [exact PR title](url)
-
-@member2
-
-**Theme name:**
-- [exact PR title](url)
+**{Another theme}:**
+- [{exact PR title}]({url})
 
 </details>
 
@@ -313,17 +262,13 @@ Narrative summary paragraph describing the team's key accomplishments and themes
 
 ### High priority
 
-@member1
-- [Work item description](https://github.com/PostHog/posthog/issues/123)
-- [Another work item](https://github.com/PostHog/posthog/pull/456)
-
-@member2
-- [Work item description](https://github.com/PostHog/posthog/issues/789)
+@{member}
+- [{work item description}]({issue or PR url})
 
 ### Side quests
 
-- [Side quest item](https://github.com/PostHog/posthog/issues/101)
-- Plain text item if no link available
+- [{side quest item}]({url})
+- {plain text item if no link available}
 ```
 ````
 
@@ -388,8 +333,6 @@ A member's count is `done / total planned items`.
 ```bash
 source ~/.claude/skills/sprint-planning/scripts/config.sh
 ```
-
-To run for the Feature Flags Platform team instead of the default Feature Flags team, export `SPRINT_TEAM=platform` before sourcing.
 
 ### Step S2: Detect and Select Target Sprint
 
@@ -463,24 +406,17 @@ HTML structure: a bold summary line, then per member a bold header and a `<ul>`.
 
 ```html
 <p><b>{SPRINT_TEAM_NAME}: {target_title} ({done_total}/{grand_total} done)</b></p>
-<p><b>@you: 6/10</b></p>
+<p><b>@{member}: {done}/{planned}</b></p>
 <ul>
-<li>✅ <a href="https://github.com/PostHog/posthog/pull/60550">add updated_at to Project model</a></li>
-<li>🔄 <a href="https://github.com/PostHog/posthog/pull/60569">strip non-allowlisted properties</a> (in review)</li>
-<li>⬜ <a href="https://github.com/PostHog/posthog/issues/60581">Orphaned person profiles</a></li>
-</ul>
-<p><b>@teammate: 1/8</b></p>
-<ul>
-<li>✅ <a href="...">...</a></li>
-<li>⬜ <a href="...">...</a></li>
+<li>{marker} <a href="{url}">{title}</a> {(optional status suffix)}</li>
 </ul>
 <p><i>New (not in sprint plan):</i></p>
 <ul>
-<li>🔄 <a href="...">...</a></li>
+<li>{marker} <a href="{url}">{title}</a></li>
 </ul>
 <p><b>Unassigned</b></p>
 <ul>
-<li>⬜ <a href="...">...</a></li>
+<li>{marker} <a href="{url}">{title}</a></li>
 </ul>
 ```
 
@@ -534,4 +470,3 @@ The output template in Step 10 is the authoritative format reference. These rule
 
 - **No status emojis on retro PR links**: the retro lists shipped work, so checkmarks or status indicators are not needed on individual PR entries
 - **Always include a Side quests section in the Plan**: include it even as a placeholder if there are no side quests
-- **Never post without explicit user confirmation**: always ask before running the `gh issue comment` command

--- a/ai/skills/squash/SKILL.md
+++ b/ai/skills/squash/SKILL.md
@@ -72,12 +72,7 @@ At the end, close the open run the same way.
 | `b2` | `bob@x.com` | Address review |
 | `s2` | `github-actions[bot]@x.com` | Update snapshots |
 
-The plan is:
-
-1. run(`alice@x.com`: `a1`, `a2`) — `s1` does not break alice's run
-2. snapshot `s1`
-3. run(`bob@x.com`: `b1`, `b2`)
-4. snapshot `s2`
+The plan is: run(`alice@x.com`: `a1`, `a2`) — `s1` does not break alice's run — then snapshot `s1`, run(`bob@x.com`: `b1`, `b2`), snapshot `s2`. Step 5's Path B shows the rebase todo this plan produces.
 
 **Stop conditions — report and exit without making any changes:**
 
@@ -86,11 +81,9 @@ The plan is:
 
 ### 4. Compose the Squash Messages
 
-For each run with two or more commits, write a present-tense imperative subject line (≤72 chars) that describes the final state of that run's changes, based on that run's commit messages. Runs with a single commit keep their original message.
+For each run with two or more commits, write a subject line (≤72 chars) for that run's combined changes, based on that run's commit messages and following the commit-message conventions in CLAUDE.md. Runs with a single commit keep their original message.
 
 If `message_hint` is non-empty, use it verbatim as the subject of the squashed run authored by `MY_EMAIL`. If multiple of your runs are being squashed, apply it to the one with the most commits and compose subjects for the rest. If none of your runs are being squashed, ignore the hint.
-
-Never mention AI, Claude, or LLMs anywhere in any message. No co-authorship lines.
 
 Number the squashed runs 1, 2, … in plan order and write each message to `/tmp/squash-msg-<n>.txt`.
 

--- a/ai/skills/standup/SKILL.md
+++ b/ai/skills/standup/SKILL.md
@@ -60,6 +60,15 @@ If `status` is "new", set `cutoff` to `last_standup_date` (date only).
 
 **Only include PRs from `PostHog/*` repos.** Personal repos (e.g. `haacked/*`) are excluded; standup is a PostHog work update, and personal tooling work isn't relevant to teammates. The `org:PostHog` qualifier in the search queries enforces this.
 
+**Batched PR lookups:** wherever a step below needs per-PR state from `gh pr view`, batch all the PRs into one Bash loop rather than one call per PR:
+
+```bash
+for pr in "owner/repo#number" "owner/repo#number"; do
+  repo="${pr%%#*}"; num="${pr##*#}"
+  echo -e "$repo#$num\t$(gh pr view "$num" --repo "$repo" --json {fields} --jq '{filter}')"
+done
+```
+
 **Completed and Side-quest PRs** (merged since the cutoff from Step 2):
 
 ```bash
@@ -76,14 +85,7 @@ Note: `gh search prs --merged` is unreliable for date filtering; it returns stal
 gh api search/issues --method GET -f q="org:PostHog is:pr is:merged merged:>=${cutoff} involves:haacked -author:haacked" --jq '.items[] | {number, title, url: .html_url, repo: (.repository_url | sub(".*/repos/"; "")), author: .user.login, merged_at: .pull_request.merged_at}'
 ```
 
-GitHub search has no merged-by qualifier, so verify each result in one Bash call and keep only PRs where `mergedBy` is haacked (drop the rest — PRs you merely reviewed or commented on, then the author merged themselves):
-
-```bash
-for pr in "owner/repo#number" "owner/repo#number"; do
-  repo="${pr%%#*}"; num="${pr##*#}"
-  echo -e "$repo#$num\t$(gh pr view "$num" --repo "$repo" --json mergedBy --jq '.mergedBy.login')"
-done
-```
+GitHub search has no merged-by qualifier, so batch-verify each result (`--json mergedBy --jq '.mergedBy.login'`) and keep only PRs where `mergedBy` is haacked (drop the rest — PRs you merely reviewed or commented on, then the author merged themselves).
 
 Route the surviving PRs by author: bot-authored (login ends in `[bot]`) to **Agent-authored (reviewed & landed by me)**, human-authored to **Shepherded (external PRs I reviewed & merged)**. Neither goes in Completed. Combine each docs follow-up with the code PR it documents. Caveat: `involves:` requires authorship, assignment, a mention, or a comment; a bot PR merged without ever commenting on it won't match. If one seems missing, retry the search with `reviewed-by:haacked` in place of `involves:haacked`.
 
@@ -93,14 +95,7 @@ Route the surviving PRs by author: bot-authored (login ends in `[bot]`) to **Age
 gh api search/issues --method GET -f q="author:haacked org:PostHog is:pr is:open" --jq '.items[] | {number, title, url: .html_url, repo: (.repository_url | sub(".*/repos/"; "")), draft: .draft, updatedAt: .updated_at}'
 ```
 
-Note: This single query replaces per-repo `gh pr list` calls and also covers the "recently updated" signal via `updatedAt`. Filter to items updated since `last_standup_date` to identify PRs with recent activity. Route core (feature-flags domain) open PRs to **Working on**; route non-core open PRs to **Side quests** with state **In progress**. The search API does not return review requests; for non-draft open PRs, fetch them in one Bash call:
-
-```bash
-for pr in "owner/repo#number" "owner/repo#number"; do
-  repo="${pr%%#*}"; num="${pr##*#}"
-  echo -e "$repo#$num\t$(gh pr view "$num" --repo "$repo" --json reviewRequests --jq '[.reviewRequests[].login] | join(",")')"
-done
-```
+Note: This single query replaces per-repo `gh pr list` calls and also covers the "recently updated" signal via `updatedAt`. Filter to items updated since `last_standup_date` to identify PRs with recent activity. Route core (feature-flags domain) open PRs to **Working on**; route non-core open PRs to **Side quests** with state **In progress**. The search API does not return review requests; for non-draft open PRs, batch-fetch them (`--json reviewRequests --jq '[.reviewRequests[].login] | join(",")'`).
 
 ### Step 4: Compose and Save Standup Notes
 
@@ -135,16 +130,7 @@ Build standup content and produce two outputs: a plain text archive file and HTM
 **Working on items:**
 
 - Include core (feature-flags domain) open PRs with recent activity
-- Carry over items from the previous standup's "Working on", but verify each one first. For all carried-over PR URLs, check their state in one Bash call:
-
-```bash
-for pr in "owner/repo#number" "owner/repo#number"; do
-  repo="${pr%%#*}"; num="${pr##*#}"
-  echo -e "$repo#$num\t$(gh pr view "$num" --repo "$repo" --json state,mergedAt --jq '[.state, (.mergedAt // "")] | @tsv')"
-done
-```
-
-Then apply these rules to each row:
+- Carry over items from the previous standup's "Working on", but verify each one first: batch-fetch the state of all carried-over PR URLs (`--json state,mergedAt --jq '[.state, (.mergedAt // "")] | @tsv'`), then apply these rules to each row:
 
 - If **MERGED** since last standup: move to Completed (deduplicate by PR number; carry-over is the safety net for PRs the merged search may miss)
 - If **CLOSED**: drop it entirely
@@ -168,83 +154,13 @@ Then apply these rules to each row:
 - Default to a playful "nothing" variant
 - Rotate between: "Nothing", "Nada", "Ain't got a thing", "Zilch", "Not a thing", "All quiet on the western front"
 
-#### Plain Text File
+#### Render Both Outputs
 
-Write to `new_file_path` for archival. Every item is a plain line. URLs appear in parentheses after the description.
-
-```text
-Completed:
-Added `getFeatureFlagResult` method for efficient flag + payload retrieval (https://github.com/PostHog/posthog-js/pull/2920)
-Added bin scripts for setup, build, and test (https://github.com/PostHog/posthog-js/pull/2824)
-Added keep-first dedup for `$feature_flag_called` events (https://github.com/PostHog/posthog/pull/62793) with dedicated redis (https://github.com/PostHog/charts/pull/12362) (shadowed it (https://github.com/PostHog/charts/pull/12370) and then turned it on for team 211871 (https://github.com/PostHog/charts/pull/12428))
-
-Agent-authored (reviewed & landed by me):
-Matched mobile app versions in semver flag conditions (https://github.com/PostHog/posthog/pull/69118) with docs (https://github.com/PostHog/posthog.com/pull/18438)
-Stopped stale parent prop from resetting rollout to 0% (https://github.com/PostHog/posthog/pull/68484)
-
-Shepherded (external PRs I reviewed & merged):
-Bulk copy flags to other projects from the flags list (by @rubychilds) (https://github.com/PostHog/posthog/pull/69044)
-
-Working on:
-Simplify readiness probe to prevent cascade failures (https://github.com/PostHog/posthog/pull/46589 - draft)
-Add source field to feature flag created analytics (https://github.com/PostHog/posthog/pull/46782 - needs review)
-Add HyperCache support to flag definitions cache (https://github.com/PostHog/posthog/pull/44701 - needs review)
-Completing migration of celery tasks to dedicated flags queue
-
-Side quests:
-Resolved worktree path from stored value, not derived from name (Completed) (https://github.com/PostHog/code/pull/2709)
-Add retry helper to the deploy script (In progress) (https://github.com/PostHog/code/pull/2741)
-
-Discussion:
-Zilch
-```
-
-#### HTML for Clipboard
-
-Every section uses `<p><b>Header:</b></p>` followed by `<ul>`. Every item, without exception, is an `<li>` inside the `<ul>`, regardless of whether it contains a link.
-
-```html
-<p><b>Completed:</b></p>
-<ul>
-<li><a href="https://github.com/PostHog/posthog-js/pull/2920">Added <code>getFeatureFlagResult</code> method for efficient flag + payload retrieval</a></li>
-<li><a href="https://github.com/PostHog/posthog-js/pull/2824">Added bin scripts for setup, build, and test</a></li>
-<li><a href="https://github.com/PostHog/posthog/pull/62793">Added keep-first dedup for <code>$feature_flag_called</code> events</a> with <a href="https://github.com/PostHog/charts/pull/12362">dedicated redis</a> (<a href="https://github.com/PostHog/charts/pull/12370">shadowed it</a> and then turned it <a href="https://github.com/PostHog/charts/pull/12428">on for team 211871</a>)</li>
-</ul>
-<p><b>Agent-authored (reviewed &amp; landed by me):</b></p>
-<ul>
-<li><a href="https://github.com/PostHog/posthog/pull/69118">Matched mobile app versions in semver flag conditions</a> with <a href="https://github.com/PostHog/posthog.com/pull/18438">docs</a></li>
-<li><a href="https://github.com/PostHog/posthog/pull/68484">Stopped stale parent prop from resetting rollout to 0%</a></li>
-</ul>
-<p><b>Shepherded (external PRs I reviewed &amp; merged):</b></p>
-<ul>
-<li><a href="https://github.com/PostHog/posthog/pull/69044">Bulk copy flags to other projects from the flags list</a> (by @rubychilds)</li>
-</ul>
-<p><b>Working on:</b></p>
-<ul>
-<li>Simplify readiness probe to prevent cascade failures (<a href="https://github.com/PostHog/posthog/pull/46589">draft</a>)</li>
-<li>Add source field to feature flag created analytics (<a href="https://github.com/PostHog/posthog/pull/46782">needs review</a>)</li>
-<li>Add HyperCache support to flag definitions cache (<a href="https://github.com/PostHog/posthog/pull/44701">needs review</a>)</li>
-<li>Completing migration of celery tasks to dedicated flags queue</li>
-</ul>
-<p><b>Side quests:</b></p>
-<ul>
-<li><a href="https://github.com/PostHog/code/pull/2709">Resolved worktree path from stored value, not derived from name</a> (Completed)</li>
-<li><a href="https://github.com/PostHog/code/pull/2741">Add retry helper to the deploy script</a> (In progress)</li>
-</ul>
-<p><b>Discussion:</b></p>
-<ul>
-<li>Zilch</li>
-</ul>
-```
-
-Copy to clipboard using the shared helper script:
+Read `~/.claude/skills/standup/templates/standup-output.md` and render the content into both skeletons: the plain text version written to `new_file_path` for archival, and the HTML version copied to the clipboard with the shared helper script:
 
 ```bash
 swift ~/.dotfiles/bin/copy-html-to-clipboard.swift <<'EOF'
-<p><b>Completed:</b></p>
-<ul>
-<li>...</li>
-</ul>
+{generated HTML}
 EOF
 ```
 

--- a/ai/skills/standup/templates/standup-output.md
+++ b/ai/skills/standup/templates/standup-output.md
@@ -1,0 +1,64 @@
+# Standup Output Skeletons
+
+Both outputs carry the same content. Sections appear in this order: Completed, Agent-authored, Shepherded, Working on, Side quests, Discussion; omit optional sections (Agent-authored, Shepherded, Side quests) entirely when empty.
+
+## Plain text archive file
+
+Every item is a plain line. URLs appear in parentheses immediately after the phrase they belong to.
+
+```text
+Completed:
+{Past-tense description with `code names` in backticks} ({PR URL})
+{Combined entry: primary description} ({primary PR URL}) with {woven phrase} ({related PR URL}) ({sequential follow-up} ({URL}) and then {another follow-up} ({URL}))
+
+Agent-authored (reviewed & landed by me):
+{Description} ({PR URL}) with docs ({docs PR URL})
+
+Shepherded (external PRs I reviewed & merged):
+{Description} (by @{handle}) ({PR URL})
+
+Working on:
+{Description} ({PR URL} - draft)
+{Description} ({PR URL} - needs review)
+{Non-PR work item, plain text, no URL}
+
+Side quests:
+{Description} ({In progress | Completed}) ({PR URL})
+
+Discussion:
+{Playful "nothing" variant}
+```
+
+## HTML for clipboard
+
+Every section uses `<p><b>Header:</b></p>` followed by `<ul>`. Every item, without exception, is an `<li>` inside the `<ul>`, regardless of whether it contains a link. In combined entries each woven phrase is its own `<a>`. Use `<code>` for method/code names and HTML-escape `&`, `<`, `>`.
+
+```html
+<p><b>Completed:</b></p>
+<ul>
+<li><a href="{PR URL}">{Past-tense description with <code>code names</code>}</a></li>
+<li><a href="{primary PR URL}">{combined entry: primary description}</a> with <a href="{related PR URL}">{woven phrase}</a> (<a href="{URL}">{sequential follow-up}</a> and then <a href="{URL}">{another follow-up}</a>)</li>
+</ul>
+<p><b>Agent-authored (reviewed &amp; landed by me):</b></p>
+<ul>
+<li><a href="{PR URL}">{Description}</a> with <a href="{docs PR URL}">docs</a></li>
+</ul>
+<p><b>Shepherded (external PRs I reviewed &amp; merged):</b></p>
+<ul>
+<li><a href="{PR URL}">{Description}</a> (by @{handle})</li>
+</ul>
+<p><b>Working on:</b></p>
+<ul>
+<li>{Description} (<a href="{PR URL}">draft</a>)</li>
+<li>{Description} (<a href="{PR URL}">needs review</a>)</li>
+<li>{Non-PR work item, no link}</li>
+</ul>
+<p><b>Side quests:</b></p>
+<ul>
+<li><a href="{PR URL}">{Description}</a> ({In progress | Completed})</li>
+</ul>
+<p><b>Discussion:</b></p>
+<ul>
+<li>{Playful "nothing" variant}</li>
+</ul>
+```

--- a/ai/skills/support/SKILL.md
+++ b/ai/skills/support/SKILL.md
@@ -27,6 +27,12 @@ Parse the user's args:
 
 If required arguments are missing for the chosen mode, ask the user before proceeding.
 
+## Ticket URLs
+
+- Zendesk: `https://posthoghelp.zendesk.com/agent/tickets/{number}`
+- GitHub: `https://github.com/PostHog/posthog/issues/{number}`
+- Tickets that exist only in Slack: use the Slack thread URL
+
 ---
 
 ## Investigation Mode
@@ -58,10 +64,7 @@ fi
 
 ### Step 3 — Initialize and confirm
 
-If new, create `notes.md` from `templates/investigation-notes.md`. Construct the ticket URL as:
-
-- Zendesk: `https://posthoghelp.zendesk.com/agent/tickets/{number}`
-- GitHub: `https://github.com/PostHog/posthog/issues/{number}`
+If new, create `notes.md` from `templates/investigation-notes.md`, constructing the ticket URL per the Ticket URLs section above.
 
 Tell the user where notes live and the ticket URL, then ask them to describe the issue. Continue the investigation using systematic debugging and documentation practices.
 
@@ -108,7 +111,7 @@ The script outputs Monday, Friday, and the directory path tab-separated. Default
 The week directory contains one subdirectory per ticket investigation, plus occasionally loose `.md` files. Read every `notes.md` (or top-level `summary.md` / `<ticket>.md` file). Pull from each:
 
 - Customer or company name
-- Ticket URL (use the existing `Ticket URL:` field if present, otherwise reconstruct: Zendesk → `https://posthoghelp.zendesk.com/agent/tickets/{number}`, GitHub → `https://github.com/PostHog/posthog/issues/{number}`; for tickets that exist only in Slack, use the Slack thread URL)
+- Ticket URL (use the existing `Ticket URL:` field if present, otherwise reconstruct per the Ticket URLs section above)
 - Symptom — what the customer reported
 - Root cause in plain English
 - What you did (recommendation, fix, handoff)
@@ -117,64 +120,11 @@ The week directory contains one subdirectory per ticket investigation, plus occa
 
 ### Step 3 — Compose the log
 
-Use this exact format. The user pastes this into Slack, so links use Slack syntax `<URL|name>`.
-
-```text
-Highlights for MM/DD/YY - MM/DD/YY
-
-<TICKET_URL|Customer Name>: <one-paragraph summary>. (Status)
-
-<TICKET_URL|Next Customer>: …
-```
-
-### Format rules
-
-- **Heading date range is Mon–Fri only.** Use the `monday` and `friday` from Step 1, formatted `MM/DD/YY - MM/DD/YY`. The support hero rotation runs Mon–Fri; weekend dates don't belong here.
-- **Customer name** wraps in Slack link syntax: `<URL|Name>`. URL is the ticket URL or Slack thread URL.
-- **GitHub issue links filed this week** go inline as raw URLs (not Slack-linked). Example: `Filed https://github.com/PostHog/posthog/issues/55410 to fix X.`
-- **Status** in trailing parens: `(Resolved)`, `(Pending)`, `(Unresolved, Pending)`, `(Pending, To close after deployed)`, `(Closed, no action needed)`. Add a short qualifier when useful.
-- **Tone: plain English, very high level.** Two to three short sentences per entry. Sound like a person describing the week to a colleague, not a postmortem.
-- **Skip specific numbers unless the number IS the story.** "Each poll bills 10x" matters; "posthog-node/4.11.1 polling from two UK BT IPs" doesn't. Drop SDK version strings, IP addresses, exact event counts, process counts.
-- **Skip operational/alert response entries** (e.g., infra alerts you handled) unless the user explicitly asks. Those aren't customer support tickets.
-- **Skip already-resolved-prior-to-this-week items** (e.g., SDK bug fixed in a shipped version before the week started) unless they're load-bearing context.
-- **Skip code snippets, file paths, ClickHouse queries.** Just the gist.
-- **Order entries by ticket number ascending** when both are Zendesk; otherwise group Zendesk first then non-Zendesk (Slack threads, internal escalations).
-
-### Status tag reference
-
-- `(Pending)` — waiting on customer response or follow-up action
-- `(Pending, To close after deployed)` — fix submitted, waiting for deployment
-- `(Pending, awaiting customer guidance)` — solution proposed, customer needs to choose
-- `(Unresolved, Pending)` — still investigating or blocked
-- `(Resolved)` — confirmed fixed
-- `(Closed, no action needed)` — not a bug, expected behavior explained
+Read `~/.claude/skills/support/references/log-format.md` and compose the log following its skeleton, format rules, and status tags.
 
 ### Step 4 — Write and offer to copy
 
-Save the log to `~/dev/ai/support/HIGHLIGHTS-{monday}.md`. Then ask the user whether to copy to the clipboard. Two options when they say yes:
-
-**Plain text (default — for Slack):**
-
-```bash
-pbcopy < ~/dev/ai/support/HIGHLIGHTS-{monday}.md
-```
-
-The `<URL|name>` syntax renders as clickable links in Slack on paste.
-
-**RTF (for rich-text editors like Notion, email, docs):**
-
-Build a parallel HTML file with proper `<a href>` tags (replacing each `<URL|name>` with `<a href="URL">name</a>` and wrapping each entry in `<p>…</p>`). Then:
-
-```bash
-textutil -convert rtf -stdout /tmp/weekly-log.html > /tmp/weekly-log.rtf
-osascript <<'EOF'
-set rtfData to read (POSIX file "/tmp/weekly-log.rtf") as «class RTF »
-set plainText to do shell script "textutil -convert txt -stdout /tmp/weekly-log.html"
-set the clipboard to {Unicode text:plainText, «class RTF »:rtfData}
-EOF
-```
-
-Setting both `Unicode text` and `«class RTF »` is required — RTF-only clipboards don't paste in many apps.
+Save the log to `~/dev/ai/support/HIGHLIGHTS-{monday}.md`. Then offer to copy it to the clipboard using the plain-text or RTF procedure in the format reference.
 
 ---
 

--- a/ai/skills/support/references/log-format.md
+++ b/ai/skills/support/references/log-format.md
@@ -1,0 +1,60 @@
+# Weekly Highlights Log Format
+
+The user pastes the log into Slack, so links use Slack link syntax `<URL|name>`. The skeleton lives in `templates/weekly-log.txt`:
+
+```text
+Highlights for MM/DD/YY - MM/DD/YY
+
+<TICKET_URL|Customer Name>: <one-paragraph summary>. (Status)
+
+<TICKET_URL|Next Customer>: …
+```
+
+## Format rules
+
+- **Heading date range is Mon–Fri only.** Use the `monday` and `friday` from the week-resolution step, formatted `MM/DD/YY - MM/DD/YY`. The support hero rotation runs Mon–Fri; weekend dates don't belong here.
+- **Customer name** wraps in Slack link syntax: `<URL|Name>`. URL is the ticket URL or Slack thread URL.
+- **GitHub issue links filed this week** go inline as raw URLs (not Slack-linked). Example: `Filed https://github.com/PostHog/posthog/issues/55410 to fix X.`
+- **Status** in trailing parens: `(Resolved)`, `(Pending)`, `(Unresolved, Pending)`, `(Pending, To close after deployed)`, `(Closed, no action needed)`. Add a short qualifier when useful.
+- **Tone: plain English, very high level.** Two to three short sentences per entry. Sound like a person describing the week to a colleague, not a postmortem.
+- **Skip specific numbers unless the number IS the story.** "Each poll bills 10x" matters; "posthog-node/4.11.1 polling from two UK BT IPs" doesn't. Drop SDK version strings, IP addresses, exact event counts, process counts.
+- **Skip operational/alert response entries** (e.g., infra alerts you handled) unless the user explicitly asks. Those aren't customer support tickets.
+- **Skip already-resolved-prior-to-this-week items** (e.g., SDK bug fixed in a shipped version before the week started) unless they're load-bearing context.
+- **Skip code snippets, file paths, ClickHouse queries.** Just the gist.
+- **Order entries by ticket number ascending** when both are Zendesk; otherwise group Zendesk first then non-Zendesk (Slack threads, internal escalations).
+
+## Status tag reference
+
+- `(Pending)` — waiting on customer response or follow-up action
+- `(Pending, To close after deployed)` — fix submitted, waiting for deployment
+- `(Pending, awaiting customer guidance)` — solution proposed, customer needs to choose
+- `(Unresolved, Pending)` — still investigating or blocked
+- `(Resolved)` — confirmed fixed
+- `(Closed, no action needed)` — not a bug, expected behavior explained
+
+## Copying to the clipboard
+
+Ask the user whether to copy to the clipboard. Two options when they say yes:
+
+**Plain text (default — for Slack):**
+
+```bash
+pbcopy < ~/dev/ai/support/HIGHLIGHTS-{monday}.md
+```
+
+The `<URL|name>` syntax renders as clickable links in Slack on paste.
+
+**RTF (for rich-text editors like Notion, email, docs):**
+
+Build a parallel HTML file with proper `<a href>` tags (replacing each `<URL|name>` with `<a href="URL">name</a>` and wrapping each entry in `<p>…</p>`). Then:
+
+```bash
+textutil -convert rtf -stdout /tmp/weekly-log.html > /tmp/weekly-log.rtf
+osascript <<'EOF'
+set rtfData to read (POSIX file "/tmp/weekly-log.rtf") as «class RTF »
+set plainText to do shell script "textutil -convert txt -stdout /tmp/weekly-log.html"
+set the clipboard to {Unicode text:plainText, «class RTF »:rtfData}
+EOF
+```
+
+Setting both `Unicode text` and `«class RTF »` is required — RTF-only clipboards don't paste in many apps.

--- a/ai/skills/support/templates/weekly-log.txt
+++ b/ai/skills/support/templates/weekly-log.txt
@@ -1,0 +1,5 @@
+Highlights for MM/DD/YY - MM/DD/YY
+
+<TICKET_URL|Customer Name>: <one-paragraph summary>. (Status)
+
+<TICKET_URL|Next Customer>: …

--- a/ai/skills/test-plan/SKILL.md
+++ b/ai/skills/test-plan/SKILL.md
@@ -98,7 +98,7 @@ Skip these (usually already asserted in code):
 
 Produce a flat GFM checklist where each item is a single line:
 
-```
+```text
 - [ ] <Title>: <Action>. <Action>. <Verification>.
 ```
 
@@ -109,14 +109,10 @@ Produce a flat GFM checklist where each item is a single line:
 - Name concrete identifiers from the code verbatim: cache keys (e.g. `posthog:auth_token:<sha256>`), table names, env vars, metric names, header names, redis prefixes, signal names, token prefixes (`phs_`, `phx_`), enum values
 - Cover both positive cases ("triggers", "sets", "is present") and negative cases ("does NOT trigger", "is NOT deleted", "remains unchanged")
 
-**Examples in the target style:**
+**Example in the target style:**
 
-```
+```text
 - [ ] Cache readthrough: Clear Redis. Make request to /flags. Confirm 200 response. Check Redis for key `posthog:flags:<team_id>`.
-- [ ] Cache hit: After readthrough, make a second /flags request. Confirm logs show `flag_cache_hit` and DB query count is unchanged.
-- [ ] Cache invalidation on token rotation: Rotate the team's secret API token. Confirm the old token's `posthog:auth_token:<sha256>` entry is gone from Redis.
-- [ ] No invalidation on unrelated edit: Update the team's name. Confirm `posthog:flags:<team_id>` is still present.
-- [ ] Forwarded IP respected: Send request with `X-Forwarded-For: 1.2.3.4`. Confirm rate-limit counter for `1.2.3.4` increments, not the load balancer's IP.
 ```
 
 **Avoid:**

--- a/ai/skills/triage-issues/SKILL.md
+++ b/ai/skills/triage-issues/SKILL.md
@@ -109,7 +109,7 @@ triage-flags-pr-candidates --days {days}
 
 It prints a JSON array on stdout, one object per PR: `{"number": 123, "title": "…", "author": "…", "isDraft": false, "paths": ["…"]}`. The `paths` are the specific flags-domain files each PR touched — carry them forward as the file-path signal for the subagent (do not re-fetch files for these). If it prints `[]`, there are no internal candidates.
 
-Then drop any candidate that is a draft (`isDraft: true`) and authored by a non-team-member (login not in the Step 1b roster): a WIP PR from another team that merely brushes flags is not ready to route. Keep draft PRs authored by team members (they surface report-only in the digest, never labeled) and all non-draft candidates.
+Then drop any candidate that is a draft (`isDraft: true`) and authored by a non-team-member (login not in the Step 1b roster), per the same rule as Step 3. Keep draft PRs authored by team members (they surface report-only in the digest, never labeled) and all non-draft candidates.
 
 ### Step 3c: Early Exit
 
@@ -156,7 +156,7 @@ Labeling, by item type:
 - **Issues and external PRs**: apply labels to HIGH-confidence candidates only; never label MEDIUM or LOW.
 - **Internal PRs (Step 3b)**: apply labels to HIGH-confidence candidates that are ready for review (not draft); never label MEDIUM or LOW, and never label a draft.
 
-Draft PRs never get a label, because a draft is not ready to route. Non-team-members' drafts were already dropped in Steps 3 and 3b, so the only drafts that reach this step are team members' own work: report them in the drafts section of the digest so the team sees them in flight, but do not label them. They get labeled on a later run once they are marked ready for review.
+Non-team-members' drafts were already dropped in Steps 3 and 3b, so the only drafts that reach this step are team members' own work: report them in the drafts section of the digest so the team sees them in flight, but do not label them. They get labeled on a later run once they are marked ready for review.
 
 Title renames (Step 4) apply in both modes without a separate prompt, since the scope match is mechanical and needs no confidence gating. In interactive mode they are part of what the user approves via "all"; they apply to internal PRs too. Do not rename a PR that was dropped as a non-team-member draft in Steps 3 or 3b: leave WIP from other teams untouched until it is ready. If a label application or rename fails, note it in the digest and continue without retrying. Then emit a Slack-friendly digest as your final output:
 


### PR DESCRIPTION
Splits ops-report and support into a lightweight SKILL.md plus templates/ and references/ files, so the report skeleton, capacity checks, and log format load only when that step actually runs.

Replaces fully worked examples in sprint-planning, standup, create-pr, test-plan, and quarterly-planning with placeholder schemas, so the model gets the format shape without fabricated content narrowing its output.

Drops instructions that duplicate `~/.claude/CLAUDE.md` (commit message conventions, attribution rules) or repeat within the same skill, such as address-pr-reviews' human-reply rule, which appeared three times and now appears once.

## Test plan

- [ ] `npx markdownlint-cli` passes on every changed skill file
- [ ] Run `/ops-report`, `/support log`, and `/standup` and confirm each reads its new templates/references file correctly
- [ ] Compare metric names and `gh` commands between the old and new ops-report and support files to confirm no domain knowledge was dropped

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*