### PR TITLE
Always include PRs with pending draft reviews in review-all-prs.sh

### DIFF
--- a/bin/lib/pending-filter.jq
+++ b/bin/lib/pending-filter.jq
@@ -8,4 +8,4 @@
 # Variables: $user - GitHub username
 #
 # The last-user-review selection is duplicated in review-filter.jq; keep in sync.
-[.[] | select((.reviews.nodes | map(select(.author.login == $user)) | last | .state) == "PENDING")]
+[.[] | select(((.reviews.nodes // []) | map(select(.author.login == $user)) | last | .state) == "PENDING")]

--- a/bin/lib/pending-filter.jq
+++ b/bin/lib/pending-filter.jq
@@ -1,0 +1,11 @@
+# pending-filter.jq - Keep only PRs whose last review by $user is an
+# unsubmitted PENDING draft.
+#
+# review-all-prs.sh uses this to pre-filter the involves:@me discovery sweep:
+# involves: also matches PRs you merely commented on or were mentioned in,
+# which would otherwise flood the listing through the unreviewed-PR gate.
+#
+# Variables: $user - GitHub username
+#
+# The last-user-review selection is duplicated in review-filter.jq; keep in sync.
+[.[] | select((.reviews.nodes | map(select(.author.login == $user)) | last | .state) == "PENDING")]

--- a/bin/lib/review-filter.jq
+++ b/bin/lib/review-filter.jq
@@ -54,7 +54,7 @@ def by_key($key; $dir):
   end;
 
 map(
-  (.reviews.nodes | map(select(.author.login == $user)) | last) as $last_review
+  ((.reviews.nodes // []) | map(select(.author.login == $user)) | last) as $last_review
   | select($include_reviewed
           or $last_review == null
           or $last_review.state == "PENDING"

--- a/bin/lib/review-filter.jq
+++ b/bin/lib/review-filter.jq
@@ -8,9 +8,11 @@
 #   $sort_specs       - array of {key, dir} sort pairs, highest precedence first.
 #                       key is priority|repo|status|number; dir is asc|desc.
 #
-# Keeps PRs the user hasn't reviewed and PRs with commits newer than the
-# user's last review. PENDING (draft) reviews have null submittedAt, so fall
-# back to createdAt for the comparison.
+# Keeps PRs the user hasn't reviewed, PRs whose last review by the user is an
+# unsubmitted PENDING draft (a pending review is unfinished work, never
+# "already reviewed"), and PRs with commits newer than the user's last
+# submitted review. Submitted reviews always carry submittedAt.
+# The last-user-review selection is duplicated in pending-filter.jq; keep in sync.
 #
 # Each PR gets a priority tier:
 #   1 - authored by a member of $team_members
@@ -53,11 +55,10 @@ def by_key($key; $dir):
 
 map(
   (.reviews.nodes | map(select(.author.login == $user)) | last) as $last_review
-  | (if $last_review == null then null
-     else ($last_review.submittedAt // $last_review.createdAt) end) as $last_review_at
   | select($include_reviewed
-          or $last_review_at == null
-          or .commits.nodes[0].commit.committedDate > $last_review_at)
+          or $last_review == null
+          or $last_review.state == "PENDING"
+          or .commits.nodes[0].commit.committedDate > $last_review.submittedAt)
   | {
       number: .number,
       title: .title,

--- a/bin/lib/test-review-filter.sh
+++ b/bin/lib/test-review-filter.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
-# Tests for the discovery jq filter loaded by review-all-prs.sh.
+# Tests for the discovery jq filters loaded by review-all-prs.sh:
+# review-filter.jq (the main discovery/priority/sort filter) and
+# pending-filter.jq (keeps only PRs whose last review by the user is an
+# unsubmitted PENDING draft).
 #
 # Usage: test-review-filter.sh
 
@@ -26,13 +29,16 @@ filter_prs() {
         -f "$SCRIPT_DIR/review-filter.jq"
 }
 
+pending_filter() {
+    echo "$2" | jq --arg user "$1" -f "$SCRIPT_DIR/pending-filter.jq"
+}
+
 make_review() {
-    # login state submittedAt(or empty for null) createdAt
-    jq -n --arg l "$1" --arg s "$2" --arg sub "$3" --arg cre "$4" '{
+    # login state submittedAt(or empty for null)
+    jq -n --arg l "$1" --arg s "$2" --arg sub "$3" '{
         author: {login: $l},
         state: $s,
-        submittedAt: (if $sub == "" then null else $sub end),
-        createdAt: $cre
+        submittedAt: (if $sub == "" then null else $sub end)
     }'
 }
 
@@ -70,26 +76,33 @@ T11="2024-01-15T11:00:00Z"
 pr_unreviewed=$(make_pr 1 "$T10" "[]")
 
 # 2: APPROVED with new commits since review (re-review candidate)
-pr_approved_new=$(make_pr 2 "$T11" "[$(make_review me APPROVED "$T10" "$T10")]")
+pr_approved_new=$(make_pr 2 "$T11" "[$(make_review me APPROVED "$T10")]")
 
 # 3: APPROVED with no new commits since review (skip)
-pr_approved_stale=$(make_pr 3 "$T09" "[$(make_review me APPROVED "$T10" "$T10")]")
+pr_approved_stale=$(make_pr 3 "$T09" "[$(make_review me APPROVED "$T10")]")
 
-# 4: PENDING (submittedAt null), commits after createdAt (refresh draft)
-pr_pending_new=$(make_pr 4 "$T11" "[$(make_review me PENDING "" "$T10")]")
+# 4: PENDING (submittedAt null) with new commits (unfinished draft, kept)
+pr_pending_new=$(make_pr 4 "$T11" "[$(make_review me PENDING "")]")
 
-# 5: PENDING with no new commits since createdAt (skip)
-pr_pending_stale=$(make_pr 5 "$T09" "[$(make_review me PENDING "" "$T10")]")
+# 5: PENDING with no new commits — unsubmitted draft is unfinished work,
+# so it's always kept regardless of commit recency
+pr_pending_stale=$(make_pr 5 "$T09" "[$(make_review me PENDING "")]")
 
 # 6: COMMENTED with no new commits — new filter drops this (old filter kept it)
-pr_commented_stale=$(make_pr 6 "$T09" "[$(make_review me COMMENTED "$T10" "$T10")]")
+pr_commented_stale=$(make_pr 6 "$T09" "[$(make_review me COMMENTED "$T10")]")
 
 # 7: only reviewed by another user — treated as unreviewed by me
-pr_other_review=$(make_pr 7 "$T09" "[$(make_review other APPROVED "$T10" "$T10")]")
+pr_other_review=$(make_pr 7 "$T09" "[$(make_review other APPROVED "$T10")]")
 
 # 8: multiple reviews by user; "last" wins (older COMMENTED, newer APPROVED, no new commits → skip)
 pr_multi_review=$(make_pr 8 "$T0930" \
-    "[$(make_review me COMMENTED "$T08" "$T08"),$(make_review me APPROVED "$T10" "$T10")]")
+    "[$(make_review me COMMENTED "$T08"),$(make_review me APPROVED "$T10")]")
+
+# 15: earlier submitted COMMENTED review by user, then a later PENDING draft by
+# user, no commits since either — last review is the PENDING draft, which is
+# always kept. Kept out of `input` so the include_reviewed count stays at 8.
+pr_commented_then_pending=$(make_pr 15 "$T09" \
+    "[$(make_review me COMMENTED "$T08"),$(make_review me PENDING "")]")
 
 input=$(jq -s '.' <<EOF
 $pr_unreviewed
@@ -103,12 +116,12 @@ $pr_multi_review
 EOF
 )
 
-# ── Test: default filter keeps unreviewed and PRs with new commits ────────
+# ── Test: default filter keeps unreviewed, new-commit PRs, and PENDING drafts ─
 
 result=$(filter_prs "$USER" "false" "$input")
 numbers=$(echo "$result" | jq -c '[.[].number] | sort')
-assert "default filter keeps {1, 2, 4, 7}: unreviewed, approved-with-new-commits, pending-with-new-commits, other-reviewer" \
-    test "$numbers" = "[1,2,4,7]"
+assert "default filter keeps {1, 2, 4, 5, 7}: unreviewed, approved-with-new-commits, pending (always kept), other-reviewer" \
+    test "$numbers" = "[1,2,4,5,7]"
 
 # ── Test: --include-reviewed keeps every PR ───────────────────────────────
 
@@ -116,17 +129,30 @@ result=$(filter_prs "$USER" "true" "$input")
 count=$(echo "$result" | jq 'length')
 assert "include_reviewed=true keeps all 8 PRs" test "$count" -eq 8
 
-# ── Test: PENDING fallback to createdAt admits draft refresh ──────────────
+# ── Test: PENDING with new commits is kept ────────────────────────────────
 
 result=$(filter_prs "$USER" "false" "[$pr_pending_new]")
 state=$(echo "$result" | jq -r '.[0].user_review_state')
-assert "PENDING with new commits is kept via createdAt fallback" test "$state" = "PENDING"
+assert "PENDING with new commits is kept" test "$state" = "PENDING"
 
-# ── Test: PENDING with no new commits drops ───────────────────────────────
+# ── Test: PENDING with no new commits is kept (unfinished draft) ──────────
 
 result=$(filter_prs "$USER" "false" "[$pr_pending_stale]")
 count=$(echo "$result" | jq 'length')
-assert "PENDING with no new commits is dropped" test "$count" -eq 0
+assert "PENDING with no new commits is kept" test "$count" -eq 1
+
+state=$(echo "$result" | jq -r '.[0].user_review_state')
+assert "PENDING with no new commits has user_review_state PENDING" test "$state" = "PENDING"
+
+# ── Test: submitted review then a later PENDING draft is kept ────────────
+
+result=$(filter_prs "$USER" "false" "[$pr_commented_then_pending]")
+count=$(echo "$result" | jq 'length')
+assert "COMMENTED then PENDING draft (no new commits) is kept" test "$count" -eq 1
+
+state=$(echo "$result" | jq -r '.[0].user_review_state')
+assert "COMMENTED then PENDING draft: user_review_state is PENDING (last review wins)" \
+    test "$state" = "PENDING"
 
 # ── Test: COMMENTED with no new commits drops (new filter behavior) ──────
 
@@ -136,7 +162,7 @@ assert "COMMENTED with no new commits is dropped" test "$count" -eq 0
 
 # ── Test: equal timestamps drop (commit must be strictly newer) ──────────
 
-pr_equal=$(make_pr 9 "$T10" "[$(make_review me APPROVED "$T10" "$T10")]")
+pr_equal=$(make_pr 9 "$T10" "[$(make_review me APPROVED "$T10")]")
 result=$(filter_prs "$USER" "false" "[$pr_equal]")
 count=$(echo "$result" | jq 'length')
 assert "equal commit and review timestamps drop the PR" test "$count" -eq 0
@@ -209,11 +235,11 @@ assert "team-authored flags PR is priority 1, not 2" \
 
 # ── Global sort tests (an explicit --sort overrides priority tiering) ───────
 
-s_approved=$(make_pr 30 "$T10" "[$(make_review me APPROVED "$T10" "$T10")]" stranger "fix(api): approved")
+s_approved=$(make_pr 30 "$T10" "[$(make_review me APPROVED "$T10")]" stranger "fix(api): approved")
 s_flags_none=$(make_pr 31 "$T10" "[]" stranger "feat(flags): unreviewed")
 s_none=$(make_pr 32 "$T10" "[]" stranger "fix(api): unreviewed")
-s_flags_commented=$(make_pr 33 "$T10" "[$(make_review me COMMENTED "$T10" "$T10")]" stranger "feat(flags): commented")
-s_changes=$(make_pr 34 "$T10" "[$(make_review me CHANGES_REQUESTED "$T10" "$T10")]" stranger "fix(api): changes")
+s_flags_commented=$(make_pr 33 "$T10" "[$(make_review me COMMENTED "$T10")]" stranger "feat(flags): commented")
+s_changes=$(make_pr 34 "$T10" "[$(make_review me CHANGES_REQUESTED "$T10")]" stranger "fix(api): changes")
 
 sort_input=$(jq -s '.' <<EOF
 $s_approved
@@ -276,6 +302,36 @@ result=$(filter_prs "$USER" "true" "$multi_input" "[]" "$spec")
 nums=$(echo "$result" | jq -c '[.[].number]')
 assert "multi-key number:desc,status: first key takes precedence" \
     test "$nums" = "[40,35]"
+
+# ── pending-filter.jq: keeps only PRs whose last review by $user is PENDING ─
+
+result=$(pending_filter "$USER" "$input")
+numbers=$(echo "$result" | jq -c '[.[].number] | sort')
+assert "pending-filter keeps exactly {4, 5}: the PENDING-last fixtures in the main input" \
+    test "$numbers" = "[4,5]"
+
+result=$(pending_filter "$USER" "[$pr_commented_then_pending]")
+count=$(echo "$result" | jq 'length')
+assert "pending-filter keeps the COMMENTED-then-PENDING fixture (last review wins)" \
+    test "$count" -eq 1
+
+result=$(pending_filter "$USER" "[$pr_approved_stale]")
+count=$(echo "$result" | jq 'length')
+assert "pending-filter drops a PR whose last user review is submitted (APPROVED)" \
+    test "$count" -eq 0
+
+result=$(pending_filter "$USER" "[$pr_multi_review]")
+count=$(echo "$result" | jq 'length')
+assert "pending-filter drops a PR whose last user review is submitted (multi-review, APPROVED wins)" \
+    test "$count" -eq 0
+
+result=$(pending_filter "$USER" "[$pr_other_review]")
+count=$(echo "$result" | jq 'length')
+assert "pending-filter drops a PR reviewed only by another user" test "$count" -eq 0
+
+result=$(pending_filter "$USER" "[]")
+count=$(echo "$result" | jq 'length')
+assert "pending-filter: empty array input returns an empty array" test "$count" -eq 0
 
 # ── Results ───────────────────────────────────────────────────────────────
 

--- a/bin/review-all-prs.sh
+++ b/bin/review-all-prs.sh
@@ -33,6 +33,11 @@
 # PRs; pass --include-reviewed too when you want the interactive listing to
 # show already-settled PRs as well.
 #
+# PRs where you have a pending (unsubmitted draft) review are always included,
+# in every mode: GitHub drops your review-requested state the moment you start
+# a draft review, so these PRs are swept in via involves:@me and are never
+# hidden by the new-commits gate — a pending review is unfinished work.
+#
 # By default, results are grouped by priority tier, then most recently updated
 # within each tier. An explicit --sort KEY orders the whole list by that key,
 # with the priority tier as a secondary tiebreaker. Priority tiers:
@@ -45,11 +50,11 @@
 #
 # The STATUS column reflects your review of each PR:
 #   Not reviewed   - no review from you
-#   Draft pending  - you have an unsubmitted draft review
+#   Draft pending  - you have an unsubmitted draft review; always listed
 #   Approved / Commented / Changes req / Dismissed - your last submitted
 #       review state. By default these rows appear only when the PR has new
-#       commits since that review; PRs whose draft or review is still current
-#       are hidden unless you pass --include-reviewed.
+#       commits since that review; PRs whose submitted review is still
+#       current are hidden unless you pass --include-reviewed.
 #
 # Output (JSON mode):
 #   [
@@ -106,7 +111,9 @@ Options:
                       the priority tier and recency are always appended as
                       final tiebreakers. The default is priority, which
                       groups by tier (most recently updated within each).
-  --include-reviewed  Include PRs you've already reviewed
+  --include-reviewed  Include PRs you've already reviewed. PRs where you have
+                      a pending (unsubmitted) draft review are always shown,
+                      with or without this flag.
   --all               Widen the list to the team's whole review queue. Defaults
                       to ${DEFAULT_TEAM} when no --priority-team or --team is
                       given. Adds, for those teams: PRs requested from the team
@@ -226,6 +233,9 @@ while [[ $# -gt 0 ]]; do
       ;;
     --pending|--draft)
       PENDING_ONLY=true
+      # Pending drafts always pass the review gate, so this doesn't change
+      # which PRs survive; it disables the hidden-PR count, which would
+      # otherwise count every non-pending involves:@me result as hidden.
       INCLUDE_REVIEWED=true
       shift
       ;;
@@ -319,7 +329,6 @@ query($searchQuery: String!, $limit: Int!, $cursor: String) {
               }
               state
               submittedAt
-              createdAt
             }
           }
           commits(last: 1) {
@@ -344,12 +353,20 @@ if [[ "$PENDING_ONLY" == "true" || "$ALL" == "true" ]]; then
   PAGINATE=true
 fi
 
+# Concatenate two JSON arrays.
+merge_results() {
+  jq -s '.[0] + .[1]' <(echo "$1") <(echo "$2")
+}
+
 # Run a search query and return a JSON array of PR nodes.
-# When PAGINATE is true, follows the cursor until all results are fetched
-# (capped at MAX_PAGES). Otherwise returns the first page only.
+# Pagination defaults to the mode-level PAGINATE flag; pass true as the second
+# argument to force it for a single query. When paginating, follows the cursor
+# until all results are fetched (capped at MAX_PAGES); otherwise returns the
+# first page only.
 MAX_PAGES=20
 run_search() {
   local search_query="$1"
+  local paginate="${2:-$PAGINATE}"
   local cursor=""
   local merged="[]"
   local page page_nodes has_next pages=0
@@ -366,10 +383,10 @@ run_search() {
     }
 
     page_nodes=$(echo "$page" | jq '[.data.search.edges[]?.node | select(. != null)]')
-    merged=$(jq -s '.[0] + .[1]' <(echo "$merged") <(echo "$page_nodes"))
+    merged=$(merge_results "$merged" "$page_nodes")
     pages=$((pages + 1))
 
-    if [[ "$PAGINATE" != "true" ]]; then
+    if [[ "$paginate" != "true" ]]; then
       break
     fi
 
@@ -424,8 +441,20 @@ fi
 ALL_RESULTS="[]"
 for search_query in "${SEARCH_QUERIES[@]}"; do
   NODES=$(run_search "$search_query") || exit 1
-  ALL_RESULTS=$(jq -s '.[0] + .[1]' <(echo "$ALL_RESULTS") <(echo "$NODES"))
+  ALL_RESULTS=$(merge_results "$ALL_RESULTS" "$NODES")
 done
+
+# Sweep for pending (unsubmitted) draft reviews. GitHub removes your
+# review-requested state the moment you start a draft review, so the queries
+# above can miss those PRs entirely. involves:@me finds them; the pre-filter
+# keeps only PRs whose last review by you is an unsubmitted draft. Always
+# paginated: drafts can sit past the first page of involves results.
+# --pending mode already searches involves:@me as its only query.
+if [[ "$PENDING_ONLY" != "true" ]]; then
+  PENDING_NODES=$(run_search "is:pr is:open involves:@me -author:@me org:${ORG}" true) || exit 1
+  PENDING_NODES=$(echo "$PENDING_NODES" | jq --arg user "$GITHUB_USER" -f "${SCRIPT_DIR}/lib/pending-filter.jq")
+  ALL_RESULTS=$(merge_results "$ALL_RESULTS" "$PENDING_NODES")
+fi
 
 # Deduplicate by PR URL
 ALL_RESULTS=$(echo "$ALL_RESULTS" | jq 'unique_by(.url)')
@@ -443,7 +472,7 @@ if [[ "$PENDING_ONLY" == "true" ]]; then
 fi
 
 # Count results. HIDDEN counts PRs dropped by the new-commits gate: you have
-# a draft or submitted review and nothing changed since.
+# a submitted review and nothing changed since. Pending drafts are never hidden.
 COUNT=$(echo "$PROCESSED" | jq 'length')
 HIDDEN=0
 if [[ "$INCLUDE_REVIEWED" != "true" ]]; then
@@ -460,7 +489,7 @@ else
     else
       echo "No PRs awaiting your review in ${ORG}."
       if [[ "$HIDDEN" -gt 0 ]]; then
-        echo "${HIDDEN} PR(s) have your draft or review with no new commits since. Use --include-reviewed to see them."
+        echo "${HIDDEN} PR(s) have your review with no new commits since. Use --include-reviewed to see them."
       fi
     fi
     exit 0
@@ -521,7 +550,7 @@ else
 
   echo ""
   if [[ "$HIDDEN" -gt 0 ]]; then
-    echo "${HIDDEN} more PR(s) have your draft or review with no new commits since. Use --include-reviewed to see them."
+    echo "${HIDDEN} more PR(s) have your review with no new commits since. Use --include-reviewed to see them."
   fi
   echo "Run with --json for machine-readable output."
 fi

--- a/bin/review-all-prs.sh
+++ b/bin/review-all-prs.sh
@@ -453,7 +453,10 @@ done
 if [[ "$PENDING_ONLY" != "true" ]]; then
   PENDING_NODES=$(run_search "is:pr is:open involves:@me -author:@me org:${ORG}" true) || exit 1
   PENDING_NODES=$(echo "$PENDING_NODES" | jq --arg user "$GITHUB_USER" -f "${SCRIPT_DIR}/lib/pending-filter.jq")
-  ALL_RESULTS=$(merge_results "$ALL_RESULTS" "$PENDING_NODES")
+  # Merge the sweep first: unique_by keeps the first copy per URL, and the
+  # sweep copy is the one that captured the pending review if the same PR was
+  # fetched by an earlier query moments before the draft existed.
+  ALL_RESULTS=$(merge_results "$PENDING_NODES" "$ALL_RESULTS")
 fi
 
 # Deduplicate by PR URL

--- a/bin/run-pr-reviews.sh
+++ b/bin/run-pr-reviews.sh
@@ -23,9 +23,12 @@
 #   -h, --help          Show this help message
 #
 # PRs are reviewed in priority order (see review-all-prs.sh): team-authored
-# first, then flags-scoped titles, then the rest. If a review fails because
-# the Claude usage limit was hit, the session stops; the next scheduled tick
-# picks up where it left off once the limit window resets.
+# first, then flags-scoped titles, then the rest. PRs where you have an
+# unsubmitted draft review are skipped: a pending draft means you're
+# mid-review, and GitHub rejects starting another review while one is
+# pending. If a review fails because the Claude usage limit was hit, the
+# session stops; the next scheduled tick picks up where it left off once
+# the limit window resets.
 #
 # State is tracked in ~/.local/state/review-all-prs/ to prevent
 # duplicate reviews within a session.
@@ -102,7 +105,8 @@ Options:
   --priority-team TEAM  PRs authored by members of this team review first
   --all               Widen discovery to the team's whole review queue (see
                       review-all-prs.sh --all). Does not re-review PRs
-                      you've already reviewed with no new commits since.
+                      you've already reviewed with no new commits since, and
+                      skips PRs where you have an unsubmitted draft review.
   -h, --help          Show this help message
 
 Output:
@@ -761,8 +765,8 @@ main() {
 
   # Process via process substitution to keep variables in the parent shell.
   while read -r pr; do
-    local pr_url pr_number pr_title pr_repo pr_author
-    IFS=$'\t' read -r pr_url pr_number pr_title pr_repo pr_author < <(echo "$pr" | jq -r '[.url, (.number | tostring), .title, .repo, .author] | @tsv')
+    local pr_url pr_number pr_title pr_repo pr_author pr_review_state
+    IFS=$'\t' read -r pr_url pr_number pr_title pr_repo pr_author pr_review_state < <(echo "$pr" | jq -r '[.url, (.number | tostring), .title, .repo, .author, .user_review_state] | @tsv')
 
     # Bail out before logging the separator if the next launchd tick is
     # imminent; remaining PRs run on the next tick instead of bleeding into it.
@@ -780,6 +784,16 @@ main() {
 
     if [[ "$pr_author" == "$GITHUB_USER" ]]; then
       log_warn "Skipping PR #${pr_number} - authored by you"
+      mark_skipped "$pr_url"
+      ((skipped++)) || true
+      continue
+    fi
+
+    # A pending draft means you're mid-review, and GitHub rejects starting
+    # another review while one is pending. Hand-piped entries without the
+    # field pass through (empty != PENDING).
+    if [[ "$pr_review_state" == "PENDING" ]]; then
+      log_warn "Skipping PR #${pr_number} - you have an unsubmitted draft review"
       mark_skipped "$pr_url"
       ((skipped++)) || true
       continue


### PR DESCRIPTION
`review-all-prs.sh --all` (and default mode) silently omitted PRs where I have a pending, unsubmitted draft review. Two causes, both fixed:

- Discovery: GitHub drops your review-requested state the moment you start a draft review, so those PRs stopped matching every search query. A paginated `involves:@me` sweep now runs in default and `--all` modes, pre-filtered by the new `lib/pending-filter.jq` so only pending-draft PRs merge in (plain `involves:` matches would flood the list with PRs you merely commented on).
- Filtering: the new-commits gate in `lib/review-filter.jq` treated a stale pending draft as "already reviewed" and hid it. The gate now always keeps a PR whose last review by you is PENDING; a pending review is unfinished work. The `submittedAt // createdAt` fallback that existed for that comparison is gone, along with the `createdAt` field in the GraphQL query.

`run-pr-reviews.sh` now skips pending-draft PRs with a logged per-PR skip, matching the existing self-authored/quarantined skip pattern. Without this, the hourly automation would try to review PRs a human is mid-review on, and GitHub rejects starting a review while one is pending.

Also folds the repeated `jq -s '.[0] + .[1]'` merge into a `merge_results` helper and gives `run_search` a per-call pagination override for the sweep.

## Test plan

- `bash bin/lib/test-review-filter.sh`: 33 assertions pass, including new coverage for `pending-filter.jq` and the flipped stale-pending case
- `bin/review-all-prs.sh --sort repo,status --all` now lists the previously missing PRs with STATUS "Draft pending"
- Subset check: every non-self-authored URL from `--pending` appears in `--all` output (comm -23 returned empty)
- Default mode: `--json` shows pending drafts (9 at time of testing)
- Synthetic dry run of `run-pr-reviews.sh` with a piped list logs "Skipping PR #1 - you have an unsubmitted draft review" and only reviews the non-pending PR

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*