### PR TITLE
Stop stalled SSH agents and key files from hanging git commit

### DIFF
--- a/bin/git-signing-key
+++ b/bin/git-signing-key
@@ -30,7 +30,8 @@ mode=$("$bin_dir/ssh-agent-sync") || mode="none"
 if [[ "$mode" == "forwarded" ]]; then
   # Bounded because a forwarded agent whose SSH transport stalled accepts the
   # connection but never answers, which hangs the commit here with no output.
-  # `env` rather than a prefix assignment: those persist past a function call.
+  # `env` rather than a prefix assignment, which would scope the variable to
+  # run_bounded (a shell function) rather than to ssh-add itself.
   forwarded_key=$(run_bounded 2 env SSH_AUTH_SOCK="$sock" ssh-add -L | head -1) || true
   # ssh-add -L prints "The agent has no identities." to stdout (not stderr)
   # and exits 1 when the agent is empty, so a bare non-empty check would
@@ -43,10 +44,8 @@ fi
 
 local_signing_key=$(git config --global --includes --get user.localSigningKey 2>/dev/null) || local_signing_key=""
 
-# A literal key needs no file open, removing one of the ways a wedged path can
-# stall a commit. It doesn't make committing hang-proof on its own: the agent
-# probe above is still unbounded. git-config(1) documents both the key:: form
-# and the older unprefixed one.
+# A literal key needs no file open, so the common case touches no filesystem at
+# all. git-config(1) documents both the key:: form and the older unprefixed one.
 if [[ "$local_signing_key" == key::* ]]; then
   printf '%s\n' "$local_signing_key"
   exit 0
@@ -55,9 +54,10 @@ elif is_key_literal "$local_signing_key"; then
   exit 0
 fi
 
-# -e rather than -f: whether the path is a regular file says nothing about
-# whether opening it will return, so let the bounded read be the judge.
-if [[ -n "$local_signing_key" && -e "$local_signing_key" ]]; then
+# No existence test first: [[ -e ]] calls stat(2), which blocks on a wedged
+# mount exactly like open(2) does, so testing would hang before the bounded read
+# ever ran. cat reports a missing path as a failure, which lands just below.
+if [[ -n "$local_signing_key" ]]; then
   if key_text=$(run_bounded 2 cat "$local_signing_key") && [[ -n "$key_text" ]]; then
     printf 'key::%s\n' "$key_text"
     exit 0

--- a/bin/git-signing-key
+++ b/bin/git-signing-key
@@ -12,6 +12,15 @@ set -euo pipefail
 
 sock="$HOME/.ssh/agent.sock"
 bin_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=bin/lib/bounded.sh
+source "$bin_dir/lib/bounded.sh"
+
+# The set of prefixes that mark a value as a literal public key rather than a
+# path or a message. Shared by the forwarded-agent and local-config paths so
+# the two can't drift apart on what counts as a key.
+is_key_literal() {
+  [[ $1 == ssh-* || $1 == ecdsa-* || $1 == sk-* ]]
+}
 
 # A healing hiccup (e.g. a transient mkdir/ln failure) shouldn't block local
 # signing, which doesn't depend on the socket at all, so a failure here
@@ -19,20 +28,42 @@ bin_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 mode=$("$bin_dir/ssh-agent-sync") || mode="none"
 
 if [[ "$mode" == "forwarded" ]]; then
-  forwarded_key=$(SSH_AUTH_SOCK="$sock" ssh-add -L 2>/dev/null | head -1) || true
+  # Bounded because a forwarded agent whose SSH transport stalled accepts the
+  # connection but never answers, which hangs the commit here with no output.
+  # `env` rather than a prefix assignment: those persist past a function call.
+  forwarded_key=$(run_bounded 2 env SSH_AUTH_SOCK="$sock" ssh-add -L | head -1) || true
   # ssh-add -L prints "The agent has no identities." to stdout (not stderr)
   # and exits 1 when the agent is empty, so a bare non-empty check would
   # treat that sentence as the key. Require an actual key-type prefix.
-  if [[ "$forwarded_key" == ssh-* || "$forwarded_key" == ecdsa-* || "$forwarded_key" == sk-* ]]; then
+  if is_key_literal "$forwarded_key"; then
     printf 'key::%s\n' "$forwarded_key"
     exit 0
   fi
 fi
 
 local_signing_key=$(git config --global --includes --get user.localSigningKey 2>/dev/null) || local_signing_key=""
-if [[ -n "$local_signing_key" && -f "$local_signing_key" ]]; then
-  printf 'key::%s\n' "$(cat "$local_signing_key")"
+
+# A literal key needs no file open, removing one of the ways a wedged path can
+# stall a commit. It doesn't make committing hang-proof on its own: the agent
+# probe above is still unbounded. git-config(1) documents both the key:: form
+# and the older unprefixed one.
+if [[ "$local_signing_key" == key::* ]]; then
+  printf '%s\n' "$local_signing_key"
   exit 0
