### PR TITLE
Add a force option to tree-me remove

### DIFF
--- a/bin/README-tree-me.md
+++ b/bin/README-tree-me.md
@@ -94,9 +94,24 @@ Shows all worktrees with their paths and checked out branches.
 ```bash
 tree-me remove branch-name          # Full command
 tree-me rm branch-name              # Shorter alias (supports tab completion)
+tree-me rm -f branch-name           # Force, flag position doesn't matter
+tree-me rm -f -f branch-name        # Also removes a locked worktree
+tree-me rm -f "review-*"            # Remove every match without confirming
 ```
 
 Removes the worktree for the specified branch. Use tab completion to see available branches.
+
+`-f` (or `--force`) is repeatable and passed straight through to `git worktree remove`, so git's own advice applies verbatim:
+
+| Situation | Flag |
+| --- | --- |
+| Clean worktree | none |
+| Uncommitted changes or untracked files | `-f` |
+| Locked worktree (`git worktree lock`, or a tool like Supacode that locks the ones it manages) | `-f -f` (or `-ff`) |
+
+For a pattern, `-f` also skips the "Remove N worktree(s)?" confirmation. Every match is attempted even if git refuses one of them; refused worktrees are listed as skipped and the command exits non-zero.
+
+Use `--` if a branch name itself starts with a dash: `tree-me rm -- -weird-branch`.
 
 ### Clean up stale worktrees
 

--- a/bin/README-tree-me.md
+++ b/bin/README-tree-me.md
@@ -164,7 +164,7 @@ export WORKTREE_ROOT=~/projects/worktrees
 This tool is just a thin wrapper. Git does the real work:
 
 | Feature | Native Git Command |
-|---------|-------------------|
+| --- | --- |
 | Create worktree | `git worktree add <path> -b <branch> <base>` |
 | List worktrees | `git worktree list` |
 | Remove worktree | `git worktree remove <path>` |

