### PR TITLE
Fix dismissed-comment state shape mismatch in address-pr-reviews

### DIFF
--- a/ai/skills/address-pr-reviews/SKILL.md
+++ b/ai/skills/address-pr-reviews/SKILL.md
@@ -108,14 +108,13 @@ With user confirmation:
 3. If any files were changed, ask the user if they want to commit and push:
    - Commit message: "Address PR review feedback"
    - Push to the current branch
-4. Update the shared state file with newly dismissed comment hashes:
+4. Record each dismissed comment in the shared state file so future runs filter it out. For each one, write the comment's `body` — byte for byte as returned by the fetch script in Step 2 — to a temp file, then pipe it into the record script:
 
 ```bash
-STATE_DIR="$HOME/.local/state/copilot-review-loop"
-STATE_FILE="${STATE_DIR}/<owner>-<repo_name>-<pr_number>.json"
+~/.claude/skills/address-pr-reviews/scripts/record-dismissed-comment.sh <repo> <pr_number> < <body-file>
 ```
 
-For each dismissed comment, compute its hash using the same logic as `hash_comment` in `~/.dotfiles/bin/lib/copilot.sh` (lowercase, trim whitespace, SHA-256) and append to the `dismissed_comments` array in the state file. Create the file if it doesn't exist.
+The script hashes the body, appends it to the state file (creating the file if needed), and is idempotent — re-running for an already-recorded comment is a no-op. If it exits non-zero, report the error; never edit the state file by hand.
 
 ## Security Note
 

--- a/ai/skills/address-pr-reviews/SKILL.md
+++ b/ai/skills/address-pr-reviews/SKILL.md
@@ -39,10 +39,11 @@ Parse these into variables for use in subsequent steps. If the script fails, rep
 
 ### Step 2: Fetch and Filter Unaddressed Comments
 
-Run the fetch script:
+Run the fetch script, saving its output to a file — Step 5 extracts comment bodies from it, so the raw JSON must survive on disk:
 
 ```bash
-~/.claude/skills/address-pr-reviews/scripts/fetch-unaddressed-comments.sh <repo> <pr_number>
+comments_file=$(mktemp)
+~/.claude/skills/address-pr-reviews/scripts/fetch-unaddressed-comments.sh <repo> <pr_number> > "$comments_file"
 ```
 
 This returns a JSON array of every **unresolved** inline review comment on the PR — from any reviewer — minus ones you've previously dismissed. Each comment has `id`, `path`, `line`, `body`, `diff_hunk`, `author` (the reviewer's login), and `is_bot` (true when a bot authored it — Copilot, ReviewHog, Greptile, Graphite, or any other GitHub App; false for human reviewers).
@@ -108,10 +109,10 @@ With user confirmation:
 3. If any files were changed, ask the user if they want to commit and push:
    - Commit message: "Address PR review feedback"
    - Push to the current branch
-4. Record each dismissed comment in the shared state file so future runs filter it out. For each one, write the comment's `body` — byte for byte as returned by the fetch script in Step 2 — to a temp file, then pipe it into the record script:
+4. Record each dismissed comment in the shared state file so future runs filter it out. Extract the body from the Step 2 file with jq — never retype or paste it yourself; a single altered byte changes the hash and breaks the dedup — and pipe it into the record script:
 
 ```bash
-~/.claude/skills/address-pr-reviews/scripts/record-dismissed-comment.sh <repo> <pr_number> < <body-file>
+jq -r --argjson id <comment_id> '.[] | select(.id == $id) | .body' "$comments_file" | ~/.claude/skills/address-pr-reviews/scripts/record-dismissed-comment.sh <repo> <pr_number>
 ```
 
 The script hashes the body, appends it to the state file (creating the file if needed), and is idempotent — re-running for an already-recorded comment is a no-op. If it exits non-zero, report the error; never edit the state file by hand.

--- a/ai/skills/address-pr-reviews/scripts/fetch-unaddressed-comments.sh
+++ b/ai/skills/address-pr-reviews/scripts/fetch-unaddressed-comments.sh
@@ -23,12 +23,7 @@ fi
 REPO="$1"
 PR_NUMBER="$2"
 
-# Derive owner and repo_name from REPO for state file path
-owner="${REPO%%/*}"
-repo_name="${REPO##*/}"
-
-STATE_DIR="${HOME}/.local/state/copilot-review-loop"
-STATE_FILE="${STATE_DIR}/${owner}-${repo_name}-${PR_NUMBER}.json"
+STATE_FILE=$(dismissed_state_file "$REPO" "$PR_NUMBER")
 
 # Fetch all unresolved review comments across every reviewer
 comments=$(fetch_unresolved_review_comments)
@@ -39,12 +34,11 @@ if [[ "$comment_count" -eq 0 ]]; then
   exit 0
 fi
 