+elif is_key_literal "$local_signing_key"; then
+  printf 'key::%s\n' "$local_signing_key"
+  exit 0
+fi
+
+# -e rather than -f: whether the path is a regular file says nothing about
+# whether opening it will return, so let the bounded read be the judge.
+if [[ -n "$local_signing_key" && -e "$local_signing_key" ]]; then
+  if key_text=$(run_bounded 2 cat "$local_signing_key") && [[ -n "$key_text" ]]; then
+    printf 'key::%s\n' "$key_text"
+    exit 0
+  fi
+  echo "git-signing-key: gave up reading $local_signing_key" >&2
+  exit 1
 fi
 
 echo "git-signing-key: no local or forwarded SSH signing key found" >&2

--- a/bin/lib/bounded.sh
+++ b/bin/lib/bounded.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# A deadline for commands that can block indefinitely. The SSH signing scripts
+# run on git's every-signed-commit path and on zsh's precmd hook, where an
+# unbounded ssh-add against a stalled agent, or a read of a key file on a
+# wedged mount, turns into a hang with no output and no error.
+#
+# Usage: source "$lib_dir/bounded.sh"
+
+# Runs "$@" with a deadline of $1 seconds, printing what it wrote to stdout and
+# returning its exit status. On timeout, kills it and returns 124, the status
+# timeout(1) uses. stderr is discarded; every caller here already did that.
+#
+# timeout(1) itself would be the obvious tool, but it's Homebrew coreutils and
+# git execs these scripts with whatever PATH it inherited. The command runs
+# behind a process substitution rather than a plain redirect so this shell never
+# blocks in open(). The trailing NUL is what `read -d ''` waits for, so reaching
+# it means the command finished, and timing out is the only way to miss it.
+# Don't infer that from read's own exit status instead: it is 1 for both cases
+# under the bash 3.2 that /usr/bin/env resolves to without Homebrew on PATH.
+run_bounded() {
+  local deadline=$1 out rc pid
+  shift
+  # `|| _rc=$?` keeps a command that legitimately exits non-zero (ssh-add -l
+  # returns 1 for an empty agent, 2 for an unreachable one) from tripping the
+  # errexit these callers set, which would kill the subshell before it reports.
+  exec 3< <({ _rc=0; "$@" || _rc=$?; printf '\0%s' "$_rc"; } 2>/dev/null)
+  pid=$!
+  if IFS= read -r -d '' -t "$deadline" out <&3; then
+    IFS= read -r -t "$deadline" rc <&3
+    exec 3<&-
+    printf '%s' "$out"
+    return "${rc:-0}"
+  fi
+  exec 3<&-
+  # $pid is the substitution's subshell, which forked the command, so the child
+  # has to go first. Skipping it orphans a blocked process onto init, one per
+  # call, for as long as whatever it is waiting on stays wedged.
+  pkill -P "$pid" 2>/dev/null
+  kill -TERM "$pid" 2>/dev/null
+  return 124
+}

--- a/bin/lib/bounded.sh
+++ b/bin/lib/bounded.sh
@@ -10,6 +10,12 @@
 # returning its exit status. On timeout, kills it and returns 124, the status
 # timeout(1) uses. stderr is discarded; every caller here already did that.
 #
+# Callers use 2 seconds for agent probes, where a reachable agent answers in
+# tens of milliseconds, and 10 for whole test invocations.
+#
+# Only for small, text-only output. `read` consumes a pipe a byte at a time, so
+# capture cost scales with output size and a NUL in the output ends it early.
+#
 # timeout(1) itself would be the obvious tool, but it's Homebrew coreutils and
 # git execs these scripts with whatever PATH it inherited. The command runs
 # behind a process substitution rather than a plain redirect so this shell never
