### PR TITLE
Follow PR template agent-context sections instead of stripping them

### DIFF
--- a/ai/CLAUDE.md
+++ b/ai/CLAUDE.md
@@ -33,7 +33,7 @@ When a plan is implemented/merged, move it to `plans/archive/` within the same r
 
 - Branch names: `haacked/<slug>`
 - Don't add yourself as a contributor to commits.
-- Commit messages: present tense imperatives ("Add", "Fix", "Remove"), short and concise, no AI attribution.
+- Commit messages: present tense imperatives ("Add", "Fix", "Remove"), short and concise, no volunteered AI attribution (tool-mandated trailers may stand).
 - When fixing a bug, include `Fixes #123` on its own line.
 
 ### Before Committing
@@ -45,7 +45,7 @@ When a plan is implemented/merged, move it to `plans/archive/` within the same r
 
 ## GitHub Operations
 
-Write as the user in all public-facing content — never refer to yourself as an AI. Never include AI/LLM attribution, co-authorship notes, or LLM context sections in PRs, commits, or any public-facing content.
+Write as the user in all public-facing content — don't refer to yourself as an AI, and don't volunteer AI/LLM attribution, co-authorship notes, or agent-context sections in PRs, commits, or other public-facing content. Two exceptions win over that default: when a repo's PR template asks about agent involvement (e.g. an "Agent context" section), follow the template and fill it honestly as the agent; and attribution the coding tool itself mandates (e.g. PostHog Code's commit trailers and PR footer) may stand.
 
 **Always use `gh` CLI** for GitHub operations. Never use GitHub MCP server tools.
 

--- a/ai/CLAUDE.md
+++ b/ai/CLAUDE.md
@@ -32,7 +32,7 @@ When a plan is implemented/merged, move it to `plans/archive/` within the same r
 ## Git
 
 - Branch names: `haacked/<slug>`
-- Don't add yourself as a contributor to commits.
+- Don't volunteer yourself as a contributor to commits.
 - Commit messages: present tense imperatives ("Add", "Fix", "Remove"), short and concise, no volunteered AI attribution (tool-mandated trailers may stand).
 - When fixing a bug, include `Fixes #123` on its own line.
 
@@ -45,7 +45,7 @@ When a plan is implemented/merged, move it to `plans/archive/` within the same r
 
 ## GitHub Operations
 
-Write as the user in all public-facing content — don't refer to yourself as an AI, and don't volunteer AI/LLM attribution, co-authorship notes, or agent-context sections in PRs, commits, or other public-facing content. Two exceptions win over that default: when a repo's PR template asks about agent involvement (e.g. an "Agent context" section), follow the template and fill it honestly as the agent; and attribution the coding tool itself mandates (e.g. PostHog Code's commit trailers and PR footer) may stand.
+Write as the user in all public-facing content — don't refer to yourself as an AI, and don't volunteer AI/LLM attribution, co-authorship notes, or agent-context sections in PRs, commits, or other public-facing content. Two exceptions win over that default: when a repo's PR template asks about agent involvement (e.g. an "Agent context" section), follow the template and fill it honestly as the agent; and attribution the coding tool itself mandates (e.g. PostHog Code's commit trailers and PR footer) is fine to add and keep.
 
 **Always use `gh` CLI** for GitHub operations. Never use GitHub MCP server tools.
 

--- a/ai/agents/code-reviewer.md
+++ b/ai/agents/code-reviewer.md
@@ -18,7 +18,7 @@ You are a senior code reviewer focused on correctness and safety. Catch bugs, se
 
 2. **Security** — Input validation, injection flaws, auth issues, data exposure, unsafe data handling.
 
-3. **Project Guidelines** — Violations of explicit rules in the project's CLAUDE.md. High-value checks: duplicate logic (OnceAndOnlyOnce), premature optimization (work → right → fast ordering), AI attribution in commits or public-facing text, error handling patterns, naming conventions.
+3. **Project Guidelines** — Violations of explicit rules in the project's CLAUDE.md. High-value checks: duplicate logic (OnceAndOnlyOnce), premature optimization (work → right → fast ordering), volunteered AI attribution in commits or public-facing text (agent-context sections a PR template requests, and tool-mandated trailers, are expected), error handling patterns, naming conventions.
 
 4. **Test Coverage** — Missing coverage for new/changed code paths, tests that don't verify behavior, missing edge case and error path coverage.
 