--- a/bin/lib/test-tree-me-remove.sh
+++ b/bin/lib/test-tree-me-remove.sh
@@ -1,0 +1,192 @@
+#!/bin/bash
+# Tests for `tree-me remove` argument parsing and its -f/--force handling.
+#
+# Usage: test-tree-me-remove.sh
+#
+# Builds a throwaway repo with a few worktrees (clean, dirty, locked) in a temp
+# dir, drives bin/tree-me against it, and cleans up on exit.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=bin/lib/test-helpers.sh
+source "$SCRIPT_DIR/test-helpers.sh"
+BIN="$(cd "$SCRIPT_DIR/.." && pwd)/tree-me"
+
+# ── Fixture: a repo whose worktrees live under $WT_BASE ────────────────────
+
+# Resolve through symlinks (macOS /var -> /private/var) so the literal paths we
+# build match the canonical paths `git worktree list` reports.
+REPO_DIR=$(cd "$(mktemp -d)" && pwd -P)
+WT_BASE=$(cd "$(mktemp -d)" && pwd -P)
+cleanup() {
+  # Locked worktrees survive a plain `rm -rf` of the repo's admin files, so
+  # unlock everything first rather than leaving stray directories behind.
+  git -C "$REPO_DIR" worktree list --porcelain 2>/dev/null |
+    sed -n 's/^worktree //p' |
+    while read -r wt; do git -C "$REPO_DIR" worktree unlock "$wt" 2>/dev/null || true; done
+  rm -rf "$REPO_DIR" "$WT_BASE"
+}
+trap cleanup EXIT
+
+git -C "$REPO_DIR" init -q
+git -C "$REPO_DIR" config user.email test@example.com
+git -C "$REPO_DIR" config user.name "Test"
+# A stable default branch name regardless of the host's init.defaultBranch.
+git -C "$REPO_DIR" checkout -q -b main
+echo one > "$REPO_DIR/file"
+git -C "$REPO_DIR" add file
+git -C "$REPO_DIR" commit -qm "one"
+
+# Creates a worktree for <branch> at $WT_BASE/<branch> and echoes its path.
+mkworktree() {
+  local branch="$1" path="$WT_BASE/$1"
+  git -C "$REPO_DIR" worktree add -q "$path" -b "$branch" main
+  printf '%s\n' "$path"
+}
+
+# Runs tree-me inside the fixture repo, capturing combined output in $out and
+# the exit status in $rc. Stdin is /dev/null so an unexpected confirmation
+# prompt fails the run instead of hanging it.
+tree_me() {
+  rc=0
+  out=$(cd "$REPO_DIR" && WORKTREE_ROOT="$WT_BASE" "$BIN" "$@" </dev/null 2>&1) || rc=$?
+}
+
+# Same, but feeds $1 to the confirmation prompt verbatim (no newline is added,
+# so callers control whether the answer is newline-terminated).
+tree_me_answering() {
+  local answer="$1"
+  shift
+  rc=0
+  out=$(printf '%s' "$answer" |
+    (cd "$REPO_DIR" && WORKTREE_ROOT="$WT_BASE" "$BIN" "$@" 2>&1)) || rc=$?
+}
+
+# ── Test: a clean worktree needs no force ──────────────────────────────────
+
+path=$(mkworktree clean-one)
+tree_me rm clean-one
+assert "removes a clean worktree without -f" test "$rc" -eq 0
+assert "clean worktree directory is gone" test ! -d "$path"
+
+# ── Test: -f removes a worktree with uncommitted changes ───────────────────
+
+path=$(mkworktree dirty-one)
+echo changed > "$path/file"
+tree_me rm dirty-one
+assert "refuses a dirty worktree without -f" test "$rc" -ne 0
+assert "dirty worktree survives the refusal" test -d "$path"
+
+tree_me rm -f dirty-one
+assert "-f removes a dirty worktree" test "$rc" -eq 0
+assert "dirty worktree directory is gone" test ! -d "$path"
+
+# ── Test: the flag is positional-agnostic ──────────────────────────────────
+
+path=$(mkworktree dirty-two)
+echo changed > "$path/file"
+tree_me rm dirty-two -f
+assert "-f is accepted after the branch name" test "$rc" -eq 0
+assert "trailing -f removed the worktree" test ! -d "$path"
+
+# ── Test: a locked worktree needs -f twice, as git itself does ─────────────
+
+path=$(mkworktree locked-one)
+git -C "$REPO_DIR" worktree lock "$path" --reason "test"
+tree_me rm -f locked-one
+assert "a single -f leaves a locked worktree alone" test "$rc" -ne 0
+assert "locked worktree survives a single -f" test -d "$path"
+
+tree_me rm -f -f locked-one
+assert "-f -f removes a locked worktree" test "$rc" -eq 0
+assert "locked worktree directory is gone" test ! -d "$path"
+
+path=$(mkworktree locked-two)
+git -C "$REPO_DIR" worktree lock "$path" --reason "test"
+tree_me rm -ff locked-two
+assert "-ff is the same as -f -f" test "$rc" -eq 0
+assert "-ff removed the locked worktree" test ! -d "$path"
+
+path=$(mkworktree locked-three)
+git -C "$REPO_DIR" worktree lock "$path" --reason "test"
+tree_me rm --force --force locked-three
+assert "--force --force removes a locked worktree" test "$rc" -eq 0
+assert "--force --force removed the worktree directory" test ! -d "$path"
+
+# ── Test: the confirmation a pattern prompts for ───────────────────────────
+
+path_a=$(mkworktree "review-a")
+path_b=$(mkworktree "review-b")
+tree_me rm "review-*"
+assert "a pattern with no answer on stdin aborts" test "$rc" -eq 0
+assert "aborted pattern leaves the first worktree" test -d "$path_a"
+assert "aborted pattern leaves the second worktree" test -d "$path_b"
+
+tree_me_answering "n"$'\n' rm "review-*"
+assert "answering no aborts" test "$rc" -eq 0
+assert "a declined pattern leaves both worktrees" test -d "$path_a" -a -d "$path_b"
+
+# Without a trailing newline `read` reports EOF, but it has still read the
+# answer, which must count as the yes it is.
+tree_me_answering "y" rm "review-*"
+assert "answering yes without a newline removes every match" test "$rc" -eq 0
+assert "unterminated yes removed the first match" test ! -d "$path_a"
+assert "unterminated yes removed the second match" test ! -d "$path_b"
+
+path_a=$(mkworktree "review-c")
+path_b=$(mkworktree "review-d")
+tree_me_answering "y"$'\n' rm "review-*"
+assert "answering yes removes every match" test "$rc" -eq 0
+assert "confirmed pattern removed the first match" test ! -d "$path_a"
+assert "confirmed pattern removed the second match" test ! -d "$path_b"
+
+# ── Test: -f skips the confirmation entirely ───────────────────────────────
+
+path_a=$(mkworktree "review-e")
+path_b=$(mkworktree "review-f")
+tree_me rm -f "review-*"
+assert "-f removes every match without prompting" test "$rc" -eq 0
+assert "first pattern match is gone" test ! -d "$path_a"
+assert "second pattern match is gone" test ! -d "$path_b"
+
+# ── Test: a match git refuses doesn't strand the rest of the batch ─────────
+
+path_a=$(mkworktree "batch-a")
+path_b=$(mkworktree "batch-b")
+path_c=$(mkworktree "batch-c")
+git -C "$REPO_DIR" worktree lock "$path_b" --reason "test"
+tree_me rm -f "batch-*"
+assert "a refused match makes the run fail" test "$rc" -ne 0
+assert "the match before the failure is removed" test ! -d "$path_a"
+assert "the refused match survives" test -d "$path_b"
+assert "the match after the failure is still attempted" test ! -d "$path_c"
+assert "the refused match is named in the output" test "${out#*batch-b}" != "$out"
+git -C "$REPO_DIR" worktree unlock "$path_b"
+
+# ── Test: bad arguments are reported as such, not treated as branch names ──
+
+tree_me rm -f
+assert "a bare -f is a missing-argument error" test "$rc" -ne 0
+assert "missing argument does not report -f as a branch" \
+  test "${out#*No worktree found}" = "$out"
+
+tree_me rm --bogus some-branch
+assert "an unknown option fails" test "$rc" -ne 0
+assert "an unknown option says so" test "${out#*Unknown option}" != "$out"
+
+tree_me rm one-branch another-branch
+assert "two branch names fail" test "$rc" -ne 0
+assert "two branch names report the extra argument" \
+  test "${out#*another-branch}" != "$out"
+
+# ── Test: -- ends option parsing ───────────────────────────────────────────
+
+tree_me rm -- -f
+assert "-- treats a following -f as the branch name" test "$rc" -ne 0
+assert "-- reports the dash-name as a missing worktree" \
+  test "${out#*No worktree found}" != "$out"
+
+# ── Results ────────────────────────────────────────────────────────────────
+
+print_results