@@ -18,18 +24,30 @@
 # Don't infer that from read's own exit status instead: it is 1 for both cases
 # under the bash 3.2 that /usr/bin/env resolves to without Homebrew on PATH.
 run_bounded() {
-  local deadline=$1 out rc pid
+  local deadline=$1 out pid rc=""
   shift
   # `|| _rc=$?` keeps a command that legitimately exits non-zero (ssh-add -l
   # returns 1 for an empty agent, 2 for an unreachable one) from tripping the
   # errexit these callers set, which would kill the subshell before it reports.
+  # fd 3 is hardcoded because bash 3.2 has no {fd}< auto-allocation, so callers
+  # must not hold it open across this function.
   exec 3< <({ _rc=0; "$@" || _rc=$?; printf '\0%s' "$_rc"; } 2>/dev/null)
   pid=$!
   if IFS= read -r -d '' -t "$deadline" out <&3; then
-    IFS= read -r -t "$deadline" rc <&3
+    # Expected to return non-zero: the status is written without a trailing
+    # delimiter, so this read assigns and then hits EOF. The value matters, the
+    # status doesn't. A missing or non-numeric one means the NUL came from the
+    # command's own output rather than the end of the protocol, so the command
+    # is still running and this is a timeout like any other.
+    IFS= read -r -t "$deadline" rc <&3 || true
     exec 3<&-
+    if [[ -z "$rc" || "$rc" == *[!0-9]* ]]; then
+      pkill -P "$pid" 2>/dev/null
+      kill -TERM "$pid" 2>/dev/null
+      return 124
+    fi
     printf '%s' "$out"
-    return "${rc:-0}"
+    return "$rc"
   fi
   exec 3<&-
   # $pid is the substitution's subshell, which forked the command, so the child

--- a/bin/lib/test-git-signing-key.sh
+++ b/bin/lib/test-git-signing-key.sh
@@ -46,8 +46,7 @@ assert "prints key:: plus the local signing key contents" \
 
 # ── Test: a literal key value needs no filesystem access ───────────────────
 # Pinning the key by value takes the key file out of the commit path, since
-# there's nothing to open. The forwarded-agent probe still runs first, so this
-# is one blocking source fewer rather than none.
+# there's nothing to open. The forwarded-agent probe still runs first.
 
 LITERAL="ssh-ed25519 AAAAliteral literal@example.com"
 set_signing_key "key::$LITERAL"
@@ -77,13 +76,31 @@ mkfifo "$BLOCKING"
 set_signing_key "$BLOCKING"
 
 rc=0
+start=$SECONDS
 run_bin >/dev/null || rc=$?
 assert "exits non-zero when the key path blocks on open" test "$rc" -ne 0
 # 124 is run_bin's kill-on-deadline status, so this is the assertion that fails
-# if the script goes back to waiting forever. Checking elapsed time instead
-# would never be reached: the run would still be blocked.
+# if the script goes back to waiting forever.
 assert "gives up on a blocking key path rather than hanging" test "$rc" -ne 124
+# The lower bound is what pins the bounded read specifically. Without it these
+# assertions also pass against a script that rejects a FIFO before opening it,
+# which is what the -f test this branch removed used to do.
+assert "waits on the blocked open rather than skipping the path" \
+  test $((SECONDS - start)) -ge 2
 
+# ── Test: an empty key file is reported rather than signed with ────────────
+# A truncated ~/.ssh/id_*.pub would otherwise print a bare "key::" and exit 0,
+# handing git an empty signing key it only rejects later.
+
+: > "$KEY_FILE"
+set_signing_key "$KEY_FILE"
+
+rc=0
+run_bin >/dev/null || rc=$?
+assert "exits non-zero on an empty key file rather than printing a bare key::" \
+  test "$rc" -ne 0
+
+echo "ssh-ed25519 AAAAtest test@example.com" > "$KEY_FILE"
 set_signing_key "$KEY_FILE"
 
 # ── Test: live forwarded agent already linked at agent.sock ────────────────
@@ -129,7 +146,10 @@ rc=0
 out=$(run_bin) || rc=$?
 assert "falls back to the local key when the forwarded agent never answers" \
   test "$out" = "key::$(cat "$KEY_FILE")"
-assert "a stalled forwarded agent doesn't hang the commit" test "$rc" -ne 124
+# Scoped to key resolution: this suite never invokes git, and git-ssh-sign's
+# own ssh-keygen against the same socket is not bounded.
+assert "key resolution against a stalled forwarded agent doesn't hang" \
+  test "$rc" -ne 124
 
 # ── Test: forwarded agent gone by the time git-signing-key runs ────────────
 # A bound-but-unlistened socket passes -S but refuses the connection

--- a/bin/lib/test-git-signing-key.sh
+++ b/bin/lib/test-git-signing-key.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-# Tests for git-signing-key's key-resolution logic: local fallback, a live
-# forwarded agent, and a forwarded agent that's gone by the time `ssh-add
-# -L` runs.
+# Tests for git-signing-key's key-resolution logic: local fallback, literal
+# key values, a key path that blocks on open, a live forwarded agent, and a
+# forwarded agent that's gone by the time `ssh-add -L` runs.
 #
 # Usage: test-git-signing-key.sh
 
@@ -23,6 +23,10 @@ cleanup() {
 }
 trap cleanup EXIT
 
+set_signing_key() {
+  git config --file "$FAKE_HOME/.gitconfig.local" user.localSigningKey "$1"
+}
+
 # ── Test: local signing key configured and present on disk ─────────────────
 # Set through an [include], mirroring the real machine's ~/.gitconfig ->
 # ~/.gitconfig.local layout, so this exercises the --includes flag
@@ -34,11 +38,53 @@ cat > "$FAKE_HOME/.gitconfig" <<EOF
 [include]
 	path = $FAKE_HOME/.gitconfig.local
 EOF
-git config --file "$FAKE_HOME/.gitconfig.local" user.localSigningKey "$KEY_FILE"
+set_signing_key "$KEY_FILE"
 
-out=$(HOME="$FAKE_HOME" "$BIN")
+out=$(run_bin)
 assert "prints key:: plus the local signing key contents" \
   test "$out" = "key::$(cat "$KEY_FILE")"
+
+# ── Test: a literal key value needs no filesystem access ───────────────────
+# Pinning the key by value takes the key file out of the commit path, since
+# there's nothing to open. The forwarded-agent probe still runs first, so this
+# is one blocking source fewer rather than none.
+
+LITERAL="ssh-ed25519 AAAAliteral literal@example.com"
+set_signing_key "key::$LITERAL"
+
+out=$(run_bin)
+assert "passes a key:: literal through unchanged" \
+  test "$out" = "key::$LITERAL"
+
+# ── Test: a bare key literal gets the key:: prefix ─────────────────────────
+# git-config(1) documents the unprefixed form as deprecated but still
+# accepted, so accept it here rather than treating it as a path.
+
+set_signing_key "$LITERAL"
+
+out=$(run_bin)
+assert "prefixes a bare key literal with key::" \
+  test "$out" = "key::$LITERAL"
+
+# ── Test: a key path that blocks on open fails fast ────────────────────────
+# The regression this guards: reading the signing key blocked forever in
+# open(), so every `git commit` hung with no output and no error. A FIFO with
+# no writer reproduces that block deterministically. The script must give up
+# and exit non-zero rather than wait.
+
+BLOCKING="$FAKE_HOME/blocking.pub"
+mkfifo "$BLOCKING"
+set_signing_key "$BLOCKING"
+
+rc=0
+run_bin >/dev/null || rc=$?
+assert "exits non-zero when the key path blocks on open" test "$rc" -ne 0
+# 124 is run_bin's kill-on-deadline status, so this is the assertion that fails
+# if the script goes back to waiting forever. Checking elapsed time instead
+# would never be reached: the run would still be blocked.
+assert "gives up on a blocking key path rather than hanging" test "$rc" -ne 124
+
+set_signing_key "$KEY_FILE"
 
 # ── Test: live forwarded agent already linked at agent.sock ────────────────
 
@@ -49,7 +95,7 @@ ssh-keygen -q -t ed25519 -N '' -f "$FAKE_HOME/forwarded_key" -C forwarded
 SSH_AUTH_SOCK="$FORWARDED" ssh-add "$FAKE_HOME/forwarded_key" >/dev/null 2>&1
 ln -sf "$FORWARDED" "$FAKE_HOME/.ssh/agent.sock"
 
-out=$(HOME="$FAKE_HOME" "$BIN")
+out=$(run_bin)
 assert "prints key:: plus the forwarded agent's key" \
   test "$out" = "key::$(cat "$FAKE_HOME/forwarded_key.pub")"
 
@@ -63,9 +109,27 @@ EMPTY_FORWARDED="$FAKE_HOME/empty-forwarded.sock"
 agent_pids+=("$(start_agent "$EMPTY_FORWARDED")")
 ln -sf "$EMPTY_FORWARDED" "$FAKE_HOME/.ssh/agent.sock"
 
-out=$(HOME="$FAKE_HOME" "$BIN")
+out=$(run_bin)
 assert "falls back to the local key when the forwarded agent has no identities" \
   test "$out" = "key::$(cat "$KEY_FILE")"
+
+# ── Test: forwarded agent that connects but never answers ──────────────────
+# The hang this guards: a forwarded agent whose SSH transport stalled (laptop
+# slept, network black-holed) still accepts the connection, so `ssh-add -L`
+# waits forever and every `git commit` hangs with no output. Secretive is
+# deliberately absent here, which is what keeps the socket adopted as
+# "forwarded" and routes the probe through git-signing-key's own ssh-add
+# rather than ssh-agent-sync's. It must give up and fall back to the local key.
+
+STALLED="$FAKE_HOME/stalled.sock"
+agent_pids+=("$(mkblackhole_sock "$STALLED")")
+ln -sf "$STALLED" "$FAKE_HOME/.ssh/agent.sock"
+
+rc=0
+out=$(run_bin) || rc=$?
+assert "falls back to the local key when the forwarded agent never answers" \
+  test "$out" = "key::$(cat "$KEY_FILE")"
+assert "a stalled forwarded agent doesn't hang the commit" test "$rc" -ne 124
 
 # ── Test: forwarded agent gone by the time git-signing-key runs ────────────
 # A bound-but-unlistened socket passes -S but refuses the connection
@@ -80,7 +144,7 @@ DEAD_FORWARDED="$FAKE_HOME/dead-forwarded.sock"
 mksock "$DEAD_FORWARDED"
 ln -sf "$DEAD_FORWARDED" "$FAKE_HOME/.ssh/agent.sock"
 
-out=$(HOME="$FAKE_HOME" "$BIN")
+out=$(run_bin)
 assert "falls back to the local key when the forwarded agent is unreachable" \
   test "$out" = "key::$(cat "$KEY_FILE")"
 assert "unreachable forwarded sock heals to Secretive" \
@@ -92,8 +156,9 @@ rm -rf "$FAKE_HOME/.ssh"
 rm -f "$KEY_FILE"
 
 rc=0
-HOME="$FAKE_HOME" "$BIN" >/dev/null 2>/dev/null || rc=$?
+run_bin >/dev/null || rc=$?
 assert "exits non-zero when no key is found" test "$rc" -ne 0
+assert "reports no key rather than hanging" test "$rc" -ne 124
 
 # ── Results ──────────────────────────────────────────────────────────────────
 

--- a/bin/lib/test-helpers.sh
+++ b/bin/lib/test-helpers.sh
@@ -4,16 +4,59 @@
 # Usage: source "$SCRIPT_DIR/test-helpers.sh"
 #
 # Provides assert/assert_not functions, socket/agent fixtures for SSH-agent
-# tests, and a print_results finalizer. Each test file should call
-# print_results at the end.
+# tests, a bounded runner for the script under test, and a print_results
+# finalizer. Each test file should call print_results at the end.
+
+_helpers_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=bin/lib/bounded.sh
+source "$_helpers_dir/bounded.sh"
 
 passes=0
 failures=0
+
+# Runs $BIN under $FAKE_HOME with any arguments given, echoing its stdout and
+# returning its exit status, or 124 if it had to be killed.
+#
+# Bounded because these suites drive SSH agents and signing paths, the code
+# most able to block forever, and they run by hand with no CI timeout behind
+# them. Unbounded, a regression in the very hang-avoidance being tested wedges
+# the run instead of failing it, and the assertion written to catch it is never
+# reached. Callers that need to distinguish a hang from an expected failure
+# should assert the status is not 124.
+run_bin() {
+    run_bounded 10 env HOME="$FAKE_HOME" "$BIN" "$@"
+}
 
 # Binds a dead AF_UNIX socket at $1: passes -S liveness checks but refuses
 # connections, for simulating an agent that's gone by connect time.
 mksock() {
     python3 -c 'import socket, sys; socket.socket(socket.AF_UNIX).bind(sys.argv[1])' "$1"
+}
+
+# Binds a listening AF_UNIX socket at $1 that accepts connections and then
+# never answers, simulating a forwarded agent whose SSH transport stalled: the
+# path passes -S, connect() succeeds, and ssh-add waits forever for a reply
+# that never comes. This is the shape mksock cannot produce, since a bound but
+# unlistened socket refuses the connection outright. Echoes the holder's PID so
+# the caller can kill it during cleanup.
+mkblackhole_sock() {
+    local pid waited=0
+    python3 -c '
+import socket, sys
+s = socket.socket(socket.AF_UNIX)
+s.bind(sys.argv[1])
+s.listen(16)
+held = []
+while True:
+    conn, _ = s.accept()
+    held.append(conn)
+' "$1" >/dev/null 2>&1 &
+    pid=$!
+    while [[ ! -S "$1" ]] && (( waited < 100 )); do
+        sleep 0.05
+        waited=$((waited + 1))
+    done
+    printf '%s\n' "$pid"
 }
 
 # The Secretive agent socket path under a fake HOME ($1), mirroring the path

--- a/bin/lib/test-helpers.sh
+++ b/bin/lib/test-helpers.sh
@@ -23,6 +23,7 @@ failures=0
 # the run instead of failing it, and the assertion written to catch it is never
 # reached. Callers that need to distinguish a hang from an expected failure
 # should assert the status is not 124.
+# shellcheck disable=SC2120  # most callers pass no arguments
 run_bin() {
     run_bounded 10 env HOME="$FAKE_HOME" "$BIN" "$@"
 }
@@ -50,12 +51,20 @@ held = []
 while True:
     conn, _ = s.accept()
     held.append(conn)
-' "$1" >/dev/null 2>&1 &
+' "$1" >/dev/null &
     pid=$!
     while [[ ! -S "$1" ]] && (( waited < 100 )); do
+        # Without this, a holder that died before binding leaves the caller with
+        # a path that never becomes a socket, and every assertion written to
+        # catch a stalled agent instead passes against a missing one.
+        kill -0 "$pid" 2>/dev/null || {
+            echo "mkblackhole_sock: holder died before binding $1" >&2
+            return 1
+        }
         sleep 0.05
         waited=$((waited + 1))
     done
+    [[ -S "$1" ]] || { echo "mkblackhole_sock: no socket at $1" >&2; return 1; }
     printf '%s\n' "$pid"
 }
 

