### PR TITLE
Add ops MCP server and fix stale grafana entries

### DIFF
--- a/ai/install.sh
+++ b/ai/install.sh
@@ -261,11 +261,21 @@ if [ "$INSTALL_SKILLS" = "true" ]; then
     success "Cleaned up migrated command symlinks"
 fi
 
+# The Grafana wrapper lives in the PostHog checkout, so Grafana installs are
+# skipped on machines without it. GRAFANA_MCP_PATH is needed because the wrapper
+# shells out to mcp-grafana on the Go path, which the server does not inherit.
+GRAFANA_MCP_WRAPPER="$HOME/dev/posthog/posthog/tools/infra-scripts/mcp/mcp-grafana-wrapper.sh"
+GRAFANA_MCP_PATH="/usr/local/bin:/usr/bin:/bin:$HOME/go/bin"
+
 # Define MCP servers as a list of entries
-# Format: "name|description|command"
+# Format: "name|transport|description|target"
+# The target is a command line for stdio servers and a URL for http servers.
 MCP_SERVERS="
-posthog-db|PostHog database connection|/Users/haacked/.local/bin/postgres-mcp --access-mode=restricted
-grafana|Grafana MCP server|/Users/haacked/.dotfiles/bin/mcp-grafana-wrapper.sh
+posthog-db|stdio|PostHog database connection|$HOME/.local/bin/postgres-mcp --access-mode=restricted
+grafana|stdio|Grafana MCP server (US)|$GRAFANA_MCP_WRAPPER
+grafana-eu|stdio|Grafana MCP server (EU)|$GRAFANA_MCP_WRAPPER
+grafana-dev|stdio|Grafana MCP server (dev)|$GRAFANA_MCP_WRAPPER
+ops|http|PostHog Ops MCP server|https://ops.posthog.dev/api/mcp
 "
 
 # Special environment variables for specific servers
@@ -275,9 +285,27 @@ set_server_env() {
         posthog-db)
             echo "-e DATABASE_URI=postgresql://posthog:posthog@localhost:5432/posthog"
             ;;
+        grafana)
+            echo "-e PATH=$GRAFANA_MCP_PATH -e GRAFANA_REGION=us"
+            ;;
+        grafana-eu)
+            echo "-e PATH=$GRAFANA_MCP_PATH -e GRAFANA_REGION=eu"
+            ;;
+        grafana-dev)
+            echo "-e PATH=$GRAFANA_MCP_PATH -e GRAFANA_REGION=dev"
+            ;;
         *)
             echo ""
             ;;
+    esac
+}
+
+# `claude mcp add` accepts a command that does not exist, which is how a stale
+# path sits in the list unnoticed. Verify the executable first.
+stdio_command_available() {
+    case "$1" in
+        /*) [ -x "$1" ] ;;
+        *) command -v "$1" >/dev/null 2>&1 ;;
     esac
 }
 
@@ -285,32 +313,37 @@ set_server_env() {
 if [ "$INSTALL_MCP" = "true" ]; then
     info "Installing MCP servers…"
 
+    # `claude mcp list` health-checks every configured server, so read it once
+    # rather than once per entry.
+    installed_servers=$(claude mcp list 2>/dev/null)
+
     # Process each server definition
-    echo "$MCP_SERVERS" | grep -v "^$" | while IFS='|' read -r name description command; do
+    echo "$MCP_SERVERS" | grep -v "^$" | while IFS='|' read -r name transport description target; do
         # Skip empty lines
         [ -z "$name" ] && continue
 
-        # Check if server already exists
-        if ! claude mcp list 2>/dev/null | grep -q "^${name}:"; then
-            info "Installing ${description}…"
-
-            # Get any special environment variables
-            env_args=$(set_server_env "$name")
-
-            # Build and execute the command
-            if [ -n "$env_args" ]; then
-                eval "claude mcp add --scope user ${name} ${env_args} -- ${command}"
-            else
-                claude mcp add --scope user ${name} -- ${command}
-            fi
-
-            if [ $? -eq 0 ]; then
-                success "${description} installed"
-            else
-                error "${description} failed to install"
-            fi
-        else
+        if echo "$installed_servers" | grep -q "^${name}:"; then
             success "${description} already installed"
+            continue
+        fi
+
+        if [ "$transport" = "stdio" ] && ! stdio_command_available "${target%% *}"; then
+            warning "${description} skipped: ${target%% *} not found"
+            continue
+        fi
+
+        info "Installing ${description}…"
+
+        if [ "$transport" = "http" ]; then
+            claude mcp add --scope user --transport http "$name" "$target"
+        else
+            eval "claude mcp add --scope user ${name} $(set_server_env "$name") -- ${target}"
+        fi
+
+        if [ $? -eq 0 ]; then
+            success "${description} installed"
+        else
+            error "${description} failed to install"
         fi
     done
 fi

--- a/ai/install.sh
+++ b/ai/install.sh
@@ -337,7 +337,11 @@ if [ "$INSTALL_MCP" = "true" ]; then
         if [ "$transport" = "http" ]; then
             claude mcp add --scope user --transport http "$name" "$target"
         else
-            eval "claude mcp add --scope user ${name} $(set_server_env "$name") -- ${target}"
+            # The env args and the target are left unquoted on purpose: field
+            # splitting turns them into separate arguments. IFS is back to the
+            # default here, since the assignment applies only to `read`.
+            # shellcheck disable=SC2086
+            claude mcp add --scope user "$name" $(set_server_env "$name") -- $target
         fi
 
         if [ $? -eq 0 ]; then


### PR DESCRIPTION
`ai/install.sh` could only install stdio MCP servers, and its grafana entry pointed at `.dotfiles/bin/mcp-grafana-wrapper.sh`, a path that does not exist. That entry has been installing nothing.

`MCP_SERVERS` entries are now `name|transport|description|target`, where the target is a command line for stdio servers and a URL for http servers. The http branch calls `claude mcp add --scope user --transport http`.

- Adds `ops` at `https://ops.posthog.dev/api/mcp` over http.
- Replaces the dead grafana entry with the three servers that exist (`grafana`, `grafana-eu`, `grafana-dev`), all running the wrapper in the PostHog checkout and selected by `GRAFANA_REGION`. Installing grafana now depends on that checkout being present, and the script warns and skips instead of adding a broken server when it is missing.
- Skips a stdio server with a warning when its command is not executable. `claude mcp add` accepts a nonexistent path without complaint, which is how the stale path went unnoticed.
- Reads `claude mcp list` once instead of once per entry. That command health-checks every configured server on each call, including every claude.ai connector.

## Test plan

Ran `./ai/install.sh --mcp-only` to exercise both transports.

- [ ] http path: `ops` lands in user scope in `~/.claude.json` as `{"type": "http", "url": "https://ops.posthog.dev/api/mcp"}`.
- [ ] stdio path with env vars: remove `grafana-dev` from user scope, rerun, and confirm the recreated entry matches the original exactly, including `GRAFANA_REGION=dev` and the `PATH` carrying `~/go/bin`.
- [ ] Already-installed detection reports correctly for all five servers. The `:` in the grep anchor keeps `grafana` from matching `grafana-eu`.
- [ ] `sh -n ai/install.sh` passes and shellcheck reports no new findings.

https://claude.ai/code/session_01WQvNFKJ43bjmGv8rh1LTFP