--- a/bin/tree-me
+++ b/bin/tree-me
@@ -46,9 +46,15 @@ Commands:
   create <branch> [base]        Create new branch in worktree (default: main/master)
   pr <number|url>               Checkout GitHub PR in worktree (uses gh)
   list, ls                      List all worktrees
-  remove, rm <branch|pattern>   Remove a worktree (quote patterns: "review-*")
+  remove, rm [-f] <branch|pat>  Remove a worktree (quote patterns: "review-*")
   prune                         Remove worktree administrative files
   shellenv                      Output shell function for auto-cd (source this)
+
+Options:
+  -f, --force                   For remove: drop a worktree with uncommitted
+                                changes, and remove every match of a pattern
+                                without confirming. Repeat it (-f -f) to remove
+                                a locked worktree, as git itself requires.
 
 Examples:
   tree-me switch feature-branch
@@ -59,6 +65,8 @@ Examples:
   tree-me pr https://github.com/org/repo/pull/123
   tree-me list
   tree-me remove old-branch
+  tree-me remove -f old-branch
+  tree-me remove -f -f locked-branch
   tree-me remove "review-*"
   tree-me prune
 
@@ -254,10 +262,9 @@ tree-me() {
 # Bash completion
 if [ -n "$BASH_VERSION" ]; then
     _tree_me_complete() {
-        local cur prev commands
+        local cur commands
         COMPREPLY=()
         cur="${COMP_WORDS[COMP_CWORD]}"
-        prev="${COMP_WORDS[COMP_CWORD-1]}"
         commands="switch sw create pr list ls remove rm prune help shellenv"
 
         # Complete commands if first argument
@@ -266,12 +273,21 @@ if [ -n "$BASH_VERSION" ]; then
             return 0
         fi
 
-        # Complete branch names for switch/remove/rm
-        case "$prev" in
+        # Complete branch names for switch/remove/rm. Keyed off the subcommand
+        # rather than the previous word so a flag before the branch (rm -f) does
+        # not turn completion off.
+        case "${COMP_WORDS[1]}" in
             co|checkout|switch|sw|remove|rm)
-                local branches
-                branches=$(git worktree list 2>/dev/null | sed -n 's/.*\[\([^]]*\)\].*/\1/p' | tail -n +2)
-                COMPREPLY=( $(compgen -W "$branches" -- "$cur") )
+                local candidates
+                candidates=$(git worktree list 2>/dev/null | sed -n 's/.*\[\([^]]*\)\].*/\1/p' | tail -n +2)
+                # Offered only once a dash is typed, so a lone branch still
+                # completes on its own rather than tying with the flag.
+                case "${COMP_WORDS[1]}" in
+                    remove|rm)
+                        [[ "$cur" == -* ]] && candidates="$candidates -f"
+                        ;;
+                esac
+                COMPREPLY=( $(compgen -W "$candidates" -- "$cur") )
                 return 0
                 ;;
         esac