-# Load dismissed hashes from state file
-if [[ -f "$STATE_FILE" ]]; then
-  dismissed_hashes=$(jq -r '.dismissed_comments[]?.body_hash // empty' < "$STATE_FILE" || echo "")
-else
-  dismissed_hashes=""
-fi
+# Load dismissed hashes from the state file, normalizing both entry shapes:
+# objects from the review loop and bare hash strings from older skill runs.
+# read_state_file fails loud on a corrupt file, ending the run via errexit.
+state=$(read_state_file "$STATE_FILE")
+dismissed_hashes=$(echo "$state" | jq -r "$DISMISSED_OBJECTS_JQ"' | .body_hash // empty')
 
 # Build a lookup set from dismissed hashes
 declare -A dismissed_set

--- a/ai/skills/address-pr-reviews/scripts/fetch-unaddressed-comments.sh
+++ b/ai/skills/address-pr-reviews/scripts/fetch-unaddressed-comments.sh
@@ -38,7 +38,7 @@ fi
 # objects from the review loop and bare hash strings from older skill runs.
 # read_state_file fails loud on a corrupt file, ending the run via errexit.
 state=$(read_state_file "$STATE_FILE")
-dismissed_hashes=$(echo "$state" | jq -r "$DISMISSED_OBJECTS_JQ"' | .body_hash // empty')
+dismissed_hashes=$(echo "$state" | jq -r "$DISMISSED_OBJECTS_JQ"' | .body_hash')
 
 # Build a lookup set from dismissed hashes
 declare -A dismissed_set

--- a/ai/skills/address-pr-reviews/scripts/record-dismissed-comment.sh
+++ b/ai/skills/address-pr-reviews/scripts/record-dismissed-comment.sh
@@ -46,7 +46,9 @@ if echo "$state" | jq -e --arg h "$body_hash" \
   exit 0
 fi
 