--- a/ai/agents/code-reviewer.md
+++ b/ai/agents/code-reviewer.md
@@ -18,7 +18,7 @@ You are a senior code reviewer focused on correctness and safety. Catch bugs, se
 
 2. **Security** — Input validation, injection flaws, auth issues, data exposure, unsafe data handling.
 
-3. **Project Guidelines** — Violations of explicit rules in the project's CLAUDE.md. High-value checks: duplicate logic (OnceAndOnlyOnce), premature optimization (work → right → fast ordering), volunteered AI attribution in commits or public-facing text (agent-context sections a PR template requests, and tool-mandated trailers, are expected), error handling patterns, naming conventions.
+3. **Project Guidelines** — Violations of explicit rules in the project's CLAUDE.md. High-value checks: duplicate logic (OnceAndOnlyOnce), premature optimization (work → right → fast ordering), volunteered AI attribution in commits or public-facing text (template-requested agent-context sections and tool-mandated trailers are not violations), error handling patterns, naming conventions.
 
 4. **Test Coverage** — Missing coverage for new/changed code paths, tests that don't verify behavior, missing edge case and error path coverage.
 

--- a/ai/skills/commit/SKILL.md
+++ b/ai/skills/commit/SKILL.md
@@ -52,7 +52,7 @@ If `git status` shows a clean working tree with nothing staged, tell the user th
 
 **Subject line rules:**
 
-- Follow the commit-message conventions in CLAUDE.md (imperative verb, final state not the journey, no AI attribution); no period at the end
+- Follow the commit-message conventions in CLAUDE.md (imperative verb, final state not the journey, no volunteered AI attribution); no period at the end
 - If `message_hint` is non-empty, use it verbatim as the subject line (trim whitespace; do not rephrase)
 
 ### 3. Show Preview and Confirm