--- a/bin/lib/test-ssh-agent-sync.sh
+++ b/bin/lib/test-ssh-agent-sync.sh
@@ -47,7 +47,7 @@ mksock "$SECRETIVE"
 FORWARDED="$FAKE_HOME/forwarded.sock"
 mksock "$FORWARDED"
 
-out=$(HOME="$FAKE_HOME" "$BIN" "$FORWARDED")
+out=$(run_bin "$FORWARDED")
 assert "live forwarded arg prints forwarded" test "$out" = "forwarded"
 assert "symlink points at the forwarded socket" test "$SOCK" -ef "$FORWARDED"
 
@@ -55,7 +55,7 @@ assert "symlink points at the forwarded socket" test "$SOCK" -ef "$FORWARDED"
 
 rm -rf "$FAKE_HOME/.ssh"
 
-out=$(HOME="$FAKE_HOME" "$BIN")
+out=$(run_bin)
 assert "no forwarded arg with Secretive present prints local" test "$out" = "local"
 assert "symlink points at Secretive" test "$SOCK" -ef "$SECRETIVE"
 
@@ -64,7 +64,7 @@ assert "symlink points at Secretive" test "$SOCK" -ef "$SECRETIVE"
 link_sock "$FAKE_HOME/torn-down.sock"
 DEAD_FORWARDED="$FAKE_HOME/dead-forwarded.sock"
 
