### PR TITLE
Fix sprint detection when the title omits the dash

### DIFF
--- a/ai/skills/sprint-planning/SKILL.md
+++ b/ai/skills/sprint-planning/SKILL.md
@@ -392,7 +392,9 @@ Returns a JSON array with `state`, `isDraft`, `stateReason`, and `title` per URL
 
 ### Step S7: Render and Copy
 
-**Slack mode**: if `slack` was passed as a second argument, skip the HTML and clipboard entirely. Render the same content as Slack markdown and emit it as your final output: a single-asterisk `*bold*` summary line, then per member a `*@handle: x/y*` line followed by `-` bullets with the marker emoji, linked title, and optional status suffix in parentheses. Skip Step S8.
+**Slack mode**: if `slack` was passed as a second argument, skip the HTML and clipboard entirely. Render the same content as **standard** markdown and emit it as your final output: a `**bold**` summary line, then per member a `**@handle: x/y**` line followed by `-` bullets with the marker emoji, `[title](url)` link, and optional status suffix in parentheses. Skip Step S8.
+
+The Slack MCP tool converts standard markdown to Slack's mrkdwn on the way out, so single-asterisk `*bold*` arrives as _italic_. Always use `**bold**`.
 
 Otherwise, build the HTML below and copy it with the shared helper, which sets the `public.html` clipboard flavor that Slack reads:
 

--- a/ai/skills/sprint-planning/scripts/parse-sprints.py
+++ b/ai/skills/sprint-planning/scripts/parse-sprints.py
@@ -42,12 +42,15 @@ def parse_date(s, reference_year):
 def parse_sprint_dates(title, today):
     """Parse 'Sprint - Feb 23 to March 8' into (start_date, end_date).
 
+    The separator after "Sprint" is optional because whoever opens the sprint
+    issue may title it "Sprint Feb 23 to March 8" instead.
+
     The title rarely includes the year, so we try candidate years and pick
     the range closest to today. This handles Dec-to-Jan sprints correctly: if
     today is Jan 2026, "Dec 30 to Jan 13" should resolve to 2025-12-30 through
     2026-01-13 rather than 2026-12-30 through 2027-01-13.
     """
-    m = re.match(r"Sprint\s*-\s*(.+?)\s+to\s+(.+)", title, re.IGNORECASE)
+    m = re.match(r"Sprint\b\s*[-–—:]?\s*(.+?)\s+to\s+(.+)", title, re.IGNORECASE)
     if not m:
         return None, None
 

--- a/ai/skills/sprint-planning/scripts/test_parse_sprints.py
+++ b/ai/skills/sprint-planning/scripts/test_parse_sprints.py
@@ -80,6 +80,31 @@ def test_parse_sprint_dates_case_insensitive():
     assert end == date(2026, 2, 23)
 
 
+def test_parse_sprint_dates_without_separator():
+    """Sprint issues are titled both 'Sprint - Feb 10 …' and 'Sprint Feb 10 …'."""
+    start, end = parse_sprint_dates("Sprint Feb 10 to Feb 23", date(2026, 2, 15))
+    assert start == date(2026, 2, 10)
+    assert end == date(2026, 2, 23)
+
+
+def test_parse_sprint_dates_en_dash_separator():
+    start, end = parse_sprint_dates("Sprint – Feb 10 to Feb 23", date(2026, 2, 15))
+    assert start == date(2026, 2, 10)
+    assert end == date(2026, 2, 23)
+
+
+def test_parse_sprint_dates_colon_separator():
+    start, end = parse_sprint_dates("Sprint: Feb 10 to Feb 23", date(2026, 2, 15))
+    assert start == date(2026, 2, 10)
+    assert end == date(2026, 2, 23)
+
+
+def test_parse_sprint_dates_ignores_sprint_prefixed_word():
+    start, end = parse_sprint_dates("Sprinting Feb 10 to Feb 23", date(2026, 2, 15))
+    assert start is None
+    assert end is None
+
+
 # --- select_sprints ---
 
 


### PR DESCRIPTION
The sprint status posted to #team-feature-flags on July 31 showed the previous sprint. The current sprint issue is titled "Sprint July 27 to August 7", with no dash after "Sprint", and the title parser required one. That issue parsed to nothing and was dropped, so detection fell back to the newest title it could parse.

- `parse-sprints.py` treats the separator after "Sprint" as optional, accepting a hyphen, en dash, em dash, colon, or nothing at all. The `\b` keeps it from matching words like "Sprinting".
- Slack mode in `SKILL.md` now specifies standard markdown. The Slack MCP tool converts markdown on send, so the single-asterisk bold the skill used to prescribe arrived as italic.

Titles that use a dash instead of "to" as the range separator, like "Sprint - March 23 - April 5" (PostHog/posthog#51424), still parse to nothing and get skipped the same way. Old enough not to affect detection today, but it's the same failure.

**Test plan:**

- `python3 -m pytest ai/skills/sprint-planning/scripts/test_parse_sprints.py` passes, 21 tests. Four are new: no separator, en dash, colon, and a guard that "Sprinting Feb 10 to Feb 23" still does not match.
- `~/.claude/skills/sprint-planning/scripts/detect-sprint.sh` returns `72561 Sprint July 27 to August 7`. Before the fix it returned `69142 Sprint - July 13 to July 24`.