@@ -299,10 +315,20 @@ if [ -n "$ZSH_VERSION" ]; then
 
         if (( CURRENT == 2 )); then
             _describe 'command' commands
-        elif (( CURRENT == 3 )); then
+        else
+            # Not pinned to CURRENT == 3, so a flag before the branch (rm -f)
+            # does not turn completion off.
             case "$words[2]" in
                 checkout|co|switch|sw|remove|rm)
                     branches=(${(f)"$(git worktree list 2>/dev/null | sed -n 's/.*\[\([^]]*\)\].*/\1/p' | tail -n +2)"})
+                    # Offered only once a dash is typed, so a lone branch still
+                    # completes on its own rather than tying with the flag.
+                    case "$words[2]" in
+                        remove|rm)
+                            [[ "$words[CURRENT]" == -* ]] && \
+                                branches+=('-f:Force removal; repeat for a locked worktree')
+                            ;;
+                    esac
                     _describe 'branch' branches
                     ;;
             esac
@@ -377,7 +403,41 @@ EOF
         ;;
 
     remove|rm)
-        pattern="${1:?Branch name or pattern required. Usage: tree-me remove <branch|pattern>}"
+        # -f is repeatable and forwarded to git as-is, so git's own advice
+        # ("use 'remove -f -f' to override") is directly runnable here: one -f
+        # removes a worktree with uncommitted changes, two also removes a
+        # locked one. It doubles as the "don't ask" flag for patterns.
+        force=0
+        args=()
+        while [ $# -gt 0 ]; do
+            case "$1" in
+                -f|--force) force=$((force + 1)) ;;
+                -ff) force=$((force + 2)) ;;
+                --) shift; args+=("$@"); break ;;
+                -*)
+                    echo "Error: Unknown option '$1'" >&2
+                    echo "Usage: tree-me remove [-f] <branch|pattern>" >&2
+                    exit 1
+                    ;;
+                *) args+=("$1") ;;
+            esac
+            shift
+        done
+
+        if [ ${#args[@]} -eq 0 ]; then
+            echo "Error: Branch name or pattern required. Usage: tree-me remove [-f] <branch|pattern>" >&2
+            exit 1
+        fi
+        if [ ${#args[@]} -gt 1 ]; then
+            echo "Error: Unexpected argument '${args[1]}' (quote patterns: \"review-*\")" >&2
+            echo "Usage: tree-me remove [-f] <branch|pattern>" >&2
+            exit 1
+        fi
+        pattern="${args[0]}"
+
+        force_args=()
+        [ "$force" -ge 1 ] && force_args+=(--force)
+        [ "$force" -ge 2 ] && force_args+=(--force)
 
         declare -A branch_to_path=()
         branches=()
@@ -404,23 +464,36 @@ EOF
             exit 1
         fi
 
-        if [ "$is_glob" = 1 ]; then
+        if [ "$is_glob" = 1 ] && [ "$force" -eq 0 ]; then
             echo "Matching worktrees:"
             for b in "${matches[@]}"; do
                 echo "  $b → ${branch_to_path[$b]}"
             done
-            read -r -p "Remove ${#matches[@]} worktree(s)? [y/N] " response
+            # `read` reports EOF as a failure even when it read an answer that
+            # simply lacked a trailing newline, so keep whatever it did read
+            # and let the default-to-no check below decide. Under `set -e` a
+            # bare EOF would otherwise abort the script instead of declining.
+            read -r -p "Remove ${#matches[@]} worktree(s)? [y/N] " response || true
             if [[ ! "$response" =~ ^[Yy]$ ]]; then
                 echo "Aborted"
                 exit 0
             fi
         fi
 
+        # One match git refuses (locked, or dirty without -f) shouldn't strand
+        # the rest of the batch unattempted, so report it and carry on, with
+        # the final status reflecting that something was left behind.
+        failed=0
         for b in "${matches[@]}"; do
             path="${branch_to_path[$b]}"
-            git worktree remove "$path"
-            echo "✓ Removed worktree: $path"
+            if git worktree remove "${force_args[@]}" "$path"; then
+                echo "✓ Removed worktree: $path"
+            else
+                echo "✗ Skipped worktree: $path" >&2
+                failed=1
+            fi
         done
+        [ "$failed" -eq 0 ] || exit 1
         ;;
 
     prune)


### PR DESCRIPTION
`tree-me remove` only took a branch name or pattern, so the flag was either ignored or mistaken for a branch:

```
$ tree-me remove some/branch -f
fatal: cannot remove a locked working tree, lock reason: {"owner":"supacode",…}
use 'remove -f -f' to override or unlock first

$ tree-me remove -f some/branch
Error: No worktree found for branch: -f
```

`remove`/`rm` now parses options in either position: `-f`, `--force`, `-ff`, and `--` to stop option parsing for a branch name that starts with a dash. Each `-f` is forwarded to `git worktree remove` as-is, so git's semantics carry through. One drops a worktree with uncommitted changes, two also drop a locked one. That makes the advice in git's own error message runnable as `tree-me remove -f -f <branch>`, which is what a Supacode-locked worktree needs.

Also in here:

- `-f` skips the "Remove N worktree(s)?" confirmation for patterns.
- A refused match no longer aborts the loop mid-batch. The remaining matches are still attempted, the refused one is reported as skipped, and the command exits non-zero.
- Answering the confirmation without a trailing newline counted as no, because `read` reports EOF as a failure even after reading the answer. It now counts as the yes it is.
- An unknown option is an error rather than a branch name, and a bare `tree-me rm -f` reports a missing argument instead of hunting for a worktree called `-f`.
- Tab completion in bash and zsh keeps offering branches once a flag is present, and suggests `-f` for `remove`/`rm` once a dash is typed.

## Test plan

`bin/lib/test-tree-me-remove.sh` follows the existing `bin/lib/test-*.sh` convention: it builds a throwaway repo with clean, dirty, and locked worktrees and drives the real script against it. 43 assertions, all passing. The two behavior fixes above have regression tests that were confirmed to fail against the pre-fix code. Shellcheck is clean apart from the pre-existing SC1091 sourcing notes.

To check by hand:

```bash
bash bin/lib/test-tree-me-remove.sh
tree-me rm -f -f <branch-of-a-locked-worktree>
```