-out=$(HOME="$FAKE_HOME" "$BIN" "$DEAD_FORWARDED")
+out=$(run_bin "$DEAD_FORWARDED")
 assert "dead forwarded arg with dangling sock prints local" test "$out" = "local"
 assert "dangling sock re-heals to Secretive" test "$SOCK" -ef "$SECRETIVE"
 
@@ -72,15 +72,32 @@ assert "dangling sock re-heals to Secretive" test "$SOCK" -ef "$SECRETIVE"
 # Unlike the test above, $SOCK already points at Secretive, so a dead
 # forwarded arg must not needlessly re-link or misclassify it.
 
-out=$(HOME="$FAKE_HOME" "$BIN" "$DEAD_FORWARDED")
+out=$(run_bin "$DEAD_FORWARDED")
 assert "dead forwarded arg with an already-healthy sock still prints local" test "$out" = "local"
 assert "already-healthy sock is left pointing at Secretive" test "$SOCK" -ef "$SECRETIVE"
+
+# ── Test: adopted sock that connects but never answers heals to local ───────
+# A forwarded session whose transport stalled leaves a socket that passes -S
+# and accepts connections but never replies, so the no-arg `ssh-add -l` probe
+# waits forever. That probe runs from zsh's precmd and from git's signing path,
+# so an unbounded one hangs the shell prompt and every signed commit alike.
+# Timing out must be treated like any other unusable agent: heal to Secretive.
+
+STALLED="$FAKE_HOME/stalled.sock"
+agent_pids+=("$(mkblackhole_sock "$STALLED")")
+link_sock "$STALLED"
+
+rc=0
+out=$(run_bin) || rc=$?
+assert "adopted sock that never answers prints local" test "$out" = "local"
+assert "stalled sock heals to Secretive" test "$SOCK" -ef "$SECRETIVE"
+assert "a stalled adopted sock doesn't hang the prompt" test "$rc" -ne 124
 
 # ── Test: nothing present ───────────────────────────────────────────────────
 
 rm -rf "$FAKE_HOME/.ssh" "$FAKE_HOME/Library"
 