--- a/ai/skills/commit/SKILL.md
+++ b/ai/skills/commit/SKILL.md
@@ -48,6 +48,8 @@ If `git status` shows a clean working tree with nothing staged, tell the user th
  why the change exists; omit entirely for small, obvious changes]
 
 [Fixes #<issue> — include only when this commit closes a GitHub issue]
+
+[trailers the coding tool mandates (e.g. Generated-By) — keep them last]
 ```
 
 **Subject line rules:**

--- a/ai/skills/create-pr/SKILL.md
+++ b/ai/skills/create-pr/SKILL.md
@@ -146,7 +146,7 @@ If a template was found, fill each section using the commits and diff:
 - Remove unfilled optional sections rather than leaving placeholder text
 - Leave checkboxes intact; check the ones clearly satisfied by the diff
 - **Never include customer-specific data.** Redact or omit any team IDs, team names, organization names, user IDs, or other identifying customer information found in commits or diffs; describe the fix generically instead (e.g., "fixes flag evaluation for teams with large cohorts" not "fixes team 12345 / Acme Corp")
-- **Agent/AI context sections: follow the template.** If the template asks about agent involvement or AI context (e.g. posthog/posthog's `## 🤖 Agent context`), fill it per "Filling an agent-context section" below. If no template section asks, the root CLAUDE.md default holds: don't volunteer AI attribution
+- **Agent/AI context sections: follow the template.** If the template asks about agent involvement or AI context (e.g. posthog/posthog's `## 🤖 Agent context`), fill it per "Filling an agent-context section" below. If no template section asks, the `~/.claude/CLAUDE.md` default holds: don't volunteer AI attribution
 - **Never hard-wrap prose.** Write each paragraph as a single line and let GitHub's renderer handle wrapping; only insert newlines between paragraphs, list items, or headings
 - **Never escape backticks, dollar signs, or other markdown.** Step 9 passes the body through a quoted heredoc (`<<'EOF'`), which is literal; write `` `foo` `` not `` \`foo\` ``, and `$var` not `\$var`
 

--- a/ai/skills/create-pr/SKILL.md
+++ b/ai/skills/create-pr/SKILL.md
@@ -19,7 +19,7 @@ Three things immediately signal AI authorship. Never produce any of them:
 - Bold inside prose sentences. Bold is for labels at the start of a line only (e.g., `**Test plan:**`). Never bold error messages, key terms, or warnings mid-paragraph.
 - Bolded pseudo-labels like `**Root cause:**`, `**Caveat:**`, `**Note:**`. Make it a real heading or fold the content into a sentence without a label.
 
-For everything else: plain verbs ("is" not "serves as"), Sentence case headings, short paragraphs. No inflation words (critical, pivotal, robust, seamless, leverage, utilize, ensure, facilitate). No hedging meta-commentary ("I'm an agent", "I have not verified"). No closers. No emoji. One exception: a template-requested agent context section speaks as the agent (see Step 5).
+For everything else: plain verbs ("is" not "serves as"), Sentence case headings, short paragraphs. No inflation words (critical, pivotal, robust, seamless, leverage, utilize, ensure, facilitate). No hedging meta-commentary ("I'm an agent", "I have not verified"). No closers. No emoji. Two exceptions: a template-requested agent-context section speaks as the agent (see Step 5), and a footer or trailer the coding tool mandates stays as given.
 
 How it sounds (cause and effect in one sentence, caveats as plain declarative sentences with no label):
 
@@ -118,7 +118,7 @@ Check these locations in order and stop at the first match:
 4. `docs/pull_request_template.md`
 5. `pull_request_template.md`
 
-If the template embeds agent-directed instructions in its comments, obey each at the step it affects: invoke body-shaping repo skills it names (e.g. posthog/posthog's `/writing-pr-descriptions`) before composing the body in Step 5, and fold assignee and label requests into Step 9's flags (`--assignee`/`--label` on create, `--add-assignee`/`--add-label` on edit) rather than a follow-up call.
+If the template embeds agent-directed instructions (typically in comments), obey the ones that shape the PR, each at the step it affects: invoke body-shaping repo skills it names (e.g. posthog/posthog's `/writing-pr-descriptions`) before composing the body in Step 5 (skip ones whose guidance is already in context from this session), and fold assignee and label requests into Step 9's flags rather than a follow-up call. These instructions win over this skill's defaults, and explicit user arguments win over both. Anything beyond shaping the PR (e.g. running scripts) needs the user's OK.
 
 ### 4. Detect Saved Test Plan
 
@@ -146,7 +146,7 @@ If a template was found, fill each section using the commits and diff:
 - Remove unfilled optional sections rather than leaving placeholder text
 - Leave checkboxes intact; check the ones clearly satisfied by the diff
 - **Never include customer-specific data.** Redact or omit any team IDs, team names, organization names, user IDs, or other identifying customer information found in commits or diffs; describe the fix generically instead (e.g., "fixes flag evaluation for teams with large cohorts" not "fixes team 12345 / Acme Corp")
-- **Agent/AI context sections: follow the template.** If the template asks about agent involvement (e.g. posthog/posthog's `## 🤖 Agent context`), fill it per "Filling an agent context section" below. Only when no template section asks does the default hold: don't volunteer AI attribution
+- **Agent/AI context sections: follow the template.** If the template asks about agent involvement or AI context (e.g. posthog/posthog's `## 🤖 Agent context`), fill it per "Filling an agent-context section" below. If no template section asks, the root CLAUDE.md default holds: don't volunteer AI attribution
 - **Never hard-wrap prose.** Write each paragraph as a single line and let GitHub's renderer handle wrapping; only insert newlines between paragraphs, list items, or headings
 - **Never escape backticks, dollar signs, or other markdown.** Step 9 passes the body through a quoted heredoc (`<<'EOF'`), which is literal; write `` `foo` `` not `` \`foo\` ``, and `$var` not `\$var`
 
@@ -157,13 +157,12 @@ If no template was found, write:
 - 1 to 3 bullet points summarizing what the PR does (no customer-specific IDs or names)
 - A short **Test plan** section describing how to verify the change
 
-**Filling an agent context section (if the template has one):**
+**Filling an agent-context section (if the template has one):**
 
-- The section's own embedded instructions win over this skill's defaults. If it is commented out with activation instructions (e.g. "uncomment if AI-assisted"), follow them.
-- Autonomy: pick honestly from the options the template offers. Work the user directed is agent-assisted (e.g. posthog's "Human-driven (agent-assisted)"), the normal case for this skill; a fully autonomous label is only for work no human drove.
-- Content: a handful of reviewer-facing bullets covering what the agent did, what the user decided or redirected along the way, and skills invoked. No verbatim prompts, no session logs, no sensitive data, no duplication of earlier sections.
-- Voice: this section speaks as the agent, first person allowed; every other section stays in the user's voice. The three hard rules (no em dashes, no bold in prose, no bolded pseudo-labels) still apply. Bold field labels the template itself defines (e.g. `**Autonomy:**`) are kept.
-- Obey the template's other agent-directed instructions (assignee/DRI, labels, named repo skills) per Step 3.
+- The section's own embedded instructions win over this skill's defaults. If it is commented out with activation instructions (e.g. "uncomment if AI-assisted"), follow them; if it is commented out with no instructions, the repo didn't ask: remove it rather than uncommenting.
+- Autonomy: pick honestly from the options the template offers. User-directed work (the normal case for this skill) is agent-assisted (e.g. posthog's "Human-driven (agent-assisted)"); reserve a fully autonomous label for work no human drove.
+- Content: answer what the section asks at the size it asks (a lone checkbox gets a check, not an essay). When it wants prose: a handful of reviewer-facing bullets covering what the agent did, what the user decided or redirected along the way, and skills invoked. No verbatim prompts, no session logs, no sensitive data, no duplication of earlier sections.
+- Voice: this section speaks as the agent, first person allowed; every other section stays in the user's voice. Every other Writing voice rule, hard and soft, still applies. Bold field labels the template itself defines (e.g. `**Autonomy:**`) are kept.
 
 **Embedding the saved test plan (if `test_plan_content` is set):**
 
@@ -189,7 +188,7 @@ Notes:
 
 ### 6. Verify voice before preview
 
-Re-read the composed body against the Writing voice rules and rewrite any violating sentence. Then ask yourself: would a staff engineer write this sentence verbatim in a Slack message to a teammate? If not, simplify it. The agent context section is exempt from the staff-engineer test; it speaks as the agent.
+Re-read the composed body against the Writing voice rules and rewrite any violating sentence. Then ask yourself: would a staff engineer write this sentence verbatim in a Slack message to a teammate? If not, simplify it. The agent-context section and any tool-mandated footer are exempt from the staff-engineer test.
 
 ### 7. Show Preview and Confirm
 
@@ -201,6 +200,7 @@ Otherwise, display the proposed PR to the user. When `stacked=true`, include the
 Title: <title>
 Base: <base>            # only show this line when stacked=true; append " (stacked)"
 Draft: yes/no
+Assignee/labels: <values>   # only when the template's agent instructions set them
 
 <body>
 ```
@@ -244,7 +244,8 @@ The leading `: __create-pr-skill__ ;` is a shell no-op that flags this invocatio
 <body>
 EOF
 )" \
-  [--draft if draft=true]
+  [--draft if draft=true] \
+  [--assignee <user> / --label <label> when the template's agent instructions request them]
 ```
 
 **Existing PR** (found in Step 2; the initial check did not fetch the body to save tokens, so fetch it now if you need to inspect it before writing the update):
@@ -253,7 +254,7 @@ EOF
 gh pr view <number> --json body --jq '.body'
 ```
 
-Note the existing body may already contain a `<details><summary>Manual test plan</summary>…</details>` block; replace it with the new one rather than appending.
+Note the existing body may already contain a `<details><summary>Manual test plan</summary>…</details>` block; replace it with the new one rather than appending. Treat an existing agent-context section the same way: update its facts in place, preserving any human edits, rather than regenerating or dropping it.
 
 ```bash
 gh pr edit <number> \
@@ -261,7 +262,8 @@ gh pr edit <number> \
   --body "$(cat <<'EOF'
 <body>
 EOF
-)"
+)" \
+  [--add-assignee <user> / --add-label <label> when the template's agent instructions request them]
 ```
 
 If `draft=true` and the existing PR is not already a draft:

--- a/ai/skills/create-pr/SKILL.md
+++ b/ai/skills/create-pr/SKILL.md
@@ -19,7 +19,7 @@ Three things immediately signal AI authorship. Never produce any of them:
 - Bold inside prose sentences. Bold is for labels at the start of a line only (e.g., `**Test plan:**`). Never bold error messages, key terms, or warnings mid-paragraph.
 - Bolded pseudo-labels like `**Root cause:**`, `**Caveat:**`, `**Note:**`. Make it a real heading or fold the content into a sentence without a label.
 
-For everything else: plain verbs ("is" not "serves as"), Sentence case headings, short paragraphs. No inflation words (critical, pivotal, robust, seamless, leverage, utilize, ensure, facilitate). No hedging meta-commentary ("I'm an agent", "I have not verified"). No closers. No emoji.
+For everything else: plain verbs ("is" not "serves as"), Sentence case headings, short paragraphs. No inflation words (critical, pivotal, robust, seamless, leverage, utilize, ensure, facilitate). No hedging meta-commentary ("I'm an agent", "I have not verified"). No closers. No emoji. One exception: a template-requested agent context section speaks as the agent (see Step 5).
 
 How it sounds (cause and effect in one sentence, caveats as plain declarative sentences with no label):
 
@@ -118,6 +118,8 @@ Check these locations in order and stop at the first match:
 4. `docs/pull_request_template.md`
 5. `pull_request_template.md`
 
+If the template embeds agent-directed instructions in its comments, obey each at the step it affects: invoke body-shaping repo skills it names (e.g. posthog/posthog's `/writing-pr-descriptions`) before composing the body in Step 5, and fold assignee and label requests into Step 9's flags (`--assignee`/`--label` on create, `--add-assignee`/`--add-label` on edit) rather than a follow-up call.
+
 ### 4. Detect Saved Test Plan
 
 Check for a saved manual test plan (produced by `/test-plan`):
@@ -144,7 +146,7 @@ If a template was found, fill each section using the commits and diff:
 - Remove unfilled optional sections rather than leaving placeholder text
 - Leave checkboxes intact; check the ones clearly satisfied by the diff
 - **Never include customer-specific data.** Redact or omit any team IDs, team names, organization names, user IDs, or other identifying customer information found in commits or diffs; describe the fix generically instead (e.g., "fixes flag evaluation for teams with large cohorts" not "fixes team 12345 / Acme Corp")
-- **Never uncomment, fill in, or add LLM/AI context sections.** If the template contains a commented-out LLM context section, leave it commented out or remove it entirely
+- **Agent/AI context sections: follow the template.** If the template asks about agent involvement (e.g. posthog/posthog's `## 🤖 Agent context`), fill it per "Filling an agent context section" below. Only when no template section asks does the default hold: don't volunteer AI attribution
 - **Never hard-wrap prose.** Write each paragraph as a single line and let GitHub's renderer handle wrapping; only insert newlines between paragraphs, list items, or headings
 - **Never escape backticks, dollar signs, or other markdown.** Step 9 passes the body through a quoted heredoc (`<<'EOF'`), which is literal; write `` `foo` `` not `` \`foo\` ``, and `$var` not `\$var`
 
@@ -154,6 +156,14 @@ If no template was found, write:
 
 - 1 to 3 bullet points summarizing what the PR does (no customer-specific IDs or names)
 - A short **Test plan** section describing how to verify the change
+
+**Filling an agent context section (if the template has one):**
+
+- The section's own embedded instructions win over this skill's defaults. If it is commented out with activation instructions (e.g. "uncomment if AI-assisted"), follow them.
+- Autonomy: pick honestly from the options the template offers. Work the user directed is agent-assisted (e.g. posthog's "Human-driven (agent-assisted)"), the normal case for this skill; a fully autonomous label is only for work no human drove.
+- Content: a handful of reviewer-facing bullets covering what the agent did, what the user decided or redirected along the way, and skills invoked. No verbatim prompts, no session logs, no sensitive data, no duplication of earlier sections.
+- Voice: this section speaks as the agent, first person allowed; every other section stays in the user's voice. The three hard rules (no em dashes, no bold in prose, no bolded pseudo-labels) still apply. Bold field labels the template itself defines (e.g. `**Autonomy:**`) are kept.
+- Obey the template's other agent-directed instructions (assignee/DRI, labels, named repo skills) per Step 3.
 
 **Embedding the saved test plan (if `test_plan_content` is set):**
 
@@ -179,7 +189,7 @@ Notes:
 
 ### 6. Verify voice before preview
 
-Re-read the composed body against the Writing voice rules and rewrite any violating sentence. Then ask yourself: would a staff engineer write this sentence verbatim in a Slack message to a teammate? If not, simplify it.
+Re-read the composed body against the Writing voice rules and rewrite any violating sentence. Then ask yourself: would a staff engineer write this sentence verbatim in a Slack message to a teammate? If not, simplify it. The agent context section is exempt from the staff-engineer test; it speaks as the agent.
 
 ### 7. Show Preview and Confirm
 

--- a/ai/skills/github-pr-operations/SKILL.md
+++ b/ai/skills/github-pr-operations/SKILL.md
@@ -5,7 +5,7 @@ description: Reference for GitHub PR review endpoints and resolving review threa
 
 # GitHub PR Operations
 
-Endpoint reference for PR review operations. The always-on rules (never post without approval, always use `gh` CLI, no AI attribution) live in the root `CLAUDE.md` — this skill is just the mechanics. For the end-to-end review-comment workflow (deciding what's a real issue, drafting replies, when to resolve vs. leave open), use the `address-pr-reviews` skill instead — it embeds these same commands in context.
+Endpoint reference for PR review operations. The always-on rules (never post without approval, always use `gh` CLI, no volunteered AI attribution) live in the root `CLAUDE.md` — this skill is just the mechanics. For the end-to-end review-comment workflow (deciding what's a real issue, drafting replies, when to resolve vs. leave open), use the `address-pr-reviews` skill instead — it embeds these same commands in context.
 
 ## Posting review comments
 

--- a/ai/skills/github-pr-operations/SKILL.md
+++ b/ai/skills/github-pr-operations/SKILL.md
@@ -5,7 +5,7 @@ description: Reference for GitHub PR review endpoints and resolving review threa
 
 # GitHub PR Operations
 
-Endpoint reference for PR review operations. The always-on rules (never post without approval, always use `gh` CLI, no volunteered AI attribution) live in the root `CLAUDE.md` — this skill is just the mechanics. For the end-to-end review-comment workflow (deciding what's a real issue, drafting replies, when to resolve vs. leave open), use the `address-pr-reviews` skill instead — it embeds these same commands in context.
+Endpoint reference for PR review operations. The always-on rules (never post without approval, always use `gh` CLI, no volunteered AI attribution) live in `~/.claude/CLAUDE.md` — this skill is just the mechanics. For the end-to-end review-comment workflow (deciding what's a real issue, drafting replies, when to resolve vs. leave open), use the `address-pr-reviews` skill instead — it embeds these same commands in context.
 
 ## Posting review comments
 


### PR DESCRIPTION
- CLAUDE.md's no-AI-attribution rule is now a default with two exceptions: a PR template that asks about agent involvement (like posthog/posthog's Agent context section) gets filled honestly, and tool-mandated attribution (PostHog Code's commit trailers and PR footer) may stand.
- create-pr gains a contract for filling agent context sections (honest autonomy pick, reviewer-facing bullets, agent voice allowed there only) and obeys template-embedded agent instructions at the step they affect: body-shaping skills before composing, assignee and label requests via create flags.
- The code-reviewer agent and the commit and github-pr-operations cross-references now flag only volunteered attribution, so they stop fighting template-requested sections.

**Test plan**

- `grep -rin "AI attribution\|LLM context\|agent context" ai/` shows every remaining mention aligned with the new policy.
- Walked posthog/posthog's PR template through the new create-pr Step 5: it yields a filled Agent context section shaped like PostHog/posthog#77118, with the DRI assigned and /writing-pr-descriptions invoked before body composition.
- A repo with no template (this one) still gets a plain body with no volunteered attribution.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*