### PR TITLE
Fetch the whole project board instead of its first 200 items

### DIFF
--- a/ai/skills/sprint-planning/SKILL.md
+++ b/ai/skills/sprint-planning/SKILL.md
@@ -15,10 +15,6 @@ Generate a bi-weekly sprint planning update for a PostHog team (the Feature Flag
 
 All team-specific values live in `~/.claude/skills/sprint-planning/scripts/config.sh`. The helper scripts source it automatically; the inline `gh` commands in this skill source it too, so always run them with the leading `source` line shown.
 
-When a helper script exits non-zero, stop and surface its stderr rather than treating the empty output as "nothing found". The scripts fail this way when they can only see part of the board, when the GitHub API rate limit is exhausted, or when a lookup resolves nothing at all, and any of those would otherwise read as work that doesn't exist.
-
-A zero exit with `Warning:` lines on stderr means the same thing on a smaller scale: the named items went unresolved, so the result is incomplete. Report them as unknown rather than letting them read as work that isn't there.
-
 The defaults target the **Feature Flags** team:
 
 | Variable | Default | Meaning |
@@ -43,6 +39,12 @@ export SPRINT_TEAM=platform
 If the members API fails and `SPRINT_FALLBACK_MEMBERS` is empty, ask the user for the team's members.
 
 In the output templates below, `{SPRINT_…}` placeholders refer to these config values; read them from `config.sh` (or `source` it) and substitute the resolved values before presenting output.
+
+## Helper Script Failures
+
+When a helper script exits non-zero, stop that step and surface its stderr rather than treating the empty output as "nothing found". The scripts fail this way when they can only see part of the board, when the GitHub API rate limit is exhausted, or when a lookup resolves nothing at all, and any of those would otherwise read as work that doesn't exist. Do not fill the gap with a guess. A headless run that has been told to produce output regardless (`bin/sprint-status-run` is) should still produce it, naming the failed step and its stderr in place of the data that step would have supplied.
+
+A zero exit with `Warning:` lines on stderr means the same thing on a smaller scale: the named items went unresolved, so the result is incomplete. Report them as unknown rather than letting them read as work that isn't there.
 
 ## Quarter Objectives
 
@@ -392,7 +394,7 @@ Collect every plan item URL (one per line) and pipe them to the resolver:
 EOF
 ```
 
-Returns a JSON array with `state`, `isDraft`, `stateReason`, and `title` per URL via a batched GraphQL call. Map each item to a marker using the Status Markers table above, combining this output with the board status from Step S5 for open issues. Plain-text plan items with no URL default to ⬜.
+Returns a JSON array with `state`, `isDraft`, `stateReason`, and `title` per URL via a batched GraphQL call. Map each item to a marker using the Status Markers table above, combining this output with the board status from Step S5 for open issues. Plain-text plan items with no URL default to ⬜. A null `state` means the lookup did not resolve that item; report it as unknown rather than ⬜, which would read as not started.
 
 ### Step S7: Render and Copy
 

--- a/ai/skills/sprint-planning/SKILL.md
+++ b/ai/skills/sprint-planning/SKILL.md
@@ -15,7 +15,9 @@ Generate a bi-weekly sprint planning update for a PostHog team (the Feature Flag
 
 All team-specific values live in `~/.claude/skills/sprint-planning/scripts/config.sh`. The helper scripts source it automatically; the inline `gh` commands in this skill source it too, so always run them with the leading `source` line shown.
 
-When a helper script exits non-zero, stop and surface its stderr rather than treating the empty output as "nothing found". The scripts fail this way when they can only see part of the board or the GitHub API rate limit is exhausted, and either one would otherwise read as work that doesn't exist.
+When a helper script exits non-zero, stop and surface its stderr rather than treating the empty output as "nothing found". The scripts fail this way when they can only see part of the board, when the GitHub API rate limit is exhausted, or when a lookup resolves nothing at all, and any of those would otherwise read as work that doesn't exist.
+
+A zero exit with `Warning:` lines on stderr means the same thing on a smaller scale: the named items went unresolved, so the result is incomplete. Report them as unknown rather than letting them read as work that isn't there.
 
 The defaults target the **Feature Flags** team:
 
@@ -390,7 +392,7 @@ Collect every plan item URL (one per line) and pipe them to the resolver:
 EOF
 ```
 
-Returns a JSON array with `state`, `isDraft`, `stateReason`, and `title` per URL via a single batched GraphQL call. Map each item to a marker using the Status Markers table above, combining this output with the board status from Step S5 for open issues. Plain-text plan items with no URL default to ⬜.
+Returns a JSON array with `state`, `isDraft`, `stateReason`, and `title` per URL via a batched GraphQL call. Map each item to a marker using the Status Markers table above, combining this output with the board status from Step S5 for open issues. Plain-text plan items with no URL default to ⬜.
 
 ### Step S7: Render and Copy
 

--- a/ai/skills/sprint-planning/SKILL.md
+++ b/ai/skills/sprint-planning/SKILL.md
@@ -15,6 +15,8 @@ Generate a bi-weekly sprint planning update for a PostHog team (the Feature Flag
 
 All team-specific values live in `~/.claude/skills/sprint-planning/scripts/config.sh`. The helper scripts source it automatically; the inline `gh` commands in this skill source it too, so always run them with the leading `source` line shown.
 
+When a helper script exits non-zero, stop and surface its stderr rather than treating the empty output as "nothing found". The scripts fail this way when they can only see part of the board or the GitHub API rate limit is exhausted, and either one would otherwise read as work that doesn't exist.
+
 The defaults target the **Feature Flags** team:
 
 | Variable | Default | Meaning |

--- a/ai/skills/sprint-planning/scripts/archive-done-items.sh
+++ b/ai/skills/sprint-planning/scripts/archive-done-items.sh
@@ -64,11 +64,6 @@ response=$(echo "$work_items" \
   | jq '[.[] | {owner: (.repo | split("/")[0]), repo: (.repo | split("/")[1]), type: .type, number: .number}]' \
   | "$BATCH_QUERY" "mergedAt closedAt" "closedAt")
 
-if [[ -z "$response" ]]; then
-  echo "[]"
-  exit 0
-fi
-
 # Join the batched results with work items and filter to those closed before
 # the sprint start date.
 echo "$work_items" | jq --arg sprint "$sprint_start" --argjson resp "$response" '

--- a/ai/skills/sprint-planning/scripts/archive-done-items.sh
+++ b/ai/skills/sprint-planning/scripts/archive-done-items.sh
@@ -17,7 +17,6 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "$SCRIPT_DIR/config.sh"
 BATCH_QUERY="$SCRIPT_DIR/batch-item-query.sh"
 BOARD_ITEMS="$SCRIPT_DIR/fetch-board-items.sh"
 

--- a/ai/skills/sprint-planning/scripts/archive-done-items.sh
+++ b/ai/skills/sprint-planning/scripts/archive-done-items.sh
@@ -13,6 +13,10 @@
 #   id, title, number, type, closed_date
 #
 # Returns an empty array [] if no items qualify.
+#
+# Exits non-zero with a message on stderr when the board can only be read in
+# part, when GitHub's GraphQL rate limit is exhausted, or when the date lookup
+# resolves nothing at all.
 
 set -euo pipefail
 

--- a/ai/skills/sprint-planning/scripts/archive-done-items.sh
+++ b/ai/skills/sprint-planning/scripts/archive-done-items.sh
@@ -19,6 +19,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/config.sh"
 BATCH_QUERY="$SCRIPT_DIR/batch-item-query.sh"
+BOARD_ITEMS="$SCRIPT_DIR/fetch-board-items.sh"
 
 if [[ $# -lt 1 ]]; then
   echo "Usage: $0 <sprint_start_date>" >&2
@@ -33,11 +34,7 @@ if ! [[ "$sprint_start" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
 fi
 
 # Fetch all Done items from the project board as JSON.
-done_items=$(gh project item-list "$SPRINT_PROJECT_NUMBER" \
-  --owner "$SPRINT_ORG" \
-  --format json \
-  --limit 200 \
-  | jq '[.items[] | select(.status == "Done")]')
+done_items=$("$BOARD_ITEMS" | jq '[.[] | select(.status == "Done")]')
 
 # Extract non-draft items (those with a content URL) into a compact working set.
 work_items=$(echo "$done_items" | jq '[
@@ -58,8 +55,8 @@ if [[ "$item_count" -eq 0 ]]; then
   exit 0
 fi
 
-# Resolve closed/merged dates for all items in one batched query. The helper
-# preserves input order, so item_<idx> lines up with work_items below.
+# Resolve closed/merged dates for all items. The helper indexes its aliases by
+# input position, so item_<idx> lines up with work_items below.
 response=$(echo "$work_items" \
   | jq '[.[] | {owner: (.repo | split("/")[0]), repo: (.repo | split("/")[1]), type: .type, number: .number}]' \
   | "$BATCH_QUERY" "mergedAt closedAt" "closedAt")

--- a/ai/skills/sprint-planning/scripts/batch-item-query.sh
+++ b/ai/skills/sprint-planning/scripts/batch-item-query.sh
@@ -43,30 +43,33 @@ if [[ "$count" -eq 0 ]]; then
   exit 0
 fi
 
+# One query per chunk, each a single line so the loop below can read them one at
+# a time. Aliases are numbered over the whole input before it is sliced, which is
+# what keeps item_<index> meaningful to callers joining by index.
+#
 # owner/repo are escaped with @json so a malformed value can't break out of
 # the query string; number is a jq number, emitted as bare digits.
-build_query() {
-  local chunk="$1" offset="$2"
-  echo "$chunk" | jq -r --arg pr "$pr_fields" --arg issue "$issue_fields" --argjson offset "$offset" '
-    [to_entries[] |
-      ($offset + .key) as $i | .value as $it |
-      "item_\($i): repository(owner: \($it.owner | @json), name: \($it.repo | @json)) { " +
-      (if $it.type == "PullRequest" then
-         "pullRequest(number: \($it.number)) { \($pr) }"
-       else
-         "issue(number: \($it.number)) { \($issue) }"
-       end) + " }"
-    ] | "query { " + join(" ") + " }"
-  '
-}
+queries=$(echo "$items" | jq -r --arg pr "$pr_fields" --arg issue "$issue_fields" --argjson size "$chunk_size" '
+  [to_entries[] |
+    .key as $i | .value as $it |
+    "item_\($i): repository(owner: \($it.owner | @json), name: \($it.repo | @json)) { " +
+    (if $it.type == "PullRequest" then
+       "pullRequest(number: \($it.number)) { \($pr) }"
+     else
+       "issue(number: \($it.number)) { \($issue) }"
+     end) + " }"
+  ] as $fields |
+  range(0; $fields | length; $size) |
+  "query { " + ($fields[. : . + $size] | join(" ")) + " }"
+')
 
 # An exhausted point budget arrives either as a RATE_LIMITED error in the body
 # or as a 403 whose message gh forwards on stderr.
 is_rate_limited() {
-  local response="$1" stderr="$2"
+  local response="$1" stderr_path="$2"
   jq -e 'any(.errors[]?; .type == "RATE_LIMITED" or ((.message // "") | test("rate limit"; "i")))' \
     <<<"$response" >/dev/null 2>&1 && return 0
-  grep -qi "rate limit" <<<"$stderr"
+  grep -qi "rate limit" "$stderr_path"
 }
 
 stderr_file=$(mktemp)
@@ -75,16 +78,12 @@ trap 'rm -f "$stderr_file"' EXIT
 chunk_data=()
 offset=0
 
-while [[ "$offset" -lt "$count" ]]; do
-  query=$(build_query \
-    "$(echo "$items" | jq --argjson off "$offset" --argjson size "$chunk_size" '.[$off:$off + $size]')" \
-    "$offset")
-
+while IFS= read -r query; do
   # gh exits non-zero for any response carrying .errors, including partial
   # successes that still hold usable .data, so decide from the body.
   response=$(gh api graphql -f query="$query" 2>"$stderr_file") || true
 
-  if is_rate_limited "$response" "$(cat "$stderr_file")"; then
+  if is_rate_limited "$response" "$stderr_file"; then
     echo "Error: GitHub's GraphQL rate limit is exhausted, so items $offset onward are unresolved." >&2
     echo "Check when it resets: gh api rate_limit --jq .resources.graphql" >&2
     exit 1
@@ -93,10 +92,15 @@ while [[ "$offset" -lt "$count" ]]; do
   data=$(jq -c '.data | select(. != null)' <<<"$response" 2>/dev/null) || data=""
   if [[ -n "$data" ]]; then
     chunk_data+=("$data")
+  else
+    # Callers read these items as null, the same as items that failed on their
+    # own, so say which ones went missing rather than let them vanish quietly.
+    last=$(( offset + chunk_size < count ? offset + chunk_size - 1 : count - 1 ))
+    echo "Warning: items $offset to $last did not resolve." >&2
   fi
 
   offset=$((offset + chunk_size))
-done
+done <<<"$queries"
 
 if [[ "${#chunk_data[@]}" -eq 0 ]]; then
   exit 0

--- a/ai/skills/sprint-planning/scripts/batch-item-query.sh
+++ b/ai/skills/sprint-planning/scripts/batch-item-query.sh
@@ -5,11 +5,13 @@
 # input array and join the response back by index.
 #
 # Usage:
-#   echo '<json-array>' | batch-item-query.sh "<pr_fields>" "<issue_fields>"
+#   echo '<json-array>' | batch-item-query.sh [--tolerate-total-loss] \
+#     "<pr_fields>" "<issue_fields>"
 #
 # Stdin: JSON array of items, each: { owner, repo, type, number }
 #   where type is "PullRequest" or "Issue". Extra fields are ignored.
 # Args:
+#   --tolerate-total-loss - optional, must come first. See "Failure" below.
 #   $1 pr_fields    - GraphQL selection set for pull requests,
 #                     e.g. "state isDraft title"
 #   $2 issue_fields - GraphQL selection set for issues,
@@ -21,13 +23,17 @@
 #   the input is empty. Items that failed individually are null in .data, and
 #   items whose whole chunk failed are absent, which callers read as null too.
 #
-# Exit codes, both with a message on stderr and nothing on stdout:
-#   1 - GitHub's GraphQL rate limit is exhausted. Returning the surviving chunks
-#       would look to callers like the missing items no longer exist.
-#   2 - No chunk resolved, so the query failed outright. A total failure is not
-#       the same answer as an empty board, which is what exiting 0 here would
-#       have said. Callers that would rather report what they know than stop can
-#       degrade on this code specifically; 1 is not safe to degrade past.
+# Failure: loss is named on stderr, and exit 1 with nothing on stdout means the
+#   query could not be answered at all. That covers an exhausted GraphQL rate
+#   limit and a run where no chunk resolved, since neither is the same answer as
+#   an empty board. Partial loss is a Warning: and a zero exit, because the
+#   surviving chunks are real answers.
+#
+#   --tolerate-total-loss is for a caller that would rather report what it knows
+#   than stop: nothing resolving becomes a Warning: and an empty .data, which
+#   every caller's index join already reads as null. An exhausted rate limit
+#   still exits 1, since the caller asked to tolerate a failed lookup and not to
+#   paper over a quota it has stopped being allowed to spend.
 
 set -euo pipefail
 
@@ -37,6 +43,14 @@ set -euo pipefail
 # fetch-approved-prs.sh, which searches at --limit 100, and archive-done-items.sh,
 # whose Done column has no upper bound.
 chunk_size=50
+
+# Whether a total loss is fatal is the caller's policy, not this script's, so it
+# is a flag here rather than an exit code the caller has to unwind.
+tolerate_total_loss=false
+if [[ "${1:-}" == "--tolerate-total-loss" ]]; then
+  tolerate_total_loss=true
+  shift
+fi
 
 pr_fields="${1:?pr_fields required}"
 issue_fields="${2:?issue_fields required}"
@@ -57,15 +71,17 @@ fi
 # what keeps item_<index> meaningful to callers joining by index.
 #
 # owner/repo are escaped with @json so a malformed value can't break out of
-# the query string; number is a jq number, emitted as bare digits.
+# the query string; number is coerced through tonumber so it is bare digits
+# whatever the caller passed, since the loop below would run a second query
+# built from a value carrying a newline.
 queries=$(echo "$items" | jq -r --arg pr "$pr_fields" --arg issue "$issue_fields" --argjson size "$chunk_size" '
   [to_entries[] |
     .key as $i | .value as $it |
     "item_\($i): repository(owner: \($it.owner | @json), name: \($it.repo | @json)) { " +
     (if $it.type == "PullRequest" then
-       "pullRequest(number: \($it.number)) { \($pr) }"
+       "pullRequest(number: \($it.number | tonumber | floor)) { \($pr) }"
      else
-       "issue(number: \($it.number)) { \($issue) }"
+       "issue(number: \($it.number | tonumber | floor)) { \($issue) }"
      end) + " }"
   ] as $fields |
   range(0; $fields | length; $size) |
@@ -99,7 +115,7 @@ while IFS= read -r query; do
   response=$(gh api graphql -f query="$query" 2>"$stderr_file") || true
 
   if is_rate_limited "$response" "$stderr_file"; then
-    echo "Error: GitHub's GraphQL rate limit is exhausted, so items $offset onward are unresolved." >&2
+    echo "Error: GitHub's GraphQL rate limit is exhausted at item $offset; none of the $count items are returned." >&2
     echo "Check when it resets: gh api rate_limit --jq .resources.graphql" >&2
     exit 1
   fi
@@ -111,7 +127,12 @@ while IFS= read -r query; do
     # Held until the end: if every chunk fails the error below covers them all,
     # and a per-chunk warning for each would just repeat it.
     last=$(( offset + chunk_size < count ? offset + chunk_size - 1 : count - 1 ))
-    lost+=("items $offset to $last")
+    # Named, not just numbered: two of the three callers drop unresolved items
+    # from their output, so a positional range points into an array the agent
+    # reading the warning never sees.
+    refs=$(jq -r --argjson from "$offset" --argjson to "$last" \
+      '[.[$from:$to + 1][] | "\(.owner)/\(.repo)#\(.number)"] | join(", ")' <<<"$items")
+    lost+=("items $offset to $last did not resolve: $refs")
   fi
 
   offset=$((offset + chunk_size))
@@ -121,17 +142,25 @@ done <<<"$queries"
 # rather than the board being empty. Those read the same to a caller that only
 # checks for empty output, which is how an expired token becomes "no work".
 if [[ "${#chunk_data[@]}" -eq 0 ]]; then
-  echo "Error: none of the $count items resolved; the GraphQL query failed for every chunk." >&2
+  lead="Error"
+  [[ "$tolerate_total_loss" == "false" ]] || lead="Warning"
+  echo "$lead: none of the $count items resolved; the GraphQL query failed for every chunk." >&2
   echo "Check that gh is authenticated: gh auth status" >&2
-  exit 2
+  if [[ "$tolerate_total_loss" == "false" ]]; then
+    exit 1
+  fi
+  # An empty .data null-propagates through every caller's index join, which is
+  # the same answer the caller would have hand-written for itself.
+  echo '{"data":{}}'
+  exit 0
 fi
 
 # Some items resolved and some did not. Callers read the missing ones as null,
 # the same as items that failed on their own, so name them rather than let them
 # vanish quietly.
 if [[ "${#lost[@]}" -gt 0 ]]; then
-  for range in "${lost[@]}"; do
-    echo "Warning: $range did not resolve." >&2
+  for entry in "${lost[@]}"; do
+    echo "Warning: $entry" >&2
   done
 fi
 

--- a/ai/skills/sprint-planning/scripts/batch-item-query.sh
+++ b/ai/skills/sprint-planning/scripts/batch-item-query.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
-# Resolve fields for many GitHub issues/PRs in one batched GraphQL query,
-# replacing N REST calls with a single request. Shared by the sprint-planning
-# and sprint-status helper scripts, which each build their own input array and
-# join the response back by index.
+# Resolve fields for many GitHub issues/PRs in batched GraphQL queries,
+# replacing N REST calls with one request per chunk of items. Shared by the
+# sprint-planning and sprint-status helper scripts, which each build their own
+# input array and join the response back by index.
 #
 # Usage:
 #   echo '<json-array>' | batch-item-query.sh "<pr_fields>" "<issue_fields>"
@@ -15,17 +15,26 @@
 #   $2 issue_fields - GraphQL selection set for issues,
 #                     e.g. "state stateReason title"
 #
-# Output: the raw GraphQL response JSON. Each input item is aliased
-#   item_<index> (matching input order) under .data, so callers join by index.
-#   Prints nothing (empty string) when the input is empty or the query fails
-#   entirely, including when no .data is returned, so callers apply their own
-#   fallback. A batch where only some items fail still returns .data with the
-#   resolved items present and the failed ones null.
+# Output: a GraphQL response whose .data merges every chunk. Each input item is
+#   aliased item_<index>, indexed by its position in the whole input rather than
+#   in its chunk, so callers join by index. Prints nothing (empty string) when
+#   the input is empty or every chunk fails, so callers apply their own
+#   fallback. Items that failed individually are null in .data, and items whose
+#   whole chunk failed are absent, which callers read as null too.
+#
+# Exits non-zero with a message on stderr, and nothing on stdout, when GitHub
+# reports its GraphQL rate limit exhausted. Returning the surviving chunks there
+# would look to callers like the missing items no longer exist.
+#
+# Environment:
+#   BATCH_ITEM_CHUNK_SIZE - items per query (default 50). A few hundred items in
+#                           one query costs the entire hourly point budget.
 
 set -euo pipefail
 
 pr_fields="${1:?pr_fields required}"
 issue_fields="${2:?issue_fields required}"
+chunk_size="${BATCH_ITEM_CHUNK_SIZE:-50}"
 
 items="$(cat)"
 
@@ -36,22 +45,61 @@ fi
 
 # owner/repo are escaped with @json so a malformed value can't break out of
 # the query string; number is a jq number, emitted as bare digits.
-query=$(echo "$items" | jq -r --arg pr "$pr_fields" --arg issue "$issue_fields" '
-  [to_entries[] |
-    .key as $i | .value as $it |
-    "item_\($i): repository(owner: \($it.owner | @json), name: \($it.repo | @json)) { " +
-    (if $it.type == "PullRequest" then
-       "pullRequest(number: \($it.number)) { \($pr) }"
-     else
-       "issue(number: \($it.number)) { \($issue) }"
-     end) + " }"
-  ] | "query { " + join(" ") + " }"
-')
+build_query() {
+  local chunk="$1" offset="$2"
+  echo "$chunk" | jq -r --arg pr "$pr_fields" --arg issue "$issue_fields" --argjson offset "$offset" '
+    [to_entries[] |
+      ($offset + .key) as $i | .value as $it |
+      "item_\($i): repository(owner: \($it.owner | @json), name: \($it.repo | @json)) { " +
+      (if $it.type == "PullRequest" then
+         "pullRequest(number: \($it.number)) { \($pr) }"
+       else
+         "issue(number: \($it.number)) { \($issue) }"
+       end) + " }"
+    ] | "query { " + join(" ") + " }"
+  '
+}
 
-response=$(gh api graphql -f query="$query" 2>/dev/null) || true
+# An exhausted point budget arrives either as a RATE_LIMITED error in the body
+# or as a 403 whose message gh forwards on stderr.
+is_rate_limited() {
+  local response="$1" stderr="$2"
+  jq -e 'any(.errors[]?; .type == "RATE_LIMITED" or ((.message // "") | test("rate limit"; "i")))' \
+    <<<"$response" >/dev/null 2>&1 && return 0
+  grep -qi "rate limit" <<<"$stderr"
+}
 
-# Keep partial data (some items resolved, others null); only stay silent when
-# there is no .data at all.
-if jq -e '.data' <<<"$response" >/dev/null 2>&1; then
-  printf '%s' "$response"
+stderr_file=$(mktemp)
+trap 'rm -f "$stderr_file"' EXIT
+
+chunk_data=()
+offset=0
+
+while [[ "$offset" -lt "$count" ]]; do
+  query=$(build_query \
+    "$(echo "$items" | jq --argjson off "$offset" --argjson size "$chunk_size" '.[$off:$off + $size]')" \
+    "$offset")
+
+  # gh exits non-zero for any response carrying .errors, including partial
+  # successes that still hold usable .data, so decide from the body.
+  response=$(gh api graphql -f query="$query" 2>"$stderr_file") || true
+
+  if is_rate_limited "$response" "$(cat "$stderr_file")"; then
+    echo "Error: GitHub's GraphQL rate limit is exhausted, so items $offset onward are unresolved." >&2
+    echo "Check when it resets: gh api rate_limit --jq .resources.graphql" >&2
+    exit 1
+  fi
+
+  data=$(jq -c '.data | select(. != null)' <<<"$response" 2>/dev/null) || data=""
+  if [[ -n "$data" ]]; then
+    chunk_data+=("$data")
+  fi
+
+  offset=$((offset + chunk_size))
+done
+
+if [[ "${#chunk_data[@]}" -eq 0 ]]; then
+  exit 0
 fi
+
+printf '%s\n' "${chunk_data[@]}" | jq -s '{data: add}'

--- a/ai/skills/sprint-planning/scripts/batch-item-query.sh
+++ b/ai/skills/sprint-planning/scripts/batch-item-query.sh
@@ -18,23 +18,32 @@
 # Output: a GraphQL response whose .data merges every chunk. Each input item is
 #   aliased item_<index>, indexed by its position in the whole input rather than
 #   in its chunk, so callers join by index. Prints nothing (empty string) when
-#   the input is empty or every chunk fails, so callers apply their own
-#   fallback. Items that failed individually are null in .data, and items whose
-#   whole chunk failed are absent, which callers read as null too.
+#   the input is empty. Items that failed individually are null in .data, and
+#   items whose whole chunk failed are absent, which callers read as null too.
 #
-# Exits non-zero with a message on stderr, and nothing on stdout, when GitHub
-# reports its GraphQL rate limit exhausted. Returning the surviving chunks there
-# would look to callers like the missing items no longer exist.
-#
-# Environment:
-#   BATCH_ITEM_CHUNK_SIZE - items per query (default 50). A few hundred items in
-#                           one query costs the entire hourly point budget.
+# Exit codes, both with a message on stderr and nothing on stdout:
+#   1 - GitHub's GraphQL rate limit is exhausted. Returning the surviving chunks
+#       would look to callers like the missing items no longer exist.
+#   2 - No chunk resolved, so the query failed outright. A total failure is not
+#       the same answer as an empty board, which is what exiting 0 here would
+#       have said. Callers that would rather report what they know than stop can
+#       degrade on this code specifically; 1 is not safe to degrade past.
 
 set -euo pipefail
 
+# Items per query. Chunking bounds the blast radius: a query that fails or times
+# out costs one chunk rather than every item, which is what lets the surviving
+# chunks still be returned. The callers that exceed one chunk are
+# fetch-approved-prs.sh, which searches at --limit 100, and archive-done-items.sh,
+# whose Done column has no upper bound.
+chunk_size=50
+
 pr_fields="${1:?pr_fields required}"
 issue_fields="${2:?issue_fields required}"
-chunk_size="${BATCH_ITEM_CHUNK_SIZE:-50}"
+# The loop below reads one query per line, so a newline in a selection set would
+# split a query in half. They are whitespace to GraphQL, so flatten them.
+pr_fields="${pr_fields//$'\n'/ }"
+issue_fields="${issue_fields//$'\n'/ }"
 
 items="$(cat)"
 
@@ -63,12 +72,17 @@ queries=$(echo "$items" | jq -r --arg pr "$pr_fields" --arg issue "$issue_fields
   "query { " + ($fields[. : . + $size] | join(" ")) + " }"
 ')
 
-# An exhausted point budget arrives either as a RATE_LIMITED error in the body
-# or as a 403 whose message gh forwards on stderr.
+# The primary point budget arrives as a RATE_LIMITED entry under .errors. A
+# secondary limit is an HTTP 403 whose body is a bare {"message": ...} with no
+# .errors array, so both shapes are checked. gh writes either body to stdout and
+# echoes only a one-line summary to stderr, which the grep catches in case a
+# future gh stops forwarding the body.
 is_rate_limited() {
   local response="$1" stderr_path="$2"
-  jq -e 'any(.errors[]?; .type == "RATE_LIMITED" or ((.message // "") | test("rate limit"; "i")))' \
-    <<<"$response" >/dev/null 2>&1 && return 0
+  jq -e '
+    any(.errors[]?; .type == "RATE_LIMITED" or ((.message // "") | test("rate limit"; "i")))
+    or ((.message // "") | test("rate limit"; "i"))
+  ' <<<"$response" >/dev/null 2>&1 && return 0
   grep -qi "rate limit" "$stderr_path"
 }
 
@@ -76,6 +90,7 @@ stderr_file=$(mktemp)
 trap 'rm -f "$stderr_file"' EXIT
 
 chunk_data=()
+lost=()
 offset=0
 
 while IFS= read -r query; do
@@ -93,17 +108,31 @@ while IFS= read -r query; do
   if [[ -n "$data" ]]; then
     chunk_data+=("$data")
   else
-    # Callers read these items as null, the same as items that failed on their
-    # own, so say which ones went missing rather than let them vanish quietly.
+    # Held until the end: if every chunk fails the error below covers them all,
+    # and a per-chunk warning for each would just repeat it.
     last=$(( offset + chunk_size < count ? offset + chunk_size - 1 : count - 1 ))
-    echo "Warning: items $offset to $last did not resolve." >&2
+    lost+=("items $offset to $last")
   fi
 
   offset=$((offset + chunk_size))
 done <<<"$queries"
 
+# The input was non-empty, so nothing resolving means the query failed outright
+# rather than the board being empty. Those read the same to a caller that only
+# checks for empty output, which is how an expired token becomes "no work".
 if [[ "${#chunk_data[@]}" -eq 0 ]]; then
-  exit 0
+  echo "Error: none of the $count items resolved; the GraphQL query failed for every chunk." >&2
+  echo "Check that gh is authenticated: gh auth status" >&2
+  exit 2
+fi
+
+# Some items resolved and some did not. Callers read the missing ones as null,
+# the same as items that failed on their own, so name them rather than let them
+# vanish quietly.
+if [[ "${#lost[@]}" -gt 0 ]]; then
+  for range in "${lost[@]}"; do
+    echo "Warning: $range did not resolve." >&2
+  done
 fi
 
 printf '%s\n' "${chunk_data[@]}" | jq -s '{data: add}'

--- a/ai/skills/sprint-planning/scripts/fetch-approved-prs.sh
+++ b/ai/skills/sprint-planning/scripts/fetch-approved-prs.sh
@@ -48,11 +48,6 @@ response=$(echo "$refs" | "$BATCH_QUERY" \
   "author { login } latestOpinionatedReviews(first: 50) { nodes { author { login } state } }" \
   "title")
 
-if [[ -z "$response" ]]; then
-  echo "[]"
-  exit 0
-fi
-
 # Join the GraphQL response back onto the search results by index (both are in
 # input order) and keep PRs whose latest opinionated review by the user approved.
 # A PR the query couldn't resolve has no reviews to judge, so it drops out.

--- a/ai/skills/sprint-planning/scripts/fetch-approved-prs.sh
+++ b/ai/skills/sprint-planning/scripts/fetch-approved-prs.sh
@@ -10,6 +10,10 @@
 # Output: JSON array sorted by most recently updated, each:
 #   { title, url, repository, number, isDraft, updatedAt, author }
 # Returns [] when nothing matches.
+#
+# Exits non-zero with a message on stderr when GitHub's GraphQL rate limit is
+# exhausted, or when the review lookup resolves nothing at all. Printing [] there
+# would read as "you approved nothing".
 
 set -euo pipefail
 

--- a/ai/skills/sprint-planning/scripts/fetch-approved-prs.sh
+++ b/ai/skills/sprint-planning/scripts/fetch-approved-prs.sh
@@ -51,11 +51,12 @@ fi
 
 # Join the GraphQL response back onto the search results by index (both are in
 # input order) and keep PRs whose latest opinionated review by the user approved.
+# A PR the query couldn't resolve has no reviews to judge, so it drops out.
 echo "$prs" | jq --argjson resp "$response" --arg me "$me" '
   [to_entries[] |
     .key as $i | .value as $it |
     $resp.data["item_\($i)"].pullRequest as $pr |
-    select($pr.latestOpinionatedReviews.nodes
+    select(($pr.latestOpinionatedReviews.nodes // [])
       | any(.author.login == $me and .state == "APPROVED")) |
     {
       title: $it.title,

--- a/ai/skills/sprint-planning/scripts/fetch-board-goals.sh
+++ b/ai/skills/sprint-planning/scripts/fetch-board-goals.sh
@@ -19,7 +19,6 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "$SCRIPT_DIR/config.sh"
 BATCH_QUERY="$SCRIPT_DIR/batch-item-query.sh"
 BOARD_ITEMS="$SCRIPT_DIR/fetch-board-items.sh"
 

--- a/ai/skills/sprint-planning/scripts/fetch-board-goals.sh
+++ b/ai/skills/sprint-planning/scripts/fetch-board-goals.sh
@@ -13,6 +13,9 @@
 # Draft items (no linked Issue/PR) have null url, type and number.
 #
 # Returns an empty array [] if no qualifying items exist.
+#
+# Exits non-zero with a message on stderr when the board can only be read in
+# part, since a short board reads as work that doesn't exist.
 
 set -euo pipefail
 
@@ -34,6 +37,8 @@ else
 fi
 
 # A draft has no linked Issue or PR, so its url, type and number stay null.
+# number needs an explicit guard because jq errors on null | tonumber, while
+# url and type read through a null $content on their own.
 echo "$active_items" | jq '[
   .[] |
   (if (.content.url // "") == "" then null else .content end) as $content |

--- a/ai/skills/sprint-planning/scripts/fetch-board-goals.sh
+++ b/ai/skills/sprint-planning/scripts/fetch-board-goals.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-# Fetch project board items with assignee information. Uses a single batched
-# GraphQL query (via batch-item-query.sh) to resolve assignees for all linkable
-# items (Issues and PRs), keeping API calls to a minimum.
+# Fetch project board items with assignee information. Assignees for every
+# linkable item (Issue or PR) come from batched GraphQL queries (via
+# batch-item-query.sh), keeping API calls to a minimum.
 #
 # Usage: fetch-board-goals.sh [--all]
 #
@@ -21,6 +21,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/config.sh"
 BATCH_QUERY="$SCRIPT_DIR/batch-item-query.sh"
+BOARD_ITEMS="$SCRIPT_DIR/fetch-board-items.sh"
 
 all_statuses=false
 if [[ "${1:-}" == "--all" ]]; then
@@ -28,11 +29,7 @@ if [[ "${1:-}" == "--all" ]]; then
 fi
 
 # Fetch all items, optionally filtering to active statuses.
-raw_items=$(gh project item-list "$SPRINT_PROJECT_NUMBER" \
-  --owner "$SPRINT_ORG" \
-  --format json \
-  --limit 200 \
-  | jq '.items')
+raw_items=$("$BOARD_ITEMS")
 
 if [[ "$all_statuses" == "false" ]]; then
   active_items=$(echo "$raw_items" | jq '[.[] | select(.status == "In Progress" or .status == "Todo" or .status == "In Review" or .status == "Approved")]')
@@ -81,15 +78,16 @@ if [[ "$linkable_count" -eq 0 ]]; then
   exit 0
 fi
 
-# Resolve assignees for every linkable item in one batched query. The helper
-# preserves input order, so item_<idx> lines up with linkable below.
+# Resolve assignees for every linkable item. The helper indexes its aliases by
+# input position, so item_<idx> lines up with linkable below.
 assignee_fields="assignees(first: 10) { nodes { login } }"
 response=$(echo "$linkable" \
   | jq '[.[] | {owner: (.repo | split("/")[0]), repo: (.repo | split("/")[1]), type: .type, number: .number}]' \
   | "$BATCH_QUERY" "$assignee_fields" "$assignee_fields")
 
-# Join assignee data with linkable items. If the GraphQL call failed,
-# fall back to empty assignees so the caller still gets usable output.
+# Join assignee data with linkable items. When the GraphQL call failed for any
+# reason short of an exhausted rate limit, which aborts, fall back to empty
+# assignees so the caller still gets usable output.
 if [[ -n "$response" ]]; then
   enriched=$(echo "$linkable" | jq --argjson resp "$response" '
     [to_entries[] |

--- a/ai/skills/sprint-planning/scripts/fetch-board-goals.sh
+++ b/ai/skills/sprint-planning/scripts/fetch-board-goals.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
-# Fetch project board items with assignee information. Assignees for every
-# linkable item (Issue or PR) come from batched GraphQL queries (via
-# batch-item-query.sh), keeping API calls to a minimum.
+# Fetch project board items with assignee information. The board listing already
+# carries each item's assignees, so one call answers the whole question.
 #
 # Usage: fetch-board-goals.sh [--all]
 #
@@ -11,15 +10,13 @@
 # Output: JSON array of items with fields:
 #   id, title, status, url, type, number, assignees
 #
-# Draft items (no linked Issue/PR) have null url, type, number,
-# and an empty assignees array.
+# Draft items (no linked Issue/PR) have null url, type and number.
 #
 # Returns an empty array [] if no qualifying items exist.
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-BATCH_QUERY="$SCRIPT_DIR/batch-item-query.sh"
 BOARD_ITEMS="$SCRIPT_DIR/fetch-board-items.sh"
 
 all_statuses=false
@@ -36,84 +33,17 @@ else
   active_items=$(echo "$raw_items" | jq '[.[]]')
 fi
 
-item_count=$(echo "$active_items" | jq 'length')
-
-if [[ "$item_count" -eq 0 ]]; then
-  echo "[]"
-  exit 0
-fi
-
-# Separate linkable items (Issues/PRs with a content URL) from drafts.
-linkable=$(echo "$active_items" | jq '[
-  .[] | select(.content.url != null and .content.url != "") |
+# A draft has no linked Issue or PR, so its url, type and number stay null.
+echo "$active_items" | jq '[
+  .[] |
+  (if (.content.url // "") == "" then null else .content end) as $content |
   {
     id: .id,
     title: .title,
     status: .status,
-    url: .content.url,
-    type: .content.type,
-    number: (.content.number | tonumber),
-    repo: .content.repository
+    url: $content.url,
+    type: $content.type,
+    number: (if $content == null then null else ($content.number | tonumber) end),
+    assignees: (.assignees // [])
   }
-]')
-
-drafts=$(echo "$active_items" | jq '[
-  .[] | select(.content.url == null or .content.url == "") |
-  {
-    id: .id,
-    title: .title,
-    status: .status,
-    url: null,
-    type: null,
-    number: null,
-    assignees: []
-  }
-]')
-
-linkable_count=$(echo "$linkable" | jq 'length')
-
-if [[ "$linkable_count" -eq 0 ]]; then
-  echo "$drafts"
-  exit 0
-fi
-
-# Resolve assignees for every linkable item. The helper indexes its aliases by
-# input position, so item_<idx> lines up with linkable below.
-assignee_fields="assignees(first: 10) { nodes { login } }"
-response=$(echo "$linkable" \
-  | jq '[.[] | {owner: (.repo | split("/")[0]), repo: (.repo | split("/")[1]), type: .type, number: .number}]' \
-  | "$BATCH_QUERY" "$assignee_fields" "$assignee_fields")
-
-# Join assignee data with linkable items. When the GraphQL call failed for any
-# reason short of an exhausted rate limit, which aborts, fall back to empty
-# assignees so the caller still gets usable output.
-if [[ -n "$response" ]]; then
-  enriched=$(echo "$linkable" | jq --argjson resp "$response" '
-    [to_entries[] |
-      .key as $idx |
-      .value as $item |
-      $resp.data["item_\($idx)"] as $data |
-      (
-        if $item.type == "PullRequest" then
-          ($data.pullRequest.assignees.nodes // [])
-        else
-          ($data.issue.assignees.nodes // [])
-        end
-      ) as $nodes |
-      {
-        id: $item.id,
-        title: $item.title,
-        status: $item.status,
-        url: $item.url,
-        type: $item.type,
-        number: $item.number,
-        assignees: [$nodes[].login]
-      }
-    ]
-  ')
-else
-  enriched=$(echo "$linkable" | jq '[.[] | . + {assignees: []} | del(.repo)]')
-fi
-
-# Merge linkable and draft items into a single array.
-echo "$enriched" | jq --argjson drafts "$drafts" '. + $drafts'
+]'

--- a/ai/skills/sprint-planning/scripts/fetch-board-items.sh
+++ b/ai/skills/sprint-planning/scripts/fetch-board-items.sh
@@ -6,10 +6,12 @@
 # Output: JSON array of project items, exactly as the .items of
 #   `gh project item-list --format json`.
 #
-# gh reports the board's real size in .totalCount, so a short read is
-# detectable. A fetch that comes up short is retried sized to the board; one
-# that is still short exits non-zero with a message on stderr, because a
-# truncated board reads to every caller as work that isn't there.
+# A short read is detectable from .totalCount when gh reports it, and otherwise
+# from a read that exactly fills the limit. A fetch that comes up short is
+# retried, sized to the board when the total is known and to twice the limit
+# when it isn't; one that is still short exits non-zero with a message on
+# stderr, because a truncated board reads to every caller as work that isn't
+# there.
 #
 # Environment:
 #   SPRINT_BOARD_FETCH_LIMIT - starting --limit (default 1000). Lower it to

--- a/ai/skills/sprint-planning/scripts/fetch-board-items.sh
+++ b/ai/skills/sprint-planning/scripts/fetch-board-items.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# Fetch every item on the team's project board.
+#
+# Usage: fetch-board-items.sh
+#
+# Output: JSON array of project items, exactly as the .items of
+#   `gh project item-list --format json`.
+#
+# gh reports the board's real size in .totalCount, so a short read is
+# detectable. A fetch that comes up short is retried sized to the board; one
+# that is still short exits non-zero with a message on stderr, because a
+# truncated board reads to every caller as work that isn't there.
+#
+# Environment:
+#   SPRINT_BOARD_FETCH_LIMIT - starting --limit (default 1000). Lower it to
+#                              exercise the retry path against a real board.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/config.sh"
+
+limit="${SPRINT_BOARD_FETCH_LIMIT:-1000}"
+
+fetch() {
+  gh project item-list "$SPRINT_PROJECT_NUMBER" \
+    --owner "$SPRINT_ORG" \
+    --format json \
+    --limit "$1"
+}
+
+# A read is short when gh returned fewer items than the board holds, or when it
+# returned exactly the limit and reported no total to compare against.
+is_short() {
+  local response="$1" fetch_limit="$2"
+  jq -e --argjson limit "$fetch_limit" '
+    (.items | length) as $count |
+    if (.totalCount | type) == "number" then $count < .totalCount
+    else $count >= $limit
+    end
+  ' <<<"$response" >/dev/null
+}
+
+response=$(fetch "$limit")
+
+if is_short "$response" "$limit"; then
+  total=$(jq '.totalCount // 0' <<<"$response")
+  # Size the retry to the board, with headroom for items added since.
+  retry_limit=$(( (total > 2 * limit ? total : 2 * limit) + 100 ))
+  response=$(fetch "$retry_limit")
+
+  if is_short "$response" "$retry_limit"; then
+    echo "Error: fetched $(jq '.items | length' <<<"$response") of $(jq -r '.totalCount // "unknown"' <<<"$response") items from project $SPRINT_PROJECT_NUMBER at --limit $retry_limit." >&2
+    echo "Refusing to continue with a truncated board." >&2
+    exit 1
+  fi
+fi
+
+jq '.items' <<<"$response"

--- a/ai/skills/sprint-planning/scripts/fetch-board-items.sh
+++ b/ai/skills/sprint-planning/scripts/fetch-board-items.sh
@@ -6,23 +6,25 @@
 # Output: JSON array of project items, exactly as the .items of
 #   `gh project item-list --format json`.
 #
+# gh's --limit is a ceiling rather than a fetch count: it pages internally and
+# stops when the board runs out, so asking for more than the board holds costs
+# nothing. The limit is set high enough that a real board never reaches it.
+#
 # A short read is detectable from .totalCount when gh reports it, and otherwise
-# from a read that exactly fills the limit. A fetch that comes up short is
-# retried, sized to the board when the total is known and to twice the limit
-# when it isn't; one that is still short exits non-zero with a message on
-# stderr, because a truncated board reads to every caller as work that isn't
-# there.
+# from a read that exactly fills the limit. A short read exits non-zero with a
+# message on stderr, because a truncated board reads to every caller as work
+# that isn't there.
 #
 # Environment:
-#   SPRINT_BOARD_FETCH_LIMIT - starting --limit (default 1000). Lower it to
-#                              exercise the retry path against a real board.
+#   BOARD_FETCH_LIMIT - --limit passed to gh (default 100000). Lower it to
+#                       exercise the truncation guard against a real board.
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/config.sh"
 
-limit="${SPRINT_BOARD_FETCH_LIMIT:-1000}"
+limit="${BOARD_FETCH_LIMIT:-100000}"
 
 fetch() {
   gh project item-list "$SPRINT_PROJECT_NUMBER" \
@@ -46,16 +48,9 @@ is_short() {
 response=$(fetch "$limit")
 
 if is_short "$response" "$limit"; then
-  total=$(jq '.totalCount // 0' <<<"$response")
-  # Size the retry to the board, with headroom for items added since.
-  retry_limit=$(( (total > 2 * limit ? total : 2 * limit) + 100 ))
-  response=$(fetch "$retry_limit")
-
-  if is_short "$response" "$retry_limit"; then
-    echo "Error: fetched $(jq '.items | length' <<<"$response") of $(jq -r '.totalCount // "unknown"' <<<"$response") items from project $SPRINT_PROJECT_NUMBER at --limit $retry_limit." >&2
-    echo "Refusing to continue with a truncated board." >&2
-    exit 1
-  fi
+  echo "Error: fetched $(jq '.items | length' <<<"$response") of $(jq -r '.totalCount // "unknown"' <<<"$response") items from project $SPRINT_PROJECT_NUMBER at --limit $limit." >&2
+  echo "Refusing to continue with a truncated board." >&2
+  exit 1
 fi
 
 jq '.items' <<<"$response"

--- a/ai/skills/sprint-planning/scripts/gh_stub.py
+++ b/ai/skills/sprint-planning/scripts/gh_stub.py
@@ -5,8 +5,10 @@ Every invocation is appended to STUB_LOG as a JSON array, which is how the tests
 assert on the queries the scripts actually built.
 
 Board fetches return STUB_TOTAL as .totalCount (omitted when set to "none") and
-min(--limit, STUB_CAP) items, so a cap below the total simulates a board that
-stays truncated however high the limit goes. STUB_DRAFT_ITEMS and
+min(--limit, STUB_CAP, STUB_TOTAL) items, or min(--limit, STUB_CAP) when
+STUB_TOTAL is "none", so a cap below the total simulates a board that stays
+truncated however high the limit goes. STUB_CLOSED_AT is the mergedAt/closedAt
+every resolved item carries. STUB_DRAFT_ITEMS and
 STUB_UNASSIGNED_ITEMS are comma-separated item indexes: a draft gets DraftIssue
 content with no url or number, and an unassigned item omits the assignees key
 entirely, which is what the real CLI does.
@@ -32,6 +34,8 @@ import json
 import os
 import re
 import sys
+
+CLOSED_AT = os.environ.get("STUB_CLOSED_AT", "2026-07-15T00:00:00Z")
 
 argv = sys.argv[1:]
 log = os.environ["STUB_LOG"]
@@ -87,7 +91,9 @@ if argv[:2] == ["search", "prs"]:
 
 if argv[:2] == ["api", "graphql"]:
     query = next(a.split("=", 1)[1] for a in argv if a.startswith("query="))
-    prior = [json.loads(line) for line in open(log)][:-1]
+    # Drop this invocation's own line, so the count is this call's zero-based number.
+    with open(log) as fh:
+        prior = [json.loads(line) for line in fh][:-1]
     call_number = sum(1 for c in prior if c[:2] == ["api", "graphql"])
 
     if str(call_number) in os.environ.get("STUB_RATE_LIMITED_CALLS", "").split(","):
@@ -119,10 +125,17 @@ if argv[:2] == ["api", "graphql"]:
                 "isDraft": False,
                 "title": f"PR{number}",
                 "author": {"login": "someone"},
+                "mergedAt": CLOSED_AT,
+                "closedAt": CLOSED_AT,
                 "latestOpinionatedReviews": {"nodes": [{"author": {"login": "stubuser"}, "state": "APPROVED"}]},
             }}
         else:
-            data[f"item_{idx}"] = {"issue": {"state": "CLOSED", "stateReason": "COMPLETED", "title": f"IS{number}"}}
+            data[f"item_{idx}"] = {"issue": {
+                "state": "CLOSED",
+                "stateReason": "COMPLETED",
+                "title": f"IS{number}",
+                "closedAt": CLOSED_AT,
+            }}
     body = {"data": data}
     if partial:
         body["errors"] = [{"type": "NOT_FOUND", "message": "Could not resolve to a PullRequest"}]

--- a/ai/skills/sprint-planning/scripts/gh_stub.py
+++ b/ai/skills/sprint-planning/scripts/gh_stub.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Stub `gh` for test_board_scripts.py, copied onto PATH by that file's fixture.
+
+Every invocation is appended to STUB_LOG as a JSON array, which is how the tests
+assert on the queries the scripts actually built.
+
+Board fetches return STUB_TOTAL as .totalCount (omitted when set to "none") and
+min(--limit, STUB_CAP) items, so a cap below the total simulates a board that
+stays truncated however high the limit goes. STUB_DRAFT_ITEMS and
+STUB_UNASSIGNED_ITEMS are comma-separated item indexes: a draft gets DraftIssue
+content with no url or number, and an unassigned item omits the assignees key
+entirely, which is what the real CLI does.
+
+GraphQL calls echo one node per item_<idx> alias in the query, titled after the
+item's number so callers' index joins can be checked for alignment.
+STUB_FAILED_CALLS, STUB_RATE_LIMITED_CALLS and STUB_PARTIAL_CALLS are
+comma-separated, zero-based GraphQL call numbers, so "1" affects the second chunk
+rather than the second item:
+
+  STUB_FAILED_CALLS       whole chunk fails with no .data
+  STUB_RATE_LIMITED_CALLS chunk hits a rate limit, shaped by STUB_RATE_LIMIT_MODE:
+                          "body" puts a RATE_LIMITED entry under .errors,
+                          "secondary" returns a bare 403 {"message": ...} with no
+                          .errors array, "stderr" prints only gh's summary line
+  STUB_PARTIAL_CALLS      chunk returns .data alongside .errors and exits
+                          non-zero, nulling the one alias named by STUB_NULL_ALIAS
+
+STUB_SEARCH_PRS is how many PRs `gh search prs` returns.
+"""
+
+import json
+import os
+import re
+import sys
+
+argv = sys.argv[1:]
+log = os.environ["STUB_LOG"]
+with open(log, "a") as fh:
+    fh.write(json.dumps(argv) + "\n")
+
+if argv[:2] == ["project", "item-list"]:
+    limit = int(argv[argv.index("--limit") + 1])
+    total = os.environ.get("STUB_TOTAL", "0")
+    cap = int(os.environ.get("STUB_CAP", "100000"))
+    returned = min(limit, cap if total == "none" else min(cap, int(total)))
+    statuses = ["Done", "In Progress", "In Review", "Todo", "Approved"]
+    drafts = {int(x) for x in os.environ.get("STUB_DRAFT_ITEMS", "").split(",") if x}
+    unassigned = {int(x) for x in os.environ.get("STUB_UNASSIGNED_ITEMS", "").split(",") if x}
+    out = {"items": [
+        {
+            "id": f"i{n}",
+            "title": f"T{n}",
+            "status": statuses[n % len(statuses)],
+            **({} if n in unassigned else {"assignees": [f"user{n}"]}),
+            "content": ({"type": "DraftIssue", "title": f"T{n}", "body": ""} if n in drafts else {
+                "url": f"https://github.com/PostHog/posthog/pull/{n}",
+                "type": "PullRequest",
+                "number": n,
+                "repository": "PostHog/posthog",
+            }),
+        }
+        for n in range(returned)
+    ]}
+    if total != "none":
+        out["totalCount"] = int(total)
+    print(json.dumps(out))
+    sys.exit(0)
+
+if argv[:2] == ["api", "user"]:
+    print("stubuser")
+    sys.exit(0)
+
+if argv[:2] == ["search", "prs"]:
+    count = int(os.environ.get("STUB_SEARCH_PRS", "0"))
+    print(json.dumps([
+        {
+            "number": n,
+            "title": f"PR{n}",
+            "url": f"https://github.com/PostHog/posthog/pull/{n}",
+            "repository": {"name": "posthog", "nameWithOwner": "PostHog/posthog"},
+            "isDraft": False,
+            "updatedAt": "2026-08-01T00:00:00Z",
+        }
+        for n in range(1, count + 1)
+    ]))
+    sys.exit(0)
+
+if argv[:2] == ["api", "graphql"]:
+    query = next(a.split("=", 1)[1] for a in argv if a.startswith("query="))
+    prior = [json.loads(line) for line in open(log)][:-1]
+    call_number = sum(1 for c in prior if c[:2] == ["api", "graphql"])
+
+    if str(call_number) in os.environ.get("STUB_RATE_LIMITED_CALLS", "").split(","):
+        mode = os.environ.get("STUB_RATE_LIMIT_MODE", "body")
+        if mode == "body":
+            print(json.dumps({"errors": [{"type": "RATE_LIMITED", "message": "API rate limit exceeded"}]}))
+        elif mode == "secondary":
+            print(json.dumps({"message": "You have exceeded a secondary rate limit", "status": "403"}))
+        else:
+            print("gh: API rate limit exceeded for user ID 1", file=sys.stderr)
+        sys.exit(1)
+
+    if str(call_number) in os.environ.get("STUB_FAILED_CALLS", "").split(","):
+        print(json.dumps({"errors": [{"message": "Something went wrong"}]}))
+        sys.exit(1)
+
+    partial = str(call_number) in os.environ.get("STUB_PARTIAL_CALLS", "").split(",")
+    null_alias = os.environ.get("STUB_NULL_ALIAS", "")
+    data = {}
+    for idx, kind, number in re.findall(
+        r'item_(\d+): repository\([^)]*\) \{ (pullRequest|issue)\(number: (\d+)\)', query
+    ):
+        if partial and idx == null_alias:
+            data[f"item_{idx}"] = None
+            continue
+        if kind == "pullRequest":
+            data[f"item_{idx}"] = {"pullRequest": {
+                "state": "OPEN",
+                "isDraft": False,
+                "title": f"PR{number}",
+                "author": {"login": "someone"},
+                "latestOpinionatedReviews": {"nodes": [{"author": {"login": "stubuser"}, "state": "APPROVED"}]},
+            }}
+        else:
+            data[f"item_{idx}"] = {"issue": {"state": "CLOSED", "stateReason": "COMPLETED", "title": f"IS{number}"}}
+    body = {"data": data}
+    if partial:
+        body["errors"] = [{"type": "NOT_FOUND", "message": "Could not resolve to a PullRequest"}]
+    print(json.dumps(body))
+    sys.exit(1 if partial else 0)
+
+print(f"unexpected gh invocation: {argv}", file=sys.stderr)
+sys.exit(1)

--- a/ai/skills/sprint-planning/scripts/resolve-item-status.sh
+++ b/ai/skills/sprint-planning/scripts/resolve-item-status.sh
@@ -21,7 +21,7 @@
 #
 # URLs that can't be parsed are skipped. Returns [] for empty input. If the
 # GraphQL call fails entirely, state/isDraft/stateReason/title come back null
-# so the caller still has the URLs.
+# so the caller still has the URLs; an exhausted rate limit aborts instead.
 
 set -euo pipefail
 

--- a/ai/skills/sprint-planning/scripts/resolve-item-status.sh
+++ b/ai/skills/sprint-planning/scripts/resolve-item-status.sh
@@ -51,7 +51,14 @@ if [[ "$count" -eq 0 ]]; then
   exit 0
 fi
 
-response=$(echo "$refs" | "$BATCH_QUERY" "state isDraft title" "state stateReason title")
+# Exit 2 means nothing resolved. The URLs came from the plan itself, so report
+# them with an unknown state rather than nothing. Exit 1 is an exhausted rate
+# limit, which stays fatal: the run should stop, not paper over a whole board.
+response=$(echo "$refs" | "$BATCH_QUERY" "state isDraft title" "state stateReason title") || status=$?
+if [[ "${status:-0}" -ne 0 ]]; then
+  [[ "$status" -eq 2 ]] || exit "$status"
+  response=""
+fi
 
 if [[ -z "$response" ]]; then
   # Query failed entirely; return refs with null state so the caller still

--- a/ai/skills/sprint-planning/scripts/resolve-item-status.sh
+++ b/ai/skills/sprint-planning/scripts/resolve-item-status.sh
@@ -20,8 +20,9 @@
 #   }
 #
 # URLs that can't be parsed are skipped. Returns [] for empty input. If the
-# GraphQL call fails entirely, state/isDraft/stateReason/title come back null
-# so the caller still has the URLs; an exhausted rate limit aborts instead.
+# GraphQL call fails entirely, state/isDraft/stateReason/title come back null so
+# the caller still has the URLs, with a Warning: on stderr naming the loss; an
+# exhausted rate limit aborts instead.
 
 set -euo pipefail
 
@@ -51,21 +52,12 @@ if [[ "$count" -eq 0 ]]; then
   exit 0
 fi
 
-# Exit 2 means nothing resolved. The URLs came from the plan itself, so report
-# them with an unknown state rather than nothing. Exit 1 is an exhausted rate
-# limit, which stays fatal: the run should stop, not paper over a whole board.
-response=$(echo "$refs" | "$BATCH_QUERY" "state isDraft title" "state stateReason title") || status=$?
-if [[ "${status:-0}" -ne 0 ]]; then
-  [[ "$status" -eq 2 ]] || exit "$status"
-  response=""
-fi
-
-if [[ -z "$response" ]]; then
-  # Query failed entirely; return refs with null state so the caller still
-  # has URLs and can degrade gracefully.
-  echo "$refs" | jq '[.[] | . + {state: null, isDraft: null, stateReason: null, title: null}]'
-  exit 0
-fi
+# The URLs came from the plan itself, so a lookup that resolves nothing should
+# still report them with an unknown state; the join below null-propagates an
+# empty .data into exactly that, and the helper warns. An exhausted rate limit
+# is not tolerated and still aborts the run.
+response=$(echo "$refs" | "$BATCH_QUERY" --tolerate-total-loss \
+  "state isDraft title" "state stateReason title")
 
 # Join the batched results back onto the refs by index. A ref that failed
 # individually (e.g. an /issues/N link that is really a PR) has a null node,

--- a/ai/skills/sprint-planning/scripts/test_board_scripts.py
+++ b/ai/skills/sprint-planning/scripts/test_board_scripts.py
@@ -45,6 +45,7 @@ if argv[:2] == ["project", "item-list"]:
             "id": f"i{n}",
             "title": f"T{n}",
             "status": statuses[n % len(statuses)],
+            "assignees": [f"user{n}"],
             "content": {
                 "url": f"https://github.com/PostHog/posthog/pull/{n}",
                 "type": "PullRequest",
@@ -341,8 +342,10 @@ def test_board_goals_sees_active_items_past_the_first_fetch(gh):
     assert len(goals) == 303 - len(range(0, 303, 5))
     assert {g["title"] for g in goals} >= {"T201", "T302"}
     assert not any(g["status"] == "Done" for g in goals)
-    # Assignees stay joined to their own item across chunk boundaries.
+    # Assignees come off the board listing, so each item keeps its own.
     assert all(g["assignees"] == [f"user{g['number']}"] for g in goals)
+    # And no follow-up query is needed to learn them.
+    assert gh.queries == []
 
 
 def test_archive_aborts_rather_than_reporting_a_truncated_board(gh):

--- a/ai/skills/sprint-planning/scripts/test_board_scripts.py
+++ b/ai/skills/sprint-planning/scripts/test_board_scripts.py
@@ -1,0 +1,378 @@
+"""Tests for the board-fetch and batched-query shell helpers.
+
+Every test drives the scripts through a stub `gh` placed first on PATH, so the
+suite exercises pagination, chunking and failure handling without touching the
+GitHub API. The stub records each invocation it receives, which is how the
+tests assert on the queries the scripts actually built.
+"""
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+SCRIPTS = Path(__file__).resolve().parent
+FETCH_BOARD_ITEMS = SCRIPTS / "fetch-board-items.sh"
+BATCH_QUERY = SCRIPTS / "batch-item-query.sh"
+RESOLVE_ITEM_STATUS = SCRIPTS / "resolve-item-status.sh"
+FETCH_APPROVED_PRS = SCRIPTS / "fetch-approved-prs.sh"
+ARCHIVE_DONE_ITEMS = SCRIPTS / "archive-done-items.sh"
+FETCH_BOARD_GOALS = SCRIPTS / "fetch-board-goals.sh"
+
+# Stub `gh`. Board fetches return STUB_TOTAL as .totalCount (omitted when set to
+# "none") and min(--limit, STUB_CAP) items, so a cap below the total simulates a
+# board that stays truncated however high the limit goes. GraphQL calls echo one
+# node per item_<idx> alias in the query, titled after the item's number so
+# callers' index joins can be checked for alignment.
+GH_STUB = r'''#!/usr/bin/env python3
+import json, os, re, sys
+
+argv = sys.argv[1:]
+log = os.environ["STUB_LOG"]
+with open(log, "a") as fh:
+    fh.write(json.dumps(argv) + "\n")
+
+if argv[:2] == ["project", "item-list"]:
+    limit = int(argv[argv.index("--limit") + 1])
+    total = os.environ.get("STUB_TOTAL", "0")
+    cap = int(os.environ.get("STUB_CAP", "100000"))
+    returned = min(limit, cap if total == "none" else min(cap, int(total)))
+    statuses = ["Done", "In Progress", "In Review", "Todo", "Approved"]
+    out = {"items": [
+        {
+            "id": f"i{n}",
+            "title": f"T{n}",
+            "status": statuses[n % len(statuses)],
+            "content": {
+                "url": f"https://github.com/PostHog/posthog/pull/{n}",
+                "type": "PullRequest",
+                "number": n,
+                "repository": "PostHog/posthog",
+            },
+        }
+        for n in range(returned)
+    ]}
+    if total != "none":
+        out["totalCount"] = int(total)
+    print(json.dumps(out))
+    sys.exit(0)
+
+if argv[:2] == ["api", "user"]:
+    print("stubuser")
+    sys.exit(0)
+
+if argv[:2] == ["search", "prs"]:
+    count = int(os.environ.get("STUB_SEARCH_PRS", "0"))
+    print(json.dumps([
+        {
+            "number": n,
+            "title": f"PR{n}",
+            "url": f"https://github.com/PostHog/posthog/pull/{n}",
+            "repository": {"name": "posthog", "nameWithOwner": "PostHog/posthog"},
+            "isDraft": False,
+            "updatedAt": "2026-08-01T00:00:00Z",
+        }
+        for n in range(1, count + 1)
+    ]))
+    sys.exit(0)
+
+if argv[:2] == ["api", "graphql"]:
+    query = next(a.split("=", 1)[1] for a in argv if a.startswith("query="))
+    prior = [json.loads(line) for line in open(log)][:-1]
+    call_number = sum(1 for c in prior if c[:2] == ["api", "graphql"])
+
+    if str(call_number) in os.environ.get("STUB_RATE_LIMITED_CALLS", "").split(","):
+        mode = os.environ.get("STUB_RATE_LIMIT_MODE", "body")
+        if mode == "body":
+            print(json.dumps({"errors": [{"type": "RATE_LIMITED", "message": "API rate limit exceeded"}]}))
+        else:
+            print("gh: API rate limit exceeded for user ID 1", file=sys.stderr)
+        sys.exit(1)
+
+    if str(call_number) in os.environ.get("STUB_FAILED_CALLS", "").split(","):
+        print(json.dumps({"errors": [{"message": "Something went wrong"}]}))
+        sys.exit(1)
+
+    data = {}
+    for idx, kind, number in re.findall(
+        r'item_(\d+): repository\([^)]*\) \{ (pullRequest|issue)\(number: (\d+)\)', query
+    ):
+        if kind == "pullRequest":
+            data[f"item_{idx}"] = {"pullRequest": {
+                "state": "OPEN",
+                "isDraft": False,
+                "title": f"PR{number}",
+                "assignees": {"nodes": [{"login": f"user{number}"}]},
+                "author": {"login": "someone"},
+                "latestOpinionatedReviews": {"nodes": [{"author": {"login": "stubuser"}, "state": "APPROVED"}]},
+            }}
+        else:
+            data[f"item_{idx}"] = {"issue": {"state": "CLOSED", "stateReason": "COMPLETED", "title": f"IS{number}"}}
+    print(json.dumps({"data": data}))
+    sys.exit(0)
+
+print(f"unexpected gh invocation: {argv}", file=sys.stderr)
+sys.exit(1)
+'''
+
+
+@pytest.fixture
+def gh(tmp_path):
+    """Install the stub `gh` on PATH and expose the calls it recorded."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    stub = bin_dir / "gh"
+    stub.write_text(GH_STUB)
+    stub.chmod(0o755)
+    log = tmp_path / "gh-calls.log"
+    log.touch()
+
+    env = dict(os.environ)
+    env["PATH"] = f"{bin_dir}{os.pathsep}{env['PATH']}"
+    env["STUB_LOG"] = str(log)
+
+    class Gh:
+        def __init__(self):
+            self.env = env
+
+        def run(self, script, args=(), stdin=None, **overrides):
+            self.env.update({k: str(v) for k, v in overrides.items()})
+            return subprocess.run(
+                [str(script), *args],
+                input=stdin,
+                capture_output=True,
+                text=True,
+                env=self.env,
+            )
+
+        @property
+        def calls(self):
+            return [json.loads(line) for line in log.read_text().splitlines()]
+
+        @property
+        def queries(self):
+            return [
+                next(a.split("=", 1)[1] for a in call if a.startswith("query="))
+                for call in self.calls
+                if call[:2] == ["api", "graphql"]
+            ]
+
+    return Gh()
+
+
+def limits_requested(calls):
+    return [int(c[c.index("--limit") + 1]) for c in calls if c[:2] == ["project", "item-list"]]
+
+
+# --- fetch-board-items.sh ---
+
+
+def test_board_fetch_returns_every_item_in_one_call(gh):
+    result = gh.run(FETCH_BOARD_ITEMS, STUB_TOTAL=5)
+
+    assert result.returncode == 0, result.stderr
+    assert len(json.loads(result.stdout)) == 5
+    assert limits_requested(gh.calls) == [1000]
+
+
+def test_board_fetch_retries_when_the_board_exceeds_the_limit(gh):
+    """A board larger than the starting limit is refetched, not truncated."""
+    result = gh.run(FETCH_BOARD_ITEMS, STUB_TOTAL=303, SPRINT_BOARD_FETCH_LIMIT=200)
+
+    assert result.returncode == 0, result.stderr
+    assert len(json.loads(result.stdout)) == 303
+    first, second = limits_requested(gh.calls)
+    assert first == 200
+    assert second >= 303
+
+
+def test_board_fetch_fails_loudly_when_still_truncated(gh):
+    """A board that stays short however high the limit goes is an error, not a
+    partial answer: callers read missing items as work that doesn't exist."""
+    result = gh.run(FETCH_BOARD_ITEMS, STUB_TOTAL=303, STUB_CAP=200, SPRINT_BOARD_FETCH_LIMIT=200)
+
+    assert result.returncode != 0
+    assert result.stdout == ""
+    assert "200 of 303" in result.stderr
+
+
+def test_board_fetch_retries_an_exactly_full_read_without_a_total(gh):
+    """Without .totalCount to compare against, a read that exactly fills the
+    limit is treated as short rather than accepted as complete."""
+    result = gh.run(FETCH_BOARD_ITEMS, STUB_TOTAL="none", STUB_CAP=7, SPRINT_BOARD_FETCH_LIMIT=5)
+
+    assert result.returncode == 0, result.stderr
+    assert len(json.loads(result.stdout)) == 7
+    assert len(limits_requested(gh.calls)) == 2
+
+
+# --- batch-item-query.sh ---
+
+
+def items(count, kind="PullRequest", start=1):
+    return json.dumps(
+        [
+            {"owner": "PostHog", "repo": "posthog", "type": kind, "number": start + n}
+            for n in range(count)
+        ]
+    )
+
+
+def test_batch_query_chunks_and_indexes_aliases_globally(gh):
+    """Callers join by index against the full input, so aliases must count from
+    the start of the input rather than restart in each chunk."""
+    result = gh.run(BATCH_QUERY, ["title", "title"], stdin=items(120), BATCH_ITEM_CHUNK_SIZE=50)
+
+    assert result.returncode == 0, result.stderr
+    assert len(gh.queries) == 3
+    assert "item_0:" in gh.queries[0] and "item_49:" in gh.queries[0]
+    assert "item_50:" in gh.queries[1] and "item_99:" in gh.queries[1]
+    assert "item_100:" in gh.queries[2] and "item_119:" in gh.queries[2]
+    assert "item_50:" not in gh.queries[0]
+
+
+def test_batch_query_merges_every_chunk_into_one_response(gh):
+    result = gh.run(BATCH_QUERY, ["title", "title"], stdin=items(120), BATCH_ITEM_CHUNK_SIZE=50)
+
+    data = json.loads(result.stdout)["data"]
+    assert len(data) == 120
+    # item_<idx> holds the item at that position in the input, numbered from 1.
+    assert data["item_0"]["pullRequest"]["title"] == "PR1"
+    assert data["item_119"]["pullRequest"]["title"] == "PR120"
+
+
+def test_batch_query_routes_issues_and_prs_to_their_own_fields(gh):
+    mixed = json.dumps(
+        [
+            {"owner": "PostHog", "repo": "posthog", "type": "PullRequest", "number": 1},
+            {"owner": "PostHog", "repo": "posthog", "type": "Issue", "number": 2},
+        ]
+    )
+    result = gh.run(BATCH_QUERY, ["state isDraft", "state stateReason"], stdin=mixed)
+
+    assert "pullRequest(number: 1) { state isDraft }" in gh.queries[0]
+    assert "issue(number: 2) { state stateReason }" in gh.queries[0]
+    data = json.loads(result.stdout)["data"]
+    assert data["item_0"]["pullRequest"]["state"] == "OPEN"
+    assert data["item_1"]["issue"]["stateReason"] == "COMPLETED"
+
+
+def test_batch_query_keeps_surviving_chunks_when_one_fails(gh):
+    """A failed chunk leaves its items absent, which callers read as null, while
+    the rest of the board still resolves."""
+    result = gh.run(
+        BATCH_QUERY, ["title", "title"], stdin=items(120), BATCH_ITEM_CHUNK_SIZE=50, STUB_FAILED_CALLS="1"
+    )
+
+    assert result.returncode == 0, result.stderr
+    data = json.loads(result.stdout)["data"]
+    assert "item_0" in data and "item_100" in data
+    assert "item_50" not in data
+
+
+def test_batch_query_prints_nothing_when_every_chunk_fails(gh):
+    result = gh.run(
+        BATCH_QUERY, ["title", "title"], stdin=items(120), BATCH_ITEM_CHUNK_SIZE=50, STUB_FAILED_CALLS="0,1,2"
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == ""
+
+
+def test_batch_query_prints_nothing_for_empty_input(gh):
+    result = gh.run(BATCH_QUERY, ["title", "title"], stdin="[]")
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == ""
+    assert gh.queries == []
+
+
+def test_batch_query_fails_on_a_rate_limit_error_in_the_body(gh):
+    """Quota exhaustion must not read as "no items": it stops the run instead."""
+    result = gh.run(
+        BATCH_QUERY,
+        ["title", "title"],
+        stdin=items(120),
+        BATCH_ITEM_CHUNK_SIZE=50,
+        STUB_RATE_LIMITED_CALLS="1",
+        STUB_RATE_LIMIT_MODE="body",
+    )
+
+    assert result.returncode != 0
+    assert result.stdout == ""
+    assert "rate limit" in result.stderr.lower()
+    assert len(gh.queries) == 2  # stopped at the failing chunk
+
+
+def test_batch_query_fails_on_a_rate_limit_reported_only_on_stderr(gh):
+    result = gh.run(
+        BATCH_QUERY,
+        ["title", "title"],
+        stdin=items(120),
+        BATCH_ITEM_CHUNK_SIZE=50,
+        STUB_RATE_LIMITED_CALLS="0",
+        STUB_RATE_LIMIT_MODE="stderr",
+    )
+
+    assert result.returncode != 0
+    assert result.stdout == ""
+    assert "rate limit" in result.stderr.lower()
+
+
+# --- caller contract ---
+
+
+def test_board_goals_sees_active_items_past_the_first_fetch(gh):
+    """The reported bug: active work sitting beyond the fetch limit never
+    reached the sprint plan, because the status filter runs after the fetch."""
+    result = gh.run(
+        FETCH_BOARD_GOALS, STUB_TOTAL=303, SPRINT_BOARD_FETCH_LIMIT=200, BATCH_ITEM_CHUNK_SIZE=50
+    )
+
+    assert result.returncode == 0, result.stderr
+    goals = json.loads(result.stdout)
+    # Every status but Done, across the whole board rather than its first 200.
+    assert len(goals) == 242
+    assert {g["title"] for g in goals} >= {"T201", "T302"}
+    assert not any(g["status"] == "Done" for g in goals)
+    # Assignees stay joined to their own item across chunk boundaries.
+    assert all(g["assignees"] == [f"user{g['number']}"] for g in goals)
+
+
+def test_archive_aborts_rather_than_reporting_a_truncated_board(gh):
+    """A short board must stop the caller. Returning the items it did see would
+    read as "nothing left to archive" and leave stale items on the board."""
+    result = gh.run(
+        ARCHIVE_DONE_ITEMS, ["2026-08-01"], STUB_TOTAL=303, STUB_CAP=200, SPRINT_BOARD_FETCH_LIMIT=200
+    )
+
+    assert result.returncode != 0
+    assert result.stdout == ""
+    assert "truncated board" in result.stderr
+
+
+def test_approved_prs_drops_unresolved_prs_instead_of_failing(gh):
+    """A chunk that fails leaves its PRs with no reviews to judge; the caller
+    reports the ones it could resolve rather than dying on a null node."""
+    result = gh.run(
+        FETCH_APPROVED_PRS, stdin="", STUB_SEARCH_PRS=60, BATCH_ITEM_CHUNK_SIZE=50, STUB_FAILED_CALLS="1"
+    )
+
+    assert result.returncode == 0, result.stderr
+    approved = json.loads(result.stdout)
+    assert len(approved) == 50
+    assert {pr["number"] for pr in approved} == set(range(1, 51))
+
+
+def test_chunking_keeps_a_callers_index_join_aligned(gh):
+    """resolve-item-status.sh joins the response back by index; with more items
+    than fit in a chunk, every URL must still get its own item's data."""
+    urls = "\n".join(f"https://github.com/PostHog/posthog/pull/{n}" for n in range(1, 61))
+    result = gh.run(RESOLVE_ITEM_STATUS, stdin=urls, BATCH_ITEM_CHUNK_SIZE=50)
+
+    assert result.returncode == 0, result.stderr
+    resolved = json.loads(result.stdout)
+    assert len(resolved) == 60
+    assert all(item["title"] == f"PR{item['number']}" for item in resolved)

--- a/ai/skills/sprint-planning/scripts/test_board_scripts.py
+++ b/ai/skills/sprint-planning/scripts/test_board_scripts.py
@@ -20,112 +20,21 @@ RESOLVE_ITEM_STATUS = SCRIPTS / "resolve-item-status.sh"
 FETCH_APPROVED_PRS = SCRIPTS / "fetch-approved-prs.sh"
 ARCHIVE_DONE_ITEMS = SCRIPTS / "archive-done-items.sh"
 FETCH_BOARD_GOALS = SCRIPTS / "fetch-board-goals.sh"
-
-# Stub `gh`. Board fetches return STUB_TOTAL as .totalCount (omitted when set to
-# "none") and min(--limit, STUB_CAP) items, so a cap below the total simulates a
-# board that stays truncated however high the limit goes. GraphQL calls echo one
-# node per item_<idx> alias in the query, titled after the item's number so
-# callers' index joins can be checked for alignment.
-GH_STUB = r'''#!/usr/bin/env python3
-import json, os, re, sys
-
-argv = sys.argv[1:]
-log = os.environ["STUB_LOG"]
-with open(log, "a") as fh:
-    fh.write(json.dumps(argv) + "\n")
-
-if argv[:2] == ["project", "item-list"]:
-    limit = int(argv[argv.index("--limit") + 1])
-    total = os.environ.get("STUB_TOTAL", "0")
-    cap = int(os.environ.get("STUB_CAP", "100000"))
-    returned = min(limit, cap if total == "none" else min(cap, int(total)))
-    statuses = ["Done", "In Progress", "In Review", "Todo", "Approved"]
-    out = {"items": [
-        {
-            "id": f"i{n}",
-            "title": f"T{n}",
-            "status": statuses[n % len(statuses)],
-            "assignees": [f"user{n}"],
-            "content": {
-                "url": f"https://github.com/PostHog/posthog/pull/{n}",
-                "type": "PullRequest",
-                "number": n,
-                "repository": "PostHog/posthog",
-            },
-        }
-        for n in range(returned)
-    ]}
-    if total != "none":
-        out["totalCount"] = int(total)
-    print(json.dumps(out))
-    sys.exit(0)
-
-if argv[:2] == ["api", "user"]:
-    print("stubuser")
-    sys.exit(0)
-
-if argv[:2] == ["search", "prs"]:
-    count = int(os.environ.get("STUB_SEARCH_PRS", "0"))
-    print(json.dumps([
-        {
-            "number": n,
-            "title": f"PR{n}",
-            "url": f"https://github.com/PostHog/posthog/pull/{n}",
-            "repository": {"name": "posthog", "nameWithOwner": "PostHog/posthog"},
-            "isDraft": False,
-            "updatedAt": "2026-08-01T00:00:00Z",
-        }
-        for n in range(1, count + 1)
-    ]))
-    sys.exit(0)
-
-if argv[:2] == ["api", "graphql"]:
-    query = next(a.split("=", 1)[1] for a in argv if a.startswith("query="))
-    prior = [json.loads(line) for line in open(log)][:-1]
-    call_number = sum(1 for c in prior if c[:2] == ["api", "graphql"])
-
-    if str(call_number) in os.environ.get("STUB_RATE_LIMITED_CALLS", "").split(","):
-        mode = os.environ.get("STUB_RATE_LIMIT_MODE", "body")
-        if mode == "body":
-            print(json.dumps({"errors": [{"type": "RATE_LIMITED", "message": "API rate limit exceeded"}]}))
-        else:
-            print("gh: API rate limit exceeded for user ID 1", file=sys.stderr)
-        sys.exit(1)
-
-    if str(call_number) in os.environ.get("STUB_FAILED_CALLS", "").split(","):
-        print(json.dumps({"errors": [{"message": "Something went wrong"}]}))
-        sys.exit(1)
-
-    data = {}
-    for idx, kind, number in re.findall(
-        r'item_(\d+): repository\([^)]*\) \{ (pullRequest|issue)\(number: (\d+)\)', query
-    ):
-        if kind == "pullRequest":
-            data[f"item_{idx}"] = {"pullRequest": {
-                "state": "OPEN",
-                "isDraft": False,
-                "title": f"PR{number}",
-                "assignees": {"nodes": [{"login": f"user{number}"}]},
-                "author": {"login": "someone"},
-                "latestOpinionatedReviews": {"nodes": [{"author": {"login": "stubuser"}, "state": "APPROVED"}]},
-            }}
-        else:
-            data[f"item_{idx}"] = {"issue": {"state": "CLOSED", "stateReason": "COMPLETED", "title": f"IS{number}"}}
-    print(json.dumps({"data": data}))
-    sys.exit(0)
-
-print(f"unexpected gh invocation: {argv}", file=sys.stderr)
-sys.exit(1)
-'''
+GH_STUB = SCRIPTS / "gh_stub.py"
 
 
 @pytest.fixture
 def gh(tmp_path):
-    """Install the stub `gh` on PATH and expose the calls it recorded."""
+    """Install the stub `gh` on PATH and expose the calls it recorded.
+
+    See gh_stub.py for the STUB_* knobs each test sets.
+    """
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
     stub = bin_dir / "gh"
-    stub.write_text(GH_STUB)
+    # Copied rather than symlinked, so the stub still resolves when this
+    # directory is deployed read-only into ~/.claude/skills/.
+    stub.write_text(GH_STUB.read_text())
     stub.chmod(0o755)
     log = tmp_path / "gh-calls.log"
     log.touch()
@@ -225,7 +134,7 @@ def items(count, kind="PullRequest", start=1):
 def test_batch_query_chunks_and_indexes_aliases_globally(gh):
     """Callers join by index against the full input, so aliases must count from
     the start of the input rather than restart in each chunk."""
-    result = gh.run(BATCH_QUERY, ["title", "title"], stdin=items(120), BATCH_ITEM_CHUNK_SIZE=50)
+    result = gh.run(BATCH_QUERY, ["title", "title"], stdin=items(120))
 
     assert result.returncode == 0, result.stderr
     assert len(gh.queries) == 3
@@ -236,7 +145,7 @@ def test_batch_query_chunks_and_indexes_aliases_globally(gh):
 
 
 def test_batch_query_merges_every_chunk_into_one_response(gh):
-    result = gh.run(BATCH_QUERY, ["title", "title"], stdin=items(120), BATCH_ITEM_CHUNK_SIZE=50)
+    result = gh.run(BATCH_QUERY, ["title", "title"], stdin=items(120))
 
     data = json.loads(result.stdout)["data"]
     assert len(data) == 120
@@ -265,7 +174,7 @@ def test_batch_query_keeps_surviving_chunks_when_one_fails(gh):
     """A failed chunk leaves its items absent, which callers read as null, while
     the rest of the board still resolves."""
     result = gh.run(
-        BATCH_QUERY, ["title", "title"], stdin=items(120), BATCH_ITEM_CHUNK_SIZE=50, STUB_FAILED_CALLS="1"
+        BATCH_QUERY, ["title", "title"], stdin=items(120), STUB_FAILED_CALLS="1"
     )
 
     assert result.returncode == 0, result.stderr
@@ -276,13 +185,34 @@ def test_batch_query_keeps_surviving_chunks_when_one_fails(gh):
     assert "items 50 to 99 did not resolve" in result.stderr
 
 
-def test_batch_query_prints_nothing_when_every_chunk_fails(gh):
-    result = gh.run(
-        BATCH_QUERY, ["title", "title"], stdin=items(120), BATCH_ITEM_CHUNK_SIZE=50, STUB_FAILED_CALLS="0,1,2"
-    )
+def test_batch_query_keeps_a_chunks_survivors_when_one_item_fails(gh):
+    """One bad item number nulls its own alias and nothing else. gh exits
+    non-zero for the whole response, so the keep decision has to come from the
+    body or the other 49 items go with it."""
+    result = gh.run(BATCH_QUERY, ["title", "title"], stdin=items(50),
+                    STUB_PARTIAL_CALLS="0", STUB_NULL_ALIAS="7")
 
     assert result.returncode == 0, result.stderr
+    data = json.loads(result.stdout)["data"]
+    assert len(data) == 50 and data["item_7"] is None
+    assert data["item_8"]["pullRequest"]["title"] == "PR9"
+    assert "did not resolve" not in result.stderr
+
+
+def test_batch_query_fails_when_every_chunk_fails(gh):
+    """Nothing resolving is not the same answer as an empty board, so it exits 2
+    rather than letting an expired token read as "no work". Exit 2 is distinct
+    from the rate limit's exit 1 so a caller can degrade past one and not the
+    other."""
+    result = gh.run(
+        BATCH_QUERY, ["title", "title"], stdin=items(120), STUB_FAILED_CALLS="0,1,2"
+    )
+
+    assert result.returncode == 2
     assert result.stdout == ""
+    assert "none of the 120 items resolved" in result.stderr
+    # The error already names every item, so the per-chunk warnings stay quiet.
+    assert "did not resolve" not in result.stderr
 
 
 def test_batch_query_prints_nothing_for_empty_input(gh):
@@ -299,7 +229,6 @@ def test_batch_query_fails_on_a_rate_limit_error_in_the_body(gh):
         BATCH_QUERY,
         ["title", "title"],
         stdin=items(120),
-        BATCH_ITEM_CHUNK_SIZE=50,
         STUB_RATE_LIMITED_CALLS="1",
         STUB_RATE_LIMIT_MODE="body",
     )
@@ -310,12 +239,28 @@ def test_batch_query_fails_on_a_rate_limit_error_in_the_body(gh):
     assert len(gh.queries) == 2  # stopped at the failing chunk
 
 
+def test_batch_query_fails_on_a_secondary_rate_limit(gh):
+    """A secondary limit is a 403 whose body is a bare message with no .errors
+    array, so the body check has to look at both shapes."""
+    result = gh.run(
+        BATCH_QUERY,
+        ["title", "title"],
+        stdin=items(120),
+        STUB_RATE_LIMITED_CALLS="1",
+        STUB_RATE_LIMIT_MODE="secondary",
+    )
+
+    assert result.returncode == 1
+    assert result.stdout == ""
+    assert "rate limit" in result.stderr.lower()
+    assert len(gh.queries) == 2  # stopped at the failing chunk
+
+
 def test_batch_query_fails_on_a_rate_limit_reported_only_on_stderr(gh):
     result = gh.run(
         BATCH_QUERY,
         ["title", "title"],
         stdin=items(120),
-        BATCH_ITEM_CHUNK_SIZE=50,
         STUB_RATE_LIMITED_CALLS="0",
         STUB_RATE_LIMIT_MODE="stderr",
     )
@@ -331,9 +276,7 @@ def test_batch_query_fails_on_a_rate_limit_reported_only_on_stderr(gh):
 def test_board_goals_sees_active_items_past_the_first_fetch(gh):
     """The reported bug: active work sitting beyond the fetch limit never
     reached the sprint plan, because the status filter runs after the fetch."""
-    result = gh.run(
-        FETCH_BOARD_GOALS, STUB_TOTAL=303, SPRINT_BOARD_FETCH_LIMIT=200, BATCH_ITEM_CHUNK_SIZE=50
-    )
+    result = gh.run(FETCH_BOARD_GOALS, STUB_TOTAL=303, SPRINT_BOARD_FETCH_LIMIT=200)
 
     assert result.returncode == 0, result.stderr
     goals = json.loads(result.stdout)
@@ -346,6 +289,52 @@ def test_board_goals_sees_active_items_past_the_first_fetch(gh):
     assert all(g["assignees"] == [f"user{g['number']}"] for g in goals)
     # And no follow-up query is needed to learn them.
     assert gh.queries == []
+
+
+def test_board_goals_projects_drafts_and_unassigned_items(gh):
+    """A draft card has no linked Issue or PR, so url, type and number stay null
+    rather than erroring on tonumber. An unassigned item omits the key."""
+    result = gh.run(FETCH_BOARD_GOALS, STUB_TOTAL=5,
+                    STUB_DRAFT_ITEMS="1", STUB_UNASSIGNED_ITEMS="3")
+
+    assert result.returncode == 0, result.stderr
+    by_id = {g["id"]: g for g in json.loads(result.stdout)}
+    assert by_id["i1"]["url"] is None and by_id["i1"]["number"] is None
+    assert by_id["i3"]["assignees"] == []
+
+
+def test_resolve_item_status_keeps_urls_when_nothing_resolves(gh):
+    """The documented degrade path: a total query failure (exit 2) still returns
+    the URLs with null state, rather than an empty array that reads as a plan
+    referencing nothing."""
+    urls = "\n".join(f"https://github.com/PostHog/posthog/pull/{n}" for n in range(1, 4))
+    result = gh.run(RESOLVE_ITEM_STATUS, stdin=urls, STUB_FAILED_CALLS="0")
+
+    assert result.returncode == 0, result.stderr
+    resolved = json.loads(result.stdout)
+    assert len(resolved) == 3
+    assert all(item["state"] is None and item["url"] for item in resolved)
+
+
+def test_resolve_item_status_still_aborts_on_a_rate_limit(gh):
+    """Exit 1 stays fatal even though the caller degrades past exit 2. Papering
+    over an exhausted limit would report a whole plan as unknown."""
+    urls = "\n".join(f"https://github.com/PostHog/posthog/pull/{n}" for n in range(1, 4))
+    result = gh.run(RESOLVE_ITEM_STATUS, stdin=urls, STUB_RATE_LIMITED_CALLS="0")
+
+    assert result.returncode == 1
+    assert result.stdout == ""
+    assert "rate limit" in result.stderr.lower()
+
+
+def test_approved_prs_aborts_when_nothing_resolves(gh):
+    """A total failure must not print [], which reads as "you approved nothing"
+    and silently drops every PR from the sprint plan."""
+    result = gh.run(FETCH_APPROVED_PRS, stdin="", STUB_SEARCH_PRS=3, STUB_FAILED_CALLS="0")
+
+    assert result.returncode != 0
+    assert result.stdout == ""
+    assert "none of the 3 items resolved" in result.stderr
 
 
 def test_archive_aborts_rather_than_reporting_a_truncated_board(gh):
@@ -364,7 +353,7 @@ def test_approved_prs_drops_unresolved_prs_instead_of_failing(gh):
     """A chunk that fails leaves its PRs with no reviews to judge; the caller
     reports the ones it could resolve rather than dying on a null node."""
     result = gh.run(
-        FETCH_APPROVED_PRS, stdin="", STUB_SEARCH_PRS=60, BATCH_ITEM_CHUNK_SIZE=50, STUB_FAILED_CALLS="1"
+        FETCH_APPROVED_PRS, stdin="", STUB_SEARCH_PRS=60, STUB_FAILED_CALLS="1"
     )
 
     assert result.returncode == 0, result.stderr
@@ -377,7 +366,7 @@ def test_chunking_keeps_a_callers_index_join_aligned(gh):
     """resolve-item-status.sh joins the response back by index; with more items
     than fit in a chunk, every URL must still get its own item's data."""
     urls = "\n".join(f"https://github.com/PostHog/posthog/pull/{n}" for n in range(1, 61))
-    result = gh.run(RESOLVE_ITEM_STATUS, stdin=urls, BATCH_ITEM_CHUNK_SIZE=50)
+    result = gh.run(RESOLVE_ITEM_STATUS, stdin=urls)
 
     assert result.returncode == 0, result.stderr
     resolved = json.loads(result.stdout)

--- a/ai/skills/sprint-planning/scripts/test_board_scripts.py
+++ b/ai/skills/sprint-planning/scripts/test_board_scripts.py
@@ -138,13 +138,14 @@ def gh(tmp_path):
             self.env = env
 
         def run(self, script, args=(), stdin=None, **overrides):
-            self.env.update({k: str(v) for k, v in overrides.items()})
+            # Per-call env, so a second run in one test doesn't inherit the
+            # first one's stub settings.
             return subprocess.run(
                 [str(script), *args],
                 input=stdin,
                 capture_output=True,
                 text=True,
-                env=self.env,
+                env={**self.env, **{k: str(v) for k, v in overrides.items()}},
             )
 
         @property
@@ -270,6 +271,8 @@ def test_batch_query_keeps_surviving_chunks_when_one_fails(gh):
     data = json.loads(result.stdout)["data"]
     assert "item_0" in data and "item_100" in data
     assert "item_50" not in data
+    # The loss is announced, so a short result isn't mistaken for a full one.
+    assert "items 50 to 99 did not resolve" in result.stderr
 
 
 def test_batch_query_prints_nothing_when_every_chunk_fails(gh):
@@ -334,7 +337,8 @@ def test_board_goals_sees_active_items_past_the_first_fetch(gh):
     assert result.returncode == 0, result.stderr
     goals = json.loads(result.stdout)
     # Every status but Done, across the whole board rather than its first 200.
-    assert len(goals) == 242
+    # The stub cycles five statuses, so every fifth item is the Done one.
+    assert len(goals) == 303 - len(range(0, 303, 5))
     assert {g["title"] for g in goals} >= {"T201", "T302"}
     assert not any(g["status"] == "Done" for g in goals)
     # Assignees stay joined to their own item across chunk boundaries.

--- a/ai/skills/sprint-planning/scripts/test_board_scripts.py
+++ b/ai/skills/sprint-planning/scripts/test_board_scripts.py
@@ -49,7 +49,8 @@ def gh(tmp_path):
 
         def run(self, script, args=(), stdin=None, **overrides):
             # Per-call env, so a second run in one test doesn't inherit the
-            # first one's stub settings.
+            # first one's stub settings. Note the STUB_*_CALLS indexes still
+            # count GraphQL calls from the start of the test, not the run.
             return subprocess.run(
                 [str(script), *args],
                 input=stdin,
@@ -85,38 +86,37 @@ def test_board_fetch_returns_every_item_in_one_call(gh):
 
     assert result.returncode == 0, result.stderr
     assert len(json.loads(result.stdout)) == 5
-    assert limits_requested(gh.calls) == [1000]
+    assert limits_requested(gh.calls) == [100000]
 
 
-def test_board_fetch_retries_when_the_board_exceeds_the_limit(gh):
-    """A board larger than the starting limit is refetched, not truncated."""
-    result = gh.run(FETCH_BOARD_ITEMS, STUB_TOTAL=303, SPRINT_BOARD_FETCH_LIMIT=200)
+def test_board_fetch_takes_a_large_board_in_one_call(gh):
+    """--limit is a ceiling, not a fetch count, so a board far larger than any
+    earlier limit still arrives whole without a second request."""
+    result = gh.run(FETCH_BOARD_ITEMS, STUB_TOTAL=3030)
 
     assert result.returncode == 0, result.stderr
-    assert len(json.loads(result.stdout)) == 303
-    first, second = limits_requested(gh.calls)
-    assert first == 200
-    assert second >= 303
+    assert len(json.loads(result.stdout)) == 3030
+    assert len(limits_requested(gh.calls)) == 1
 
 
-def test_board_fetch_fails_loudly_when_still_truncated(gh):
-    """A board that stays short however high the limit goes is an error, not a
-    partial answer: callers read missing items as work that doesn't exist."""
-    result = gh.run(FETCH_BOARD_ITEMS, STUB_TOTAL=303, STUB_CAP=200, SPRINT_BOARD_FETCH_LIMIT=200)
+def test_board_fetch_fails_loudly_when_truncated(gh):
+    """A board that comes back short is an error, not a partial answer: callers
+    read missing items as work that doesn't exist."""
+    result = gh.run(FETCH_BOARD_ITEMS, STUB_TOTAL=303, STUB_CAP=200, BOARD_FETCH_LIMIT=200)
 
     assert result.returncode != 0
     assert result.stdout == ""
     assert "200 of 303" in result.stderr
 
 
-def test_board_fetch_retries_an_exactly_full_read_without_a_total(gh):
+def test_board_fetch_refuses_an_exactly_full_read_without_a_total(gh):
     """Without .totalCount to compare against, a read that exactly fills the
     limit is treated as short rather than accepted as complete."""
-    result = gh.run(FETCH_BOARD_ITEMS, STUB_TOTAL="none", STUB_CAP=7, SPRINT_BOARD_FETCH_LIMIT=5)
+    result = gh.run(FETCH_BOARD_ITEMS, STUB_TOTAL="none", STUB_CAP=7, BOARD_FETCH_LIMIT=5)
 
-    assert result.returncode == 0, result.stderr
-    assert len(json.loads(result.stdout)) == 7
-    assert len(limits_requested(gh.calls)) == 2
+    assert result.returncode != 0
+    assert result.stdout == ""
+    assert "of unknown items" in result.stderr
 
 
 # --- batch-item-query.sh ---
@@ -183,6 +183,43 @@ def test_batch_query_keeps_surviving_chunks_when_one_fails(gh):
     assert "item_50" not in data
     # The loss is announced, so a short result isn't mistaken for a full one.
     assert "items 50 to 99 did not resolve" in result.stderr
+    # Named, not just numbered: two callers drop unresolved items from their
+    # output, so a bare range points into an array the reader never sees.
+    assert "PostHog/posthog#51" in result.stderr
+
+
+def test_batch_query_names_the_final_partial_chunk_exactly(gh):
+    """The last chunk holds 20 of the 120 items, so its warning has to stop at
+    the last real item rather than at the chunk's nominal end."""
+    result = gh.run(BATCH_QUERY, ["title", "title"], stdin=items(120), STUB_FAILED_CALLS="2")
+
+    assert result.returncode == 0, result.stderr
+    assert "items 100 to 119" in result.stderr
+
+
+def test_batch_query_sends_one_query_for_exactly_one_chunk(gh):
+    """An input that exactly fills a chunk must not emit a trailing empty query."""
+    result = gh.run(BATCH_QUERY, ["title", "title"], stdin=items(50))
+
+    assert result.returncode == 0, result.stderr
+    assert len(gh.queries) == 1
+
+
+def test_batch_query_flattens_a_multiline_selection_set(gh):
+    """A newline in either selection set would split one query into fragments,
+    so both are flattened before the chunk loop reads them line by line."""
+    mixed = json.dumps(
+        [
+            {"owner": "PostHog", "repo": "posthog", "type": "PullRequest", "number": 1},
+            {"owner": "PostHog", "repo": "posthog", "type": "Issue", "number": 2},
+        ]
+    )
+    result = gh.run(BATCH_QUERY, ["state\nisDraft", "state\nstateReason"], stdin=mixed)
+
+    assert result.returncode == 0, result.stderr
+    assert len(gh.queries) == 1
+    assert "pullRequest(number: 1) { state isDraft }" in gh.queries[0]
+    assert "issue(number: 2) { state stateReason }" in gh.queries[0]
 
 
 def test_batch_query_keeps_a_chunks_survivors_when_one_item_fails(gh):
@@ -200,19 +237,48 @@ def test_batch_query_keeps_a_chunks_survivors_when_one_item_fails(gh):
 
 
 def test_batch_query_fails_when_every_chunk_fails(gh):
-    """Nothing resolving is not the same answer as an empty board, so it exits 2
-    rather than letting an expired token read as "no work". Exit 2 is distinct
-    from the rate limit's exit 1 so a caller can degrade past one and not the
-    other."""
+    """Nothing resolving is not the same answer as an empty board, so it fails
+    rather than letting an expired token read as "no work"."""
     result = gh.run(
         BATCH_QUERY, ["title", "title"], stdin=items(120), STUB_FAILED_CALLS="0,1,2"
     )
 
-    assert result.returncode == 2
+    assert result.returncode == 1
     assert result.stdout == ""
-    assert "none of the 120 items resolved" in result.stderr
+    assert "Error: none of the 120 items resolved" in result.stderr
     # The error already names every item, so the per-chunk warnings stay quiet.
     assert "did not resolve" not in result.stderr
+
+
+def test_batch_query_tolerates_a_total_loss_when_the_caller_opts_in(gh):
+    """A caller that would rather report what it knows gets an empty .data and a
+    Warning:, which is the vocabulary SKILL.md keys "incomplete" off. Its index
+    join reads the absent aliases as null, exactly as it reads a failed chunk."""
+    result = gh.run(
+        BATCH_QUERY,
+        ["--tolerate-total-loss", "title", "title"],
+        stdin=items(120),
+        STUB_FAILED_CALLS="0,1,2",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert json.loads(result.stdout) == {"data": {}}
+    assert "Warning: none of the 120 items resolved" in result.stderr
+
+
+def test_batch_query_still_fails_on_a_rate_limit_when_tolerating_total_loss(gh):
+    """Opting into a tolerated lookup failure is not opting into spending a quota
+    GitHub has stopped allowing, so exit 1 survives the flag."""
+    result = gh.run(
+        BATCH_QUERY,
+        ["--tolerate-total-loss", "title", "title"],
+        stdin=items(120),
+        STUB_RATE_LIMITED_CALLS="0",
+    )
+
+    assert result.returncode == 1
+    assert result.stdout == ""
+    assert "rate limit" in result.stderr.lower()
 
 
 def test_batch_query_prints_nothing_for_empty_input(gh):
@@ -236,6 +302,8 @@ def test_batch_query_fails_on_a_rate_limit_error_in_the_body(gh):
     assert result.returncode != 0
     assert result.stdout == ""
     assert "rate limit" in result.stderr.lower()
+    # The position is the only thing naming where the run stopped.
+    assert "at item 50" in result.stderr
     assert len(gh.queries) == 2  # stopped at the failing chunk
 
 
@@ -274,9 +342,9 @@ def test_batch_query_fails_on_a_rate_limit_reported_only_on_stderr(gh):
 
 
 def test_board_goals_sees_active_items_past_the_first_fetch(gh):
-    """The reported bug: active work sitting beyond the fetch limit never
+    """The reported bug: active work sitting beyond the old 200-item cap never
     reached the sprint plan, because the status filter runs after the fetch."""
-    result = gh.run(FETCH_BOARD_GOALS, STUB_TOTAL=303, SPRINT_BOARD_FETCH_LIMIT=200)
+    result = gh.run(FETCH_BOARD_GOALS, STUB_TOTAL=303)
 
     assert result.returncode == 0, result.stderr
     goals = json.loads(result.stdout)
@@ -304,9 +372,10 @@ def test_board_goals_projects_drafts_and_unassigned_items(gh):
 
 
 def test_resolve_item_status_keeps_urls_when_nothing_resolves(gh):
-    """The documented degrade path: a total query failure (exit 2) still returns
-    the URLs with null state, rather than an empty array that reads as a plan
-    referencing nothing."""
+    """The documented degrade path: this caller passes --tolerate-total-loss, so
+    a query that resolves nothing still returns the URLs with null state rather
+    than an empty array that reads as a plan referencing nothing. The Warning: is
+    what tells the agent the states are unknown rather than genuinely absent."""
     urls = "\n".join(f"https://github.com/PostHog/posthog/pull/{n}" for n in range(1, 4))
     result = gh.run(RESOLVE_ITEM_STATUS, stdin=urls, STUB_FAILED_CALLS="0")
 
@@ -314,11 +383,12 @@ def test_resolve_item_status_keeps_urls_when_nothing_resolves(gh):
     resolved = json.loads(result.stdout)
     assert len(resolved) == 3
     assert all(item["state"] is None and item["url"] for item in resolved)
+    assert "Warning: none of the 3 items resolved" in result.stderr
 
 
 def test_resolve_item_status_still_aborts_on_a_rate_limit(gh):
-    """Exit 1 stays fatal even though the caller degrades past exit 2. Papering
-    over an exhausted limit would report a whole plan as unknown."""
+    """A tolerated lookup failure is not a tolerated quota failure. Papering over
+    an exhausted limit would report a whole plan as unknown."""
     urls = "\n".join(f"https://github.com/PostHog/posthog/pull/{n}" for n in range(1, 4))
     result = gh.run(RESOLVE_ITEM_STATUS, stdin=urls, STUB_RATE_LIMITED_CALLS="0")
 
@@ -341,12 +411,33 @@ def test_archive_aborts_rather_than_reporting_a_truncated_board(gh):
     """A short board must stop the caller. Returning the items it did see would
     read as "nothing left to archive" and leave stale items on the board."""
     result = gh.run(
-        ARCHIVE_DONE_ITEMS, ["2026-08-01"], STUB_TOTAL=303, STUB_CAP=200, SPRINT_BOARD_FETCH_LIMIT=200
+        ARCHIVE_DONE_ITEMS, ["2026-08-01"], STUB_TOTAL=303, STUB_CAP=200, BOARD_FETCH_LIMIT=200
     )
 
     assert result.returncode != 0
     assert result.stdout == ""
     assert "truncated board" in result.stderr
+
+
+def test_archive_lists_done_items_closed_before_the_sprint(gh):
+    """Happy path: Done items merged before the sprint start are archive
+    candidates. Nothing else runs archive-done-items.sh to completion, so
+    without this the board projection and the date join are both unexercised."""
+    result = gh.run(ARCHIVE_DONE_ITEMS, ["2026-08-01"], STUB_TOTAL=10)
+
+    assert result.returncode == 0, result.stderr
+    candidates = json.loads(result.stdout)
+    # The stub cycles five statuses, so items 0 and 5 are the Done ones.
+    assert {c["number"] for c in candidates} == {0, 5}
+    assert all(c["closed_date"] == "2026-07-15" for c in candidates)
+
+
+def test_archive_skips_items_closed_after_the_sprint_started(gh):
+    """An item closed during the sprint is this sprint's work, not stale."""
+    result = gh.run(ARCHIVE_DONE_ITEMS, ["2026-07-01"], STUB_TOTAL=10)
+
+    assert result.returncode == 0, result.stderr
+    assert json.loads(result.stdout) == []
 
 
 def test_approved_prs_drops_unresolved_prs_instead_of_failing(gh):


### PR DESCRIPTION
`/sprint-planning` read the board with `gh project item-list --limit 200`, so on a board past 200 items everything after that was invisible. In Review and In Progress work never reached the plan, and Done items that should have been archived stayed on the board.

Board reads now go through `fetch-board-items.sh`, which compares the returned count against the board's `totalCount` and exits non-zero rather than hand back a partial board. `gh` reports the real size on the first page and never rewrites it during pagination, so a short read is detectable rather than guessed at. `--limit` is a ceiling rather than a fetch count, so one request sized well above any real board returns the whole thing.

Removing the cap meant the shared batched query could be handed the whole board, so `batch-item-query.sh` splits into 50-item chunks. Aliases are numbered across the whole input before it is sliced, which is what keeps `item_<index>` meaningful to the three callers that join by index.

Three failure modes used to be indistinguishable from an empty board, and each now stops the run: a truncated board, an exhausted GraphQL rate limit, and a query where no chunk resolves at all. Whether that last one is fatal is the caller's policy, so it is a `--tolerate-total-loss` flag rather than an exit code the caller has to unwind. `resolve-item-status.sh` passes it and keeps its documented degrade path, reporting the plan's URLs with unknown state and a `Warning:` naming the loss, while an exhausted limit still aborts. A partial loss stays a warning, since the surviving chunks are real answers.

`fetch-board-goals.sh` reads assignees off the board listing instead of resolving them again over GraphQL. That drops a request count that grew with the board, and since the script runs twice per session it removes four requests per run. Verified against board 112: byte-for-byte identical output across all 71 items.

Three smaller fixes fell out of the above. A secondary rate limit is a 403 whose body is a bare message with no `.errors` array, which the original check missed entirely, leaving the stderr grep as the only thing catching it. `fetch-approved-prs.sh` called `any()` directly on a possibly-null node, which is a hard jq error that a failed chunk makes reachable. And `number` is now coerced through `tonumber` before it reaches the query: it was the one value interpolated without `@json`, and since the chunk loop reads one query per line, a value carrying a newline would have run a second query.

## Test plan

New suite at `ai/skills/sprint-planning/scripts/test_board_scripts.py`, 29 tests driving the scripts through a stub `gh` on `PATH`. No network, no real API.

```
cd ai/skills/sprint-planning/scripts && python3 -m pytest -q
```

- [ ] 50 tests pass (29 new plus the pre-existing `test_parse_sprints.py`)
- [ ] `shellcheck -e SC1091 ai/skills/sprint-planning/scripts/*.sh` is clean
- [ ] Run `/sprint-planning` against a real board and confirm In Review and In Progress items past the 200th appear in the plan
- [ ] Run `/sprint-planning --status` and confirm plan items still resolve to the right markers
- [ ] Run `/sprint-planning --approved` and confirm approved PRs are listed

The truncation guard is covered by the stub rather than against a real board, since a real board never reaches the limit. `BOARD_FETCH_LIMIT` lowers it if you want to exercise it live.