-out=$(HOME="$FAKE_HOME" "$BIN")
+out=$(run_bin)
 assert "nothing present prints none" test "$out" = "none"
 assert "no symlink is created" test ! -e "$SOCK"
 
@@ -100,7 +117,7 @@ LOOPED="$FAKE_HOME/looped.sock"
 agent_pids+=("$(start_agent "$LOOPED")")
 SSH_AUTH_SOCK="$LOOPED" ssh-add "$FAKE_HOME/shared_key" >/dev/null 2>&1
 
-out=$(HOME="$FAKE_HOME" "$BIN" "$LOOPED")
+out=$(run_bin "$LOOPED")
 assert "looped forwarded arg prints local" test "$out" = "local"
 assert "looped forwarded arg leaves the symlink on Secretive" test "$SOCK" -ef "$SECRETIVE"
 
@@ -111,7 +128,7 @@ agent_pids+=("$(start_agent "$GENUINE")")
 ssh-keygen -q -t ed25519 -N '' -f "$FAKE_HOME/remote_key" -C remote
 SSH_AUTH_SOCK="$GENUINE" ssh-add "$FAKE_HOME/remote_key" >/dev/null 2>&1
 
-out=$(HOME="$FAKE_HOME" "$BIN" "$GENUINE")
+out=$(run_bin "$GENUINE")
 assert "distinct-key forwarded arg prints forwarded" test "$out" = "forwarded"
 assert "symlink points at the genuine forwarded socket" test "$SOCK" -ef "$GENUINE"
 