-body_preview=$(echo "$body" | head -c 80)
+# printf, not `echo | head -c`: head exiting after 80 bytes SIGPIPEs echo on
+# large bodies, killing the script under pipefail.
+body_preview=$(printf '%.80s' "$body")
 state=$(echo "$state" | jq \
   --arg h "$body_hash" \
   --arg p "$body_preview" \

--- a/ai/skills/address-pr-reviews/scripts/record-dismissed-comment.sh
+++ b/ai/skills/address-pr-reviews/scripts/record-dismissed-comment.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# record-dismissed-comment.sh - Record a dismissed review comment in the shared state file
+#
+# Usage: record-dismissed-comment.sh <repo> <pr_number> < comment-body
+#
+# Reads the comment body from stdin (bodies contain quotes and newlines), hashes
+# it with the same normalization as the review loop, and appends
+# {"body_hash", "body_preview"} to the dismissed_comments array in:
+#   ~/.local/state/copilot-review-loop/{owner}-{repo_name}-{pr_number}.json
+#
+# Creates the state file if it doesn't exist. Idempotent: a body whose hash is
+# already recorded — in either the object or legacy bare-string shape — is a
+# no-op.
+
+set -euo pipefail
+
+DOTFILES_DIR="${DOTFILES_DIR:-$HOME/.dotfiles}"
+# shellcheck source=bin/lib/copilot.sh
+source "${DOTFILES_DIR}/bin/lib/copilot.sh"
+# shellcheck source=bin/lib/fs.sh
+source "${DOTFILES_DIR}/bin/lib/fs.sh"
+
+if [[ $# -lt 2 ]]; then
+  echo "Usage: $(basename "$0") <repo> <pr_number> < comment-body" >&2
+  exit 1
+fi
+
+REPO="$1"
+PR_NUMBER="$2"
+
+STATE_FILE=$(dismissed_state_file "$REPO" "$PR_NUMBER")
+
+body=$(cat)
+if [[ -z "${body//[[:space:]]/}" ]]; then
+  echo "Error: empty comment body on stdin" >&2
+  exit 1
+fi
+
+state=$(read_state_file "$STATE_FILE")
+
+body_hash=$(hash_comment "$body")
+
+if echo "$state" | jq -e --arg h "$body_hash" \
+  '[ '"$DISMISSED_OBJECTS_JQ"' | select(.body_hash == $h) ] | length > 0' >/dev/null; then
+  echo "Already recorded: ${body_hash}"
+  exit 0
+fi
+
+body_preview=$(echo "$body" | head -c 80)
+state=$(echo "$state" | jq \
+  --arg h "$body_hash" \
+  --arg p "$body_preview" \
+  '.dismissed_comments += [{"body_hash": $h, "body_preview": $p}]')
+
+mkdir -p "$(dirname "$STATE_FILE")"
+echo "$state" | atomic_write "$STATE_FILE"
+echo "Recorded: ${body_hash}"

--- a/bin/copilot-review-loop.sh
+++ b/bin/copilot-review-loop.sh
@@ -20,6 +20,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/lib/logging.sh"
 source "${SCRIPT_DIR}/lib/github.sh"
 source "${SCRIPT_DIR}/lib/copilot.sh"
+source "${SCRIPT_DIR}/lib/fs.sh"
 
 # ── Configuration Defaults ───────────────────────────────────────────────────
 
@@ -86,20 +87,13 @@ validate_working_directory() {
 # ── State Management ─────────────────────────────────────────────────────────
 
 load_state() {
-  STATE_FILE="${STATE_DIR}/${OWNER}-${REPO_NAME}-${PR_NUMBER}.json"
+  STATE_FILE=$(dismissed_state_file "$REPO" "$PR_NUMBER")
   mkdir -p "$STATE_DIR"
-  if [[ -f "$STATE_FILE" ]]; then
-    STATE=$(cat "$STATE_FILE")
-  else
-    STATE='{"dismissed_comments":[],"rounds":[]}'
-  fi
+  STATE=$(read_state_file "$STATE_FILE")
 }
 
 save_state() {
-  local tmp
-  tmp=$(mktemp)
-  echo "$STATE" > "$tmp"
-  mv "$tmp" "$STATE_FILE"
+  echo "$STATE" | atomic_write "$STATE_FILE"
 }
 
 add_dismissed() {
@@ -545,7 +539,7 @@ main() {
     while IFS=$'\t' read -r h r; do
       dismissed_hashes["$h"]=1
       dismissed_rounds["$h"]="$r"
-    done < <(echo "$STATE" | jq -r '.dismissed_comments[] | [.body_hash, (.round | tostring)] | @tsv')
+    done < <(echo "$STATE" | jq -r "$DISMISSED_HASH_ROUNDS_JQ")
 
     # Filter out comments whose body hash matches a previously dismissed one,
     # collecting new comments as ndjson and assembling them with jq -s at the end.
@@ -606,7 +600,12 @@ main() {
             continue
           fi
           local orig_round="${skipped_orig_rounds[$i]:-?}"
-          local reply_body="Already addressed in round ${orig_round} of this review loop. See the earlier discussion on this PR for context."
+          # Skill-recorded dismissals carry no round, so don't cite one.
+          local when="an earlier review pass"
+          if [[ "$orig_round" != "?" ]]; then
+            when="round ${orig_round} of this review loop"
+          fi
+          local reply_body="Already addressed in ${when}. See the earlier discussion on this PR for context."
           if gh api "repos/${REPO}/pulls/${PR_NUMBER}/comments/${cid}/replies" \
             --method POST -f body="$reply_body" --silent 2>/dev/null; then
             reack_resolve_args+=(--comment-id "$cid")

--- a/bin/copilot-review-loop.sh
+++ b/bin/copilot-review-loop.sh
@@ -31,7 +31,7 @@ POLL_INTERVAL=15
 POLL_TIMEOUT=600
 DRY_RUN=false
 SKIP_PERMISSIONS=false
-STATE_DIR="${HOME}/.local/state/copilot-review-loop"
+STATE_DIR="$(dismissed_state_dir)"
 
 # ── Usage ────────────────────────────────────────────────────────────────────
 
@@ -135,7 +135,9 @@ process_dismissed_comments() {
       '.[] | select(.id == $id) | .body')
     [[ -z "$body" ]] && continue
     body_hash=$(hash_comment "$body")
-    body_preview=$(echo "$body" | head -c 80)
+    # printf, not `echo | head -c`: head exiting after 80 bytes SIGPIPEs echo
+    # on large bodies, killing the script under pipefail.
+    body_preview=$(printf '%.80s' "$body")
     add_dismissed "$body_hash" "$body_preview" "$round"
 
     reply=$(echo "$summary" | jq -r --argjson id "$dismissed_id" \

--- a/bin/lib/copilot.sh
+++ b/bin/lib/copilot.sh
@@ -14,6 +14,8 @@
 #   PR_NUMBER   - PR number (e.g. "123")
 #
 # Functions:
+#   dismissed_state_file      - Path of a PR's shared dismissed-comments state file
+#   read_state_file           - Emit a state document, defaulting when absent
 #   hash_comment              - SHA-256 hash of a normalized comment body
 #   get_pr_head_sha           - Current HEAD SHA of the PR
 #   get_latest_copilot_review - Latest Copilot review as JSON {id, commit_id}
@@ -65,6 +67,46 @@ UNRESOLVED_COMMENTS_JQ='
       }
   ]
 '
+
+# jq sub-filter: streams dismissed_comments entries normalized to objects. The
+# review loop writes {"body_hash", "body_preview", "round"}; older skill runs
+# appended bare hash strings, and state files with that shape exist on every
+# machine indefinitely, so every reader must accept either. Exposed as a
+# constant so the unit test exercises the exact same program.
+DISMISSED_OBJECTS_JQ='.dismissed_comments[]? | if type == "object" then . else {body_hash: .} end'
+
+# Full program copilot-review-loop.sh uses to build its dedup table: one
+# "hash<TAB>round" line per entry. Entries without a round (skill-recorded
+# dismissals) get "?", matching the loop's unknown-round display fallback.
+# Entries without a body_hash are dropped rather than emitted as empty keys,
+# which would be a fatal bad array subscript in the loop's associative array.
+# shellcheck disable=SC2034  # consumed by copilot-review-loop.sh
+DISMISSED_HASH_ROUNDS_JQ="${DISMISSED_OBJECTS_JQ}"' | select((.body_hash // "") != "") | [.body_hash, ((.round // "?") | tostring)] | @tsv'
+
+# Path of the shared state file recording a PR's dismissed review comments.
+# Usage: dismissed_state_file <owner/repo> <pr_number>
+dismissed_state_file() {
+  local slug="$1" pr="$2"
+  echo "${HOME}/.local/state/copilot-review-loop/${slug%%/*}-${slug##*/}-${pr}.json"
+}
+
+# Emit the state document at $1, or the empty default when the file doesn't
+# exist. Fails when the file exists but is not a JSON object: proceeding with
+# an empty dedup set would resurface every previously dismissed comment.
+read_state_file() {
+  local file="$1" doc
+  if [[ ! -f "$file" ]]; then
+    echo '{"dismissed_comments":[],"rounds":[]}'
+    return 0
+  fi
+  doc=$(cat "$file")
+  if ! echo "$doc" | jq -e 'type == "object"' >/dev/null 2>&1; then
+    echo "Error: cannot parse state file: ${file}" >&2
+    echo "Fix or delete it, then re-run." >&2
+    return 1
+  fi
+  echo "$doc"
+}
 
 # Compute SHA-256 hash of a normalized (trimmed, lowercased) comment body.
 # Prefers sha256sum (Linux) with fallback to shasum -a 256 (macOS).

--- a/bin/lib/copilot.sh
+++ b/bin/lib/copilot.sh
@@ -71,36 +71,50 @@ UNRESOLVED_COMMENTS_JQ='
 # jq sub-filter: streams dismissed_comments entries normalized to objects. The
 # review loop writes {"body_hash", "body_preview", "round"}; older skill runs
 # appended bare hash strings, and state files with that shape exist on every
-# machine indefinitely, so every reader must accept either. Exposed as a
-# constant so the unit test exercises the exact same program.
-DISMISSED_OBJECTS_JQ='.dismissed_comments[]? | if type == "object" then . else {body_hash: .} end'
+# machine indefinitely, so every reader must accept either. Entries without a
+# body_hash are dropped rather than surfaced as empty strings, which would be
+# fatal bad array subscripts in the consumers' associative arrays. Exposed as
+# a constant so the unit test exercises the exact same program.
+DISMISSED_OBJECTS_JQ='.dismissed_comments[]? | if type == "object" then . else {body_hash: .} end | select((.body_hash // "") != "")'
 
 # Full program copilot-review-loop.sh uses to build its dedup table: one
 # "hash<TAB>round" line per entry. Entries without a round (skill-recorded
 # dismissals) get "?", matching the loop's unknown-round display fallback.
-# Entries without a body_hash are dropped rather than emitted as empty keys,
-# which would be a fatal bad array subscript in the loop's associative array.
 # shellcheck disable=SC2034  # consumed by copilot-review-loop.sh
-DISMISSED_HASH_ROUNDS_JQ="${DISMISSED_OBJECTS_JQ}"' | select((.body_hash // "") != "") | [.body_hash, ((.round // "?") | tostring)] | @tsv'
+DISMISSED_HASH_ROUNDS_JQ="${DISMISSED_OBJECTS_JQ}"' | [.body_hash, ((.round // "?") | tostring)] | @tsv'
+
+# Directory holding the shared review-loop state (dismissed-comment files,
+# reply drafts, round logs). Single source of the path; copilot-review-loop.sh
+# derives its STATE_DIR from it.
+dismissed_state_dir() {
+  echo "${HOME}/.local/state/copilot-review-loop"
+}
 
 # Path of the shared state file recording a PR's dismissed review comments.
 # Usage: dismissed_state_file <owner/repo> <pr_number>
 dismissed_state_file() {
   local slug="$1" pr="$2"
-  echo "${HOME}/.local/state/copilot-review-loop/${slug%%/*}-${slug##*/}-${pr}.json"
+  echo "$(dismissed_state_dir)/${slug%%/*}-${slug##*/}-${pr}.json"
 }
 
-# Emit the state document at $1, or the empty default when the file doesn't
-# exist. Fails when the file exists but is not a JSON object: proceeding with
-# an empty dedup set would resurface every previously dismissed comment.
+# Emit the state document at $1, defaulting when the file is missing or empty.
+# Fails when the file holds anything other than a JSON object whose
+# dismissed_comments (if present) is an array: proceeding with an empty dedup
+# set would resurface every previously dismissed comment.
 read_state_file() {
   local file="$1" doc
+  local default='{"dismissed_comments":[],"rounds":[]}'
   if [[ ! -f "$file" ]]; then
-    echo '{"dismissed_comments":[],"rounds":[]}'
+    echo "$default"
     return 0
   fi
   doc=$(cat "$file")
-  if ! echo "$doc" | jq -e 'type == "object"' >/dev/null 2>&1; then
+  if [[ -z "${doc//[[:space:]]/}" ]]; then
+    echo "$default"
+    return 0
+  fi
+  if ! echo "$doc" | jq -e \
+    '(type == "object") and ((.dismissed_comments // []) | type == "array")' >/dev/null 2>&1; then
     echo "Error: cannot parse state file: ${file}" >&2
     echo "Fix or delete it, then re-run." >&2
     return 1

--- a/bin/lib/test-dismissed-replies.sh
+++ b/bin/lib/test-dismissed-replies.sh
@@ -138,6 +138,11 @@ assert "index records the reply for comment 2" test "$entry2_reply" = "$HUMAN_RE
 state_dismissed=$(echo "$STATE" | jq '.dismissed_comments | length')
 assert "all dismissed comments recorded in state" test "$state_dismissed" -eq 4
 
+# Each entry must be an object with a body_hash key — the canonical shape both
+# readers dedup on.
+object_entries=$(echo "$STATE" | jq '[.dismissed_comments[] | select(type == "object" and has("body_hash"))] | length')
+assert "every dismissed entry is an object with body_hash" test "$object_entries" -eq 4
+
 # ── Scenario: a Copilot comment with an empty reply is left unresolved ──────
 # Resolution requires a posted reply. An empty draft means nothing to say, so we
 # skip the post AND leave the thread open rather than closing it silently.

--- a/bin/lib/test-dismissed-state.sh
+++ b/bin/lib/test-dismissed-state.sh
@@ -65,6 +65,11 @@ out=$(read_state_file "$TESTTMP/does-not-exist.json")
 assert "read_state_file defaults when the file is missing" \
   test "$out" = '{"dismissed_comments":[],"rounds":[]}'
 
+printf '  \n ' > "$TESTTMP/blank.json"
+out=$(read_state_file "$TESTTMP/blank.json")
+assert "read_state_file defaults when the file is empty" \
+  test "$out" = '{"dismissed_comments":[],"rounds":[]}'
+
 printf '{bad' > "$TESTTMP/corrupt.json"
 rc=0; read_state_file "$TESTTMP/corrupt.json" >/dev/null 2>&1 || rc=$?
 assert "read_state_file fails on unparseable input" test "$rc" -ne 0
@@ -72,6 +77,10 @@ assert "read_state_file fails on unparseable input" test "$rc" -ne 0
 printf '[]' > "$TESTTMP/array.json"
 rc=0; read_state_file "$TESTTMP/array.json" >/dev/null 2>&1 || rc=$?
 assert "read_state_file rejects non-object documents" test "$rc" -ne 0
+
+printf '%s' '{"dismissed_comments":"h1"}' > "$TESTTMP/string-field.json"
+rc=0; read_state_file "$TESTTMP/string-field.json" >/dev/null 2>&1 || rc=$?
+assert "read_state_file rejects a non-array dismissed_comments" test "$rc" -ne 0
 
 # ── record-dismissed-comment.sh ──────────────────────────────────────────────
 
@@ -136,6 +145,14 @@ printf '{bad' > "$corrupt_file"
 rc=0; printf '%s' "some body" | record 126 || rc=$?
 assert "record: corrupt state file rejected" test "$rc" -ne 0
 assert "record: corrupt file left unchanged" test "$(cat "$corrupt_file")" = "{bad"
+
+# A body far beyond the pipe buffer must not SIGPIPE the preview computation.
+huge_file="$record_state_dir/acme-widgets-127.json"
+rc=0; head -c 200000 /dev/zero | tr '\0' 'x' | record 127 || rc=$?
+assert "record: 200KB body exits 0" test "$rc" -eq 0
+assert "record: 200KB body recorded" test "$(jq '.dismissed_comments | length' "$huge_file")" -eq 1
+assert "record: 200KB body preview capped at 80 bytes" \
+  test "$(jq -r '.dismissed_comments[0].body_preview | length' "$huge_file")" -eq 80
 
 # ── fetch-unaddressed-comments.sh end-to-end ─────────────────────────────────
 

--- a/bin/lib/test-dismissed-state.sh
+++ b/bin/lib/test-dismissed-state.sh
@@ -1,0 +1,216 @@
+#!/bin/bash
+# Tests for the dismissed_comments state plumbing shared by copilot-review-loop.sh
+# and the address-pr-reviews skill: the normalizing jq constants in copilot.sh,
+# the record-dismissed-comment.sh writer, and fetch-unaddressed-comments.sh's
+# filtering against state files in either entry shape (objects from the loop,
+# legacy bare hash strings from older skill runs).
+#
+# Usage: test-dismissed-state.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# shellcheck source=bin/lib/test-helpers.sh
+source "$SCRIPT_DIR/test-helpers.sh"
+# shellcheck source=bin/lib/copilot.sh
+source "$SCRIPT_DIR/copilot.sh"
+
+RECORD="$REPO_ROOT/ai/skills/address-pr-reviews/scripts/record-dismissed-comment.sh"
+FETCH="$REPO_ROOT/ai/skills/address-pr-reviews/scripts/fetch-unaddressed-comments.sh"
+
+# All temp artifacts live under one dir so a single trap cleans them up.
+TESTTMP="$(mktemp -d)"
+trap 'rm -rf "$TESTTMP"' EXIT
+
+# ── The normalizing constants ────────────────────────────────────────────────
+
+# Apply the production programs to a JSON document on stdin.
+hashes() { jq -r "$DISMISSED_OBJECTS_JQ"' | .body_hash'; }
+hash_rounds() { jq -r "$DISMISSED_HASH_ROUNDS_JQ"; }
+
+out=$(printf '%s' '{"dismissed_comments":[{"body_hash":"h1","round":1},{"body_hash":"h2","body_preview":"p","round":2}]}' | hashes)
+assert "object entries yield their hashes" test "$out" = "$(printf 'h1\nh2')"
+
+out=$(printf '%s' '{"dismissed_comments":["h1","h2"]}' | hashes)
+assert "bare-string entries normalize to hashes" test "$out" = "$(printf 'h1\nh2')"
+
+out=$(printf '%s' '{"dismissed_comments":["h1",{"body_hash":"h2","round":3}]}' | hashes)
+assert "mixed entries all normalize" test "$out" = "$(printf 'h1\nh2')"
+
+rc=0; out=$(printf '%s' '{"dismissed_comments":[]}' | hashes) || rc=$?
+assert "empty array exits 0" test "$rc" -eq 0
+assert "empty array emits nothing" test -z "$out"
+
+rc=0; out=$(printf '%s' '{"rounds":[]}' | hashes) || rc=$?
+assert "missing key exits 0" test "$rc" -eq 0
+assert "missing key emits nothing" test -z "$out"
+
+rc=0; out=$(printf '%s' '{"dismissed_comments":null}' | hashes) || rc=$?
+assert "null value exits 0" test "$rc" -eq 0
+assert "null value emits nothing" test -z "$out"
+
+out=$(printf '%s' '{"dismissed_comments":["bare1",{"body_hash":"h2","round":2},{"body_hash":"h3","round":0},{"round":9}]}' | hash_rounds)
+expected=$(printf 'bare1\t?\nh2\t2\nh3\t0')
+assert "TSV: bare entry gets round ?, round 0 stays 0, hashless entry dropped" \
+  test "$out" = "$expected"
+
+# ── dismissed_state_file / read_state_file ───────────────────────────────────
+
+assert "state path derives owner-repo-pr under HOME" \
+  test "$(HOME="$TESTTMP" dismissed_state_file acme/widgets 123)" = "$TESTTMP/.local/state/copilot-review-loop/acme-widgets-123.json"
+
+out=$(read_state_file "$TESTTMP/does-not-exist.json")
+assert "read_state_file defaults when the file is missing" \
+  test "$out" = '{"dismissed_comments":[],"rounds":[]}'
+
+printf '{bad' > "$TESTTMP/corrupt.json"
+rc=0; read_state_file "$TESTTMP/corrupt.json" >/dev/null 2>&1 || rc=$?
+assert "read_state_file fails on unparseable input" test "$rc" -ne 0
+
+printf '[]' > "$TESTTMP/array.json"
+rc=0; read_state_file "$TESTTMP/array.json" >/dev/null 2>&1 || rc=$?
+assert "read_state_file rejects non-object documents" test "$rc" -ne 0
+
+# ── record-dismissed-comment.sh ──────────────────────────────────────────────
+
+RECORD_HOME="$TESTTMP/record-home"
+mkdir -p "$RECORD_HOME"
+record_state_dir="$RECORD_HOME/.local/state/copilot-review-loop"
+
+record() {  # $1 = pr number; body on stdin
+  env HOME="$RECORD_HOME" DOTFILES_DIR="$REPO_ROOT" "$RECORD" acme/widgets "$1" >/dev/null 2>&1
+}
+
+long_body='This body has "quotes" and embedded detail long enough to exceed the eighty byte preview boundary for sure.'
+state_file="$record_state_dir/acme-widgets-123.json"
+
+rc=0; printf '%s' "$long_body" | record 123 || rc=$?
+assert "record: first run exits 0" test "$rc" -eq 0
+assert "record: creates the state file" test -f "$state_file"
+assert "record: one entry recorded" test "$(jq '.dismissed_comments | length' "$state_file")" -eq 1
+assert "record: body_hash matches hash_comment" \
+  test "$(jq -r '.dismissed_comments[0].body_hash' "$state_file")" = "$(hash_comment "$long_body")"
+assert "record: body_preview is the first 80 bytes" \
+  test "$(jq -r '.dismissed_comments[0].body_preview' "$state_file")" = "$(printf '%s' "$long_body" | head -c 80)"
+assert "record: entry has no round key" \
+  test "$(jq '.dismissed_comments[0] | has("round")' "$state_file")" = "false"
+
+rc=0; printf '%s' "$long_body" | record 123 || rc=$?
+assert "record: re-run exits 0" test "$rc" -eq 0
+assert "record: re-run appends nothing" test "$(jq '.dismissed_comments | length' "$state_file")" -eq 1
+
+# A hash already present as a legacy bare string is recognized: no duplicate,
+# and the legacy entry survives as a bare string (value-level; jq re-serializes).
+legacy_file="$record_state_dir/acme-widgets-124.json"
+legacy_body="a legacy comment"
+printf '%s' "{\"dismissed_comments\":[\"$(hash_comment "$legacy_body")\"],\"rounds\":[{\"round\":1}]}" > "$legacy_file"
+
+rc=0; printf '%s' "$legacy_body" | record 124 || rc=$?
+assert "record: legacy bare-string hash is a no-op" test "$rc" -eq 0
+assert "record: no duplicate next to the legacy entry" test "$(jq '.dismissed_comments | length' "$legacy_file")" -eq 1
+assert "record: legacy entry survives as a bare string" \
+  test "$(jq -r '.dismissed_comments[0] | type' "$legacy_file")" = "string"
+
+rc=0; printf '%s' "a brand new comment" | record 124 || rc=$?
+assert "record: append alongside legacy exits 0" test "$rc" -eq 0
+assert "record: new object appended after legacy entry" test "$(jq '.dismissed_comments | length' "$legacy_file")" -eq 2
+assert "record: legacy entry still a bare string after append" \
+  test "$(jq -r '.dismissed_comments[0] | type' "$legacy_file")" = "string"
+assert "record: appended entry carries the new hash" \
+  test "$(jq -r '.dismissed_comments[1].body_hash' "$legacy_file")" = "$(hash_comment "a brand new comment")"
+assert "record: rounds key preserved" test "$(jq '.rounds | length' "$legacy_file")" -eq 1
+
+missing_file="$record_state_dir/acme-widgets-125.json"
+rc=0; printf '' | record 125 || rc=$?
+assert "record: empty stdin rejected" test "$rc" -ne 0
+assert_not "record: empty stdin creates no file" test -f "$missing_file"
+
+rc=0; printf '  \n\t ' | record 125 || rc=$?
+assert "record: whitespace-only stdin rejected" test "$rc" -ne 0
+assert_not "record: whitespace stdin creates no file" test -f "$missing_file"
+
+corrupt_file="$record_state_dir/acme-widgets-126.json"
+printf '{bad' > "$corrupt_file"
+rc=0; printf '%s' "some body" | record 126 || rc=$?
+assert "record: corrupt state file rejected" test "$rc" -ne 0
+assert "record: corrupt file left unchanged" test "$(cat "$corrupt_file")" = "{bad"
+
+# ── fetch-unaddressed-comments.sh end-to-end ─────────────────────────────────
+
+# gh shim: ignores its arguments and prints the canned GraphQL response, so the
+# fetch script (executed, not sourced) resolves it via PATH with no network.
+mkdir -p "$TESTTMP/bin"
+cat > "$TESTTMP/bin/gh" <<'SHIM'
+#!/bin/bash
+cat "$GH_FIXTURE"
+SHIM
+chmod +x "$TESTTMP/bin/gh"
+
+body_dismissed="dismissed one"
+body_fresh="fresh one"
+dismissed_hash=$(hash_comment "$body_dismissed")
+fresh_hash=$(hash_comment "$body_fresh")
+
+fixture="$TESTTMP/gh-fixture.json"
+cat > "$fixture" <<JSON
+{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[
+  {"isResolved": false, "comments": {"nodes": [
+    {"databaseId": 101, "path": "src/a.py", "line": 10, "body": "$body_dismissed", "diffHunk": "@@", "author": {"login": "Copilot", "__typename": "Bot"}}
+  ]}},
+  {"isResolved": false, "comments": {"nodes": [
+    {"databaseId": 102, "path": "src/b.py", "line": 20, "body": "$body_fresh", "diffHunk": "@@", "author": {"login": "octocat", "__typename": "User"}}
+  ]}}
+],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}
+JSON
+
+run_fetch() {  # $1 = fake home dir
+  run_bounded 10 env HOME="$1" DOTFILES_DIR="$REPO_ROOT" \
+    PATH="$TESTTMP/bin:$PATH" GH_FIXTURE="$fixture" "$FETCH" acme/widgets 123
+}
+
+seed_state() {  # $1 = fake home dir, $2 = state file JSON
+  mkdir -p "$1/.local/state/copilot-review-loop"
+  printf '%s' "$2" > "$1/.local/state/copilot-review-loop/acme-widgets-123.json"
+}
+
+# The reported regression: a hash recorded as a bare string must still filter
+# out its comment.
+home_bare="$TESTTMP/fetch-bare"
+seed_state "$home_bare" "{\"dismissed_comments\":[\"$dismissed_hash\"],\"rounds\":[]}"
+rc=0; out=$(run_fetch "$home_bare") || rc=$?
+assert "fetch: bare-string state exits 0" test "$rc" -eq 0
+assert "fetch: bare-string hash filters its comment" test "$(echo "$out" | jq 'length')" -eq 1
+assert "fetch: survivor is the fresh comment" test "$(echo "$out" | jq -r '.[0].body')" = "$body_fresh"
+
+home_obj="$TESTTMP/fetch-obj"
+seed_state "$home_obj" "{\"dismissed_comments\":[{\"body_hash\":\"$dismissed_hash\",\"round\":1}],\"rounds\":[]}"
+rc=0; out=$(run_fetch "$home_obj") || rc=$?
+assert "fetch: object state exits 0" test "$rc" -eq 0
+assert "fetch: object hash filters its comment" test "$(echo "$out" | jq 'length')" -eq 1
+assert "fetch: object-state survivor is the fresh comment" test "$(echo "$out" | jq -r '.[0].body')" = "$body_fresh"
+
+home_mixed="$TESTTMP/fetch-mixed"
+seed_state "$home_mixed" "{\"dismissed_comments\":[\"$dismissed_hash\",{\"body_hash\":\"$fresh_hash\",\"round\":2}],\"rounds\":[]}"
+rc=0; out=$(run_fetch "$home_mixed") || rc=$?
+assert "fetch: mixed state exits 0" test "$rc" -eq 0
+assert "fetch: mixed state filters both comments" test "$(echo "$out" | jq 'length')" -eq 0
+
+home_none="$TESTTMP/fetch-none"
+mkdir -p "$home_none"
+rc=0; out=$(run_fetch "$home_none") || rc=$?
+assert "fetch: missing state file exits 0" test "$rc" -eq 0
+assert "fetch: missing state file passes everything through" test "$(echo "$out" | jq 'length')" -eq 2
+
+# A state file that exists but cannot be parsed must fail the run rather than
+# silently resurfacing every previously-dismissed comment.
+home_corrupt="$TESTTMP/fetch-corrupt"
+seed_state "$home_corrupt" '{bad'
+rc=0; out=$(run_fetch "$home_corrupt") || rc=$?
+assert "fetch: corrupt state file fails" test "$rc" -ne 0
+assert "fetch: corrupt state is a failure, not a hang" test "$rc" -ne 124
+
+# ── Results ─────────────────────────────────────────────────────────────────
+
+print_results


### PR DESCRIPTION
- The address-pr-reviews skill's SKILL.md told the model to "append to the `dismissed_comments` array" without specifying the entry shape, so most state files got bare hash strings while both readers expected `{"body_hash": ...}` objects. jq fails on those entries ("Cannot index string"), both readers swallowed the failure, and the dedup set came up empty, so previously dismissed comments resurfaced on later runs. 58 of 130 state files on my machine have the bare-string shape, including one written this week.
- Both readers now normalize either shape through shared jq constants in `bin/lib/copilot.sh`, and new `dismissed_state_file`/`read_state_file` helpers keep the path scheme, empty default, and corrupt-file check in one place. A state file that exists but won't parse now fails the run loudly instead of silently returning every comment.
- The skill's write path is now deterministic: a new `record-dismissed-comment.sh` hashes the body from stdin and idempotently appends the canonical object shape, and SKILL.md Step 5 invokes it instead of describing the hash algorithm in prose. `save_state` in the review loop now writes through `atomic_write`, keeping the temp file on the state dir's filesystem.

## Test plan

- `bash bin/lib/test-dismissed-state.sh` (new, 48 assertions): the jq constants over object/bare/mixed/empty inputs, the state helpers, the record script (creation, hash parity with `hash_comment`, idempotency, legacy-entry preservation, empty and corrupt input), and the fetch script end to end with a stubbed `gh`, including the exact bare-string regression.
- `bash bin/lib/test-dismissed-replies.sh` (now asserts entry shape) and `bash bin/lib/test-unresolved-comments.sh` still pass.
- Verified the pre-fix fetch script reproduces the bug against the same fixture (returns 2 comments where the fixed one returns 1), and ran the fixed script against a real PR state file holding bare-string hashes: all three previously dismissed comments were filtered out.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