@@ -124,7 +141,7 @@ assert "symlink points at the genuine forwarded socket" test "$SOCK" -ef "$GENUI
 EMPTY="$FAKE_HOME/empty.sock"
 agent_pids+=("$(start_agent "$EMPTY")")
 
-out=$(HOME="$FAKE_HOME" "$BIN" "$EMPTY")
+out=$(run_bin "$EMPTY")
 assert "empty forwarded arg prints forwarded" test "$out" = "forwarded"
 assert "symlink points at the empty forwarded socket" test "$SOCK" -ef "$EMPTY"
 
@@ -138,7 +155,7 @@ STALE="$FAKE_HOME/stale-forwarded.sock"
 mksock "$STALE"
 link_sock "$STALE"
 
-out=$(HOME="$FAKE_HOME" "$BIN")
+out=$(run_bin)
 assert "no arg with stale forwarded sock prints local" test "$out" = "local"
 assert "stale forwarded sock heals to Secretive" test "$SOCK" -ef "$SECRETIVE"
 
@@ -147,7 +164,7 @@ assert "stale forwarded sock heals to Secretive" test "$SOCK" -ef "$SECRETIVE"
 
 link_sock "$GENUINE"
 
-out=$(HOME="$FAKE_HOME" "$BIN")
+out=$(run_bin)
 assert "no arg with live forwarded sock stays forwarded" test "$out" = "forwarded"
 assert "live forwarded sock is left in place" test "$SOCK" -ef "$GENUINE"
 
@@ -157,7 +174,7 @@ assert "live forwarded sock is left in place" test "$SOCK" -ef "$GENUINE"
 
 link_sock "$EMPTY"
 
-out=$(HOME="$FAKE_HOME" "$BIN")
+out=$(run_bin)
 assert "no arg with live empty forwarded sock stays forwarded" test "$out" = "forwarded"
 assert "live empty forwarded sock is left in place" test "$SOCK" -ef "$EMPTY"
 

--- a/bin/ssh-agent-sync
+++ b/bin/ssh-agent-sync
@@ -20,7 +20,7 @@
 
 set -euo pipefail
 
-lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/lib" && pwd)"
+lib_dir="${BASH_SOURCE[0]%/*}/lib"
 # shellcheck source=bin/lib/bounded.sh
 source "$lib_dir/bounded.sh"
 

--- a/bin/ssh-agent-sync
+++ b/bin/ssh-agent-sync
@@ -20,6 +20,10 @@
 
 set -euo pipefail
 
+lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/lib" && pwd)"
+# shellcheck source=bin/lib/bounded.sh
+source "$lib_dir/bounded.sh"
+
 sock="$HOME/.ssh/agent.sock"
 # This path is also hardcoded in git/gitconfig.symlink's core.sshCommand
 # (IdentityAgent=...), for git's own SSH transport rather than signing.
@@ -28,10 +32,13 @@ secretive="$HOME/Library/Containers/com.maxgoedjen.Secretive.SecretAgent/Data/so
 forwarded="${1:-}"
 
 # Lists the keys an agent socket offers; empty when the agent is
-# unreachable or has none. Requiring a key-type prefix filters out
-# ssh-add's "The agent has no identities." sentence, which goes to stdout.
+# unreachable, has none, or doesn't answer within the deadline. Requiring a
+# key-type prefix filters out ssh-add's "The agent has no identities."
+# sentence, which goes to stdout. A socket whose SSH transport stalled accepts
+# the connection but never replies, so this must not be left unbounded: it runs
+# from zsh's precmd and from git's signing path, and would hang both.
 agent_keys() {
-  SSH_AUTH_SOCK="$1" ssh-add -L 2>/dev/null | grep -E '^(ssh-|ecdsa-|sk-)' || true
+  run_bounded 2 env SSH_AUTH_SOCK="$1" ssh-add -L | grep -E '^(ssh-|ecdsa-|sk-)' || true
 }
 
 [[ -d "$HOME/.ssh" ]] || mkdir -p -m 700 "$HOME/.ssh"
@@ -47,9 +54,11 @@ elif [[ -S "$secretive" ]] && ! [[ "$sock" -ef "$secretive" ]]; then
   # An adopted forwarded socket can outlive its SSH session as a file that
   # still passes -S. ssh-add exits 2 when it cannot reach the agent at all
   # (a stale, missing, or dangling sock alike); 1 means reachable-but-empty,
-  # which stays adopted (matching the empty-forwarded adoption above).
+  # which stays adopted (matching the empty-forwarded adoption above). A socket
+  # that connects but never answers times out to 124, which lands in the same
+  # ">= 2" bucket: unusable, so heal back to Secretive.
   rc=0
-  SSH_AUTH_SOCK="$sock" ssh-add -l >/dev/null 2>&1 || rc=$?
+  run_bounded 2 env SSH_AUTH_SOCK="$sock" ssh-add -l >/dev/null || rc=$?
   if (( rc >= 2 )); then
     ln -sf "$secretive" "$sock"
   fi


### PR DESCRIPTION
`git commit` could hang forever with no output and no error. Four calls on the signing path had no deadline: three `ssh-add` probes against the agent socket, and the read of the configured signing key file. A forwarded agent whose SSH transport stalled (laptop slept, network dropped) still accepts the connection, so `ssh-add` waits for a reply that never arrives.

`ssh-agent-sync` runs from zsh's precmd hook too, so the same stall hung the shell prompt, not just commits.

## What changed

`bin/lib/bounded.sh` adds `run_bounded SECONDS COMMAND`. It runs a command behind a process substitution and enforces the deadline with `read -t`, returning the command's real exit status or 124 on timeout. `timeout(1)` would be the obvious tool, but it comes from Homebrew coreutils and git execs these scripts with whatever PATH it inherited. On timeout it kills the substitution's child before the subshell, since killing only the parent orphans a blocked process onto init once per call.

The command signals completion by writing a NUL and then its exit status, so `run_bounded` checks that what it read back is actually a number. A NUL in the command's own output would otherwise look like the end of the protocol, and the call would report success while leaving the still-running child behind.

All four call sites now go through it with a 2 second deadline. In `ssh-agent-sync` the heal probe already distinguished an empty agent (exit 1) from an unreachable one (exit 2), so a timeout at 124 lands in the unusable bucket and heals the symlink back to Secretive.

Reading the key file has no existence test in front of it. `[[ -e ]]` calls `stat(2)`, which blocks on a wedged mount exactly the way `open(2)` does, so testing first would hang one line before the deadline could apply. `cat` reports a missing path as a failure, which lands in the same branch.

`user.localSigningKey` now also accepts a literal public key, both the `key::` form and the older unprefixed one, so the common case opens no file at all. A live forwarded agent still takes precedence over a configured literal, which is the existing order.

## Measurements

Against a socket that accepts connections and never answers, both scripts previously hung until killed at 8 seconds. Now `ssh-agent-sync` returns in 2 seconds and resolves to local, and `git-signing-key` returns in 2 seconds and falls back to the local key.

The healthy path costs about half a millisecond, which is sourcing `bounded.sh`. Paired runs of 150 iterations in the healthy-local steady state put `ssh-agent-sync` at a median 6.8 to 6.9 ms before and 7.3 to 7.5 ms after. `git-signing-key` is at parity on a file-path config, 32.9 ms against 33.3 ms, and slightly cheaper on a `key::` literal at 31.7 ms because it opens no file.

## Known gap

`bin/git-ssh-sign` execs `ssh-keygen -Y sign` against the same socket with no deadline, so a signed commit against a stalled agent still blocks there once key resolution succeeds. It only bites when Secretive is absent, since otherwise `ssh-agent-sync` heals the symlink first. Not covered by the suites and not addressed here.

## Test plan

- [x] `bin/lib/test-git-signing-key.sh` (15 assertions)
- [x] `bin/lib/test-ssh-agent-sync.sh` (25 assertions)
- [x] `bin/lib/test-git-signing-integration.sh` (6 assertions, real `git commit -S`)

A new `mkblackhole_sock` fixture binds a listening socket that accepts and never replies, which is the shape `mksock` cannot produce. It fails loudly if the holder dies before binding, so a fixture that never came up can't leave the regression tests passing against a missing socket instead of a stalled one.

The two black-hole regression tests fail against the previous code with exit 124, so they exercise the fix rather than passing either way. The FIFO test asserts a lower bound on elapsed time as well, since a script that rejects a FIFO without opening it would otherwise satisfy the same assertions.

Test invocations are themselves bounded through a new `run_bin` helper. Without it, a regression in the hang avoidance being tested wedges the suite instead of failing it, and there is no CI here to time it out.

Suites pass on bash 5.3 and on system bash 3.2, which is what `/usr/bin/env bash` resolves to without Homebrew on PATH.