### PR TITLE
Resolve skill base branches stack-aware via git-pr-base.sh

### DIFF
--- a/ai/skills/create-pr/SKILL.md
+++ b/ai/skills/create-pr/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: create-pr
 description: Create or update a GitHub PR with automatic template detection and filling, enforcing a plain staff-engineer writing voice in the PR body
-argument-hint: "[--ready] [--force] [<title>]"
+argument-hint: "[--ready] [--force] [--parent <ref>] [<title>]"
 model: sonnet
 ---
 
@@ -31,6 +31,7 @@ How it sounds (cause and effect in one sentence, caveats as plain declarative se
 
 - `--ready`: create the PR ready for review instead of as a draft (PRs are drafts by default)
 - `--force`: skip preview and confirmation; create or update immediately
+- `--parent <ref>`: target the PR at this base instead of auto-detecting
 - `<title>`: optional title hint; if omitted, derive from commits
 
 Example invocations:
@@ -38,6 +39,7 @@ Example invocations:
 - `/create-pr`
 - `/create-pr --ready`
 - `/create-pr --force`
+- `/create-pr --parent origin/parent-branch`
 - `/create-pr Add support for webhook retries`
 - `/create-pr --ready Fix race condition in job queue`
 - `/create-pr --force --ready Fix race condition in job queue`
@@ -50,63 +52,35 @@ Extract from user input:
 
 - `draft` = true unless `--ready` is present (PRs are drafts by default)
 - `force` = true if `--force` is present
-- `title_hint` = remaining text after stripping `--ready` and `--force`, or empty string
+- `parent` = ref after `--parent`, or empty
+- `title_hint` = remaining text after stripping `--ready`, `--force`, and `--parent <ref>`, or empty string
 
 ### 2. Gather Git Context
 
 Determine the base branch and gather context. The base is normally the repo's default branch, but for stacked PRs (e.g. created with `gt`) it's the parent branch in the stack.
 
 ```bash
-head=$(git rev-parse --abbrev-ref HEAD)                                # current branch
-default_branch=$(bash "$HOME/.dotfiles/bin/lib/git-default-branch.sh") # default branch (bare name)
+eval "$(bash "$HOME/.dotfiles/bin/lib/git-pr-base.sh")"     # append --parent <ref> if the user passed one
+base="$BASE"                 # bare branch name: gh pr create --base and git ls-remote need this form
+stacked=$([ "$base" != "$DEFAULT" ] && echo true || echo false)
 ```
 
-If the helper is not available or `default_branch` is empty, tell the user and **stop**.
+The helper resolves the stack-aware base, an existing open PR's base foremost (never silently retarget a PR someone already opened); the precedence and full key contract are documented in its header. This skill consumes `BASE` (bare name), `REF` (the diffable, origin-preferred form — use it for every log/diff below), `PR` (the open PR's number, if any), `DEFAULT`, and `NOTES` (non-empty when detection degraded). If the helper is not available or `base` is empty, tell the user and **stop**. If `NOTES` reports the PR's base has no local ref, it names the exact `git fetch` command — run it, then re-run the helper.
 
-Pick the base in this precedence:
+Then run in parallel:
 
 ```bash
-# 1. If a PR already exists for this head, honor its base. Never silently
-#    retarget it. Use `gh pr list --head` (queries the API by branch name)
-#    rather than `gh pr view`, which depends on local upstream tracking and
-#    can miss PRs in worktrees or after re-clones.
-existing_pr=$(gh pr list --head "$head" --state open --json number,baseRefName --jq '.[0]' 2>/dev/null || true)
-existing_base=$(printf '%s' "$existing_pr" | jq -r '.baseRefName // empty' 2>/dev/null || true)
-
-# 2. Ask gt for the parent (current gt stores stack metadata in
-#    .git/.graphite_cache_persist, not in git config). Gate on `command -v gt`
-#    so the skill works for users without gt installed.
-gt_parent=""
-if command -v gt >/dev/null 2>&1; then
-  gt_parent=$(gt parent 2>/dev/null || true)
-fi
-
-if [ -n "$existing_base" ]; then
-  base="$existing_base"
-  stacked=$([ "$base" != "$default_branch" ] && echo true || echo false)
-elif [ -n "$gt_parent" ] && [ "$gt_parent" != "$default_branch" ]; then
-  base="$gt_parent"
-  stacked=true
-else
-  base="$default_branch"
-  stacked=false
-fi
+git log "$REF"..HEAD --oneline                                                # commits on this branch
+git diff "$REF"...HEAD --stat                                                 # changed-file summary
+if [ -n "$PR" ]; then gh pr view "$PR" --json number,title,isDraft,url; fi    # existing PR's display fields
 ```
 
-Then, using `$base`, run in parallel:
-
-```bash
-git log origin/$base..HEAD --oneline                                                    # commits on this branch
-git diff origin/$base...HEAD --stat                                                     # changed-file summary
-gh pr list --head "$head" --state open --json number,title,isDraft,url --jq '.[0]'     # existing PR, if any
-```
-
-If a PR already exists, note its number and URL: you will **update** it rather than create a new one (see Step 9). Use `gh pr list --head` rather than `gh pr view`: it queries by branch name (reliable in worktrees and after re-clones) instead of relying on local upstream tracking.
+The helper already determined whether an open PR exists: a non-empty `PR` means you will **update** that PR rather than create a new one (see Step 9). `PR` can be empty-but-wrong in exactly two cases — you passed `--parent` (the override skips the PR lookup) or `NOTES` says GitHub was unreachable; in those cases check with `gh pr list --head "$(git rev-parse --abbrev-ref HEAD)" --state open --json number,title,isDraft,url --jq '.[0]'`.
 
 When composing the PR body in Step 5, use the `--stat` output to decide how much diff to read:
 
-- If the stat shows fewer than ~200 changed lines total, fetch the full diff with `git diff origin/$base...HEAD`.
-- Otherwise, read per-file diffs only for files that are directly relevant to the PR description: `git diff origin/$base...HEAD -- <path>`. Skip generated files, lock files, and files whose names make their changes obvious (e.g. version bumps in `package.json`).
+- If the stat shows fewer than ~200 changed lines total, fetch the full diff with `git diff "$REF"...HEAD`.
+- Otherwise, read per-file diffs only for files that are directly relevant to the PR description: `git diff "$REF"...HEAD -- <path>`. Skip generated files, lock files, and files whose names make their changes obvious (e.g. version bumps in `package.json`).
 
 ### 3. Find PR Template
 
@@ -255,6 +229,8 @@ gh pr view <number> --json body --jq '.body'
 ```
 
 Note the existing body may already contain a `<details><summary>Manual test plan</summary>…</details>` block; replace it with the new one rather than appending. Treat an existing agent-context section the same way: update its facts in place, preserving any human edits, rather than regenerating or dropping it.
+
+If the user passed `--parent` and the existing PR targets a different base, confirm the retarget with the user, then add `--base "$base"` to the `gh pr edit` call; without an explicit `--parent`, never change an existing PR's base.
 
 ```bash
 gh pr edit <number> \

--- a/ai/skills/create-pr/SKILL.md
+++ b/ai/skills/create-pr/SKILL.md
@@ -53,7 +53,7 @@ Extract from user input:
 - `draft` = true unless `--ready` is present (PRs are drafts by default)
 - `force` = true if `--force` is present
 - `parent` = branch after `--parent`, or empty
-- `title_hint` = remaining text after stripping `--ready`, `--force`, and `--parent <ref>`, or empty string
+- `title_hint` = remaining text after stripping `--ready`, `--force`, and `--parent <branch>`, or empty string
 
 ### 2. Gather Git Context
 

--- a/ai/skills/create-pr/SKILL.md
+++ b/ai/skills/create-pr/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: create-pr
 description: Create or update a GitHub PR with automatic template detection and filling, enforcing a plain staff-engineer writing voice in the PR body
-argument-hint: "[--ready] [--force] [--parent <ref>] [<title>]"
+argument-hint: "[--ready] [--force] [--parent <branch>] [<title>]"
 model: sonnet
 ---
 
@@ -31,7 +31,7 @@ How it sounds (cause and effect in one sentence, caveats as plain declarative se
 
 - `--ready`: create the PR ready for review instead of as a draft (PRs are drafts by default)
 - `--force`: skip preview and confirmation; create or update immediately
-- `--parent <ref>`: target the PR at this base instead of auto-detecting
+- `--parent <branch>`: target the PR at this base instead of auto-detecting; it becomes the PR's base on GitHub, so it must be a branch name (bare or `origin/`-prefixed), not an arbitrary ref
 - `<title>`: optional title hint; if omitted, derive from commits
 
 Example invocations:
@@ -52,7 +52,7 @@ Extract from user input:
 
 - `draft` = true unless `--ready` is present (PRs are drafts by default)
 - `force` = true if `--force` is present
-- `parent` = ref after `--parent`, or empty
+- `parent` = branch after `--parent`, or empty
 - `title_hint` = remaining text after stripping `--ready`, `--force`, and `--parent <ref>`, or empty string
 
 ### 2. Gather Git Context
@@ -60,7 +60,7 @@ Extract from user input:
 Determine the base branch and gather context. The base is normally the repo's default branch, but for stacked PRs (e.g. created with `gt`) it's the parent branch in the stack.
 
 ```bash
-eval "$(bash "$HOME/.dotfiles/bin/lib/git-pr-base.sh")"     # append --parent <ref> if the user passed one
+eval "$(bash "$HOME/.dotfiles/bin/lib/git-pr-base.sh")"     # append --parent <branch> if the user passed one
 base="$BASE"                 # bare branch name: gh pr create --base and git ls-remote need this form
 stacked=$([ "$base" != "$DEFAULT" ] && echo true || echo false)
 ```

--- a/ai/skills/squash/SKILL.md
+++ b/ai/skills/squash/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: squash
 description: Squash each contributor's run of contiguous commits on the current branch into one, preserving authorship. CI snapshot commits (authored by bots) are preserved in place and reported.
-argument-hint: "[<message hint>]"
+argument-hint: "[--parent <ref>] [<message hint>]"
 model: sonnet
 ---
 
@@ -9,12 +9,13 @@ model: sonnet
 
 Squash the current branch's commits while preserving attribution. Each contributor's run of contiguous commits collapses into a single commit authored by that contributor. CI snapshot commits are left untouched.
 
-`message_hint` = any text after `/squash`, or empty string if none was given.
+`message_hint` = any text after `/squash` once a `--parent <ref>` flag (if present) is stripped, or empty string if none was given. `--parent <ref>` overrides base detection: only commits after `<ref>` are squashed.
 
 Example invocations:
 
 - `/squash`
 - `/squash Refactor authentication flow`
+- `/squash --parent origin/haacked/parent-branch`
 
 ## Definitions
 
@@ -39,15 +40,17 @@ If the output is empty, proceed.
 ### 2. Gather Context
 
 ```bash
-BASE_BRANCH=$(bash "$HOME/.dotfiles/bin/lib/git-default-branch.sh")
-MERGE_BASE=$(git merge-base HEAD "origin/$BASE_BRANCH")
+eval "$(bash "$HOME/.dotfiles/bin/lib/git-pr-base.sh")"   # append --parent <ref> if the user passed one
+MERGE_BASE=$(git merge-base HEAD "$REF")
 MY_EMAIL=$(git config user.email)
 git log "$MERGE_BASE"..HEAD --format="%H %ae %s"
 ```
 
-If the helper is not available or `BASE_BRANCH` is empty, tell the user and **stop**.
+If the helper is not available, exits non-zero, or leaves `BASE` or `MERGE_BASE` empty, tell the user and **stop**. The helper resolves the base a PR from this branch targets (precedence documented in its header: an open PR's base first, then recorded stack parents, then the repo default branch), reports its pick on stderr, and exports `NOTES` — non-empty when detection degraded or ignored a recorded parent.
 
 The log output is **newest-first**. Reverse it to get the oldest-first order used by every step below.
+
+**Range safety.** Squashing past the true base rewrites other commits' history, so check two things before touching anything. First, if `NOTES` is non-empty, detection hit a problem (GitHub unreachable, a recorded parent ignored, a stacked base rewritten since this branch was cut): report `NOTES` and **stop and ask the user to confirm the range**. Second, when `BASE` differs from `DEFAULT`, this branch is stacked on another branch: report the base, how it was resolved (`SOURCE`, plus the PR number from `PR` when set), and the full commit list above before changing anything; if the commit list plausibly contains another branch's commits (more commits than this branch should have, or subjects belonging to other work), **stop and ask** as well.
 
 ### 3. Build the Plan
 

--- a/ai/skills/test-plan/SKILL.md
+++ b/ai/skills/test-plan/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: test-plan
 description: Generate a GitHub Flavored Markdown manual test plan checklist that focuses on scenarios not covered by existing unit/integration tests. Use when the user wants to create a test plan for a PR or an implementation plan.
-argument-hint: "[--force] [--save <path>] [--plan <file>]"
+argument-hint: "[--force] [--save <path>] [--plan <file>] [--parent <ref>]"
 model: sonnet
 ---
 
@@ -21,6 +21,7 @@ The plan must focus on **end-to-end scenarios that automated unit and integratio
 - `--force` — skip preview and confirmation; save immediately
 - `--plan <file>` — path to an implementation plan file (skip git analysis, use this file as input)
 - `--save <path>` — custom output path (default: `.context/test-plan.md`)
+- `--parent <ref>` — override base detection; diff against `<ref>` instead of the auto-detected PR base
 
 Example invocations:
 
@@ -28,6 +29,7 @@ Example invocations:
 - `/test-plan --plan ./plans/my-feature.md` — generate from plan file
 - `/test-plan --save /tmp/test-plan.md` — custom save path
 - `/test-plan --force` — skip preview and save immediately
+- `/test-plan --parent origin/parent-branch` — diff against a stacked parent explicitly
 
 ## Steps
 
@@ -36,6 +38,7 @@ Example invocations:
 - `force` = true if `--force` is present
 - `plan_file` = path after `--plan`, or empty (branch mode)
 - `save_path` = path after `--save`, or `.context/test-plan.md`
+- `parent` = ref after `--parent`, or empty
 
 ### 2. Gather Context
 
@@ -44,10 +47,11 @@ Example invocations:
 Determine the base branch:
 
 ```bash
-base="origin/$(bash "$HOME/.dotfiles/bin/lib/git-default-branch.sh")"
+eval "$(bash "$HOME/.dotfiles/bin/lib/git-pr-base.sh")"   # append --parent <ref> if the user passed one
+base="$REF"
 ```
 
-If the helper is not available, tell the user and **stop**.
+If the helper is not available or `base` is empty, tell the user and **stop**. On a stacked branch (`BASE` differs from `DEFAULT`) the helper resolves the parent branch, so the diff below covers only this branch's commits, not the parent PR's. If `NOTES` is non-empty, tell the user what it says before continuing.
 
 Then run in parallel:
 

--- a/ai/skills/test-plan/SKILL.md
+++ b/ai/skills/test-plan/SKILL.md
@@ -57,18 +57,18 @@ Then run in parallel:
 
 ```bash
 git log "$base"..HEAD --oneline
-git diff "$base"..HEAD --stat
+git diff "$base"...HEAD --stat
 ```
 
 If there are no commits ahead of base or the diff is empty, tell the user there are no changes to generate a test plan for and stop.
 
 Check the stat output's total line count:
 
-- **Under ~200 lines changed:** fetch the full diff (`git diff "$base"..HEAD`) and proceed.
+- **Under ~200 lines changed:** fetch the full diff (`git diff "$base"...HEAD`) and proceed.
 - **200 or more lines changed:** fetch a reduced diff, excluding lock files and generated files:
 
   ```bash
-  git diff --unified=2 "$base"..HEAD -- . ':(exclude)*.lock' ':(exclude)*-lock.*' ':(exclude)package-lock.json'
+  git diff --unified=2 "$base"...HEAD -- . ':(exclude)*.lock' ':(exclude)*-lock.*' ':(exclude)package-lock.json'
   ```
 
 - **Reduced diff still exceeds ~4000 lines:** stop and ask the user to narrow scope (e.g., point to a specific subdirectory or file set).

--- a/bin/lib/git-pr-base.sh
+++ b/bin/lib/git-pr-base.sh
@@ -15,9 +15,6 @@
 #   SOURCE    override | pr | graphite | config | default
 #   PR        open PR number when SOURCE=pr, else empty
 #   DEFAULT   repo default branch (bare name)
-#   ANCESTOR  yes when REF's tip is an ancestor of HEAD, else no. Meaningful
-#             for stacked bases; trunk normally advances past the branch
-#             point, so default-based branches usually report no.
 #   NOTES     empty when resolution was clean; otherwise '; '-joined notes on
 #             everything that degraded it (GitHub unreachable, a recorded
 #             parent ignored, a stacked base no longer an ancestor of HEAD).
@@ -230,11 +227,7 @@ get_pr_base() {
   # BASE is always the bare branch name; candidates may arrive origin/-prefixed.
   base="${base#origin/}"
 
-  local ancestor=no
-  if git merge-base --is-ancestor "$ref" HEAD 2>/dev/null; then
-    ancestor=yes
-  fi
-  if [ "$ancestor" = "no" ] && [ "$base" != "$default" ]; then
+  if [ "$base" != "$default" ] && ! git merge-base --is-ancestor "$ref" HEAD 2>/dev/null; then
     _pr_base_note "note: '$ref' is not an ancestor of HEAD; the base may have been rewritten or advanced since this branch was cut (rebase needed?)"
   fi
 
@@ -250,7 +243,6 @@ get_pr_base() {
   printf 'SOURCE=%q\n' "$source"
   printf 'PR=%q\n' "$pr"
   printf 'DEFAULT=%q\n' "$default"
-  printf 'ANCESTOR=%q\n' "$ancestor"
   printf 'NOTES=%q\n' "$notes"
 }
 

--- a/bin/lib/git-pr-base.sh
+++ b/bin/lib/git-pr-base.sh
@@ -150,7 +150,7 @@ get_pr_base() {
     fi
     base="$override"
     source="override"
-    if [ "$ref" != "$default_ref" ] && ! _pr_base_narrows "$ref" "$default_ref"; then
+    if [ "${override#origin/}" != "$default" ] && ! _pr_base_narrows "$ref" "$default_ref"; then
       echo "git-pr-base: note: '$override' does not narrow history beyond '$default'; proceeding as instructed" >&2
     fi
   fi

--- a/bin/lib/git-pr-base.sh
+++ b/bin/lib/git-pr-base.sh
@@ -1,0 +1,260 @@
+#!/usr/bin/env bash
+# git-pr-base.sh - Resolve the base branch a PR from HEAD targets (stack-aware)
+#
+# Source this file to get the resolution function:
+#   source "${SCRIPT_DIR}/lib/git-pr-base.sh"
+#   eval "$(get_pr_base)"
+#
+# Or run directly:
+#   eval "$(path/to/git-pr-base.sh [--parent <ref>])"
+#
+# Prints eval-safe KEY=VALUE assignments on stdout, and nothing on failure, so
+# an eval of the output is a no-op and the caller's empty-var check fires:
+#   BASE      bare base branch name (for `gh pr create --base`, `git ls-remote`)
+#   REF       diffable ref for the base, preferring origin/<BASE>
+#   SOURCE    override | pr | graphite | config | default
+#   PR        open PR number when SOURCE=pr, else empty
+#   DEFAULT   repo default branch (bare name)
+#   ANCESTOR  yes when REF's tip is an ancestor of HEAD, else no. Meaningful
+#             for stacked bases; trunk normally advances past the branch
+#             point, so default-based branches usually report no.
+#   NOTES     empty when resolution was clean; otherwise '; '-joined notes on
+#             everything that degraded it (GitHub unreachable, a recorded
+#             parent ignored, a stacked base no longer an ancestor of HEAD).
+#             History-rewriting callers should treat non-empty NOTES as a
+#             prompt to confirm the range. Notes are mirrored on stderr.
+#
+# Resolution order: --parent override, the open PR's base branch (gh),
+# `gt parent`, `git config branch.<name>.parent`, then the default branch.
+# An open PR's base is what GitHub actually diffs and merges against, so it
+# only has to resolve to a local ref. A gt/config candidate must also strictly
+# narrow `git merge-base HEAD <ref>` beyond the default branch, which rejects
+# rewritten or stale parents; rejected candidates fall through to the next
+# source. An explicit --parent is honored as given but must resolve to a ref.
+#
+# Everything that can touch the network (gh, gt, default-branch detection) is
+# bounded by ${GIT_PR_BASE_TIMEOUT:-5} seconds.
+
+_pr_base_lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=bin/lib/git-default-branch.sh
+source "$_pr_base_lib_dir/git-default-branch.sh"
+# shellcheck source=bin/lib/bounded.sh
+source "$_pr_base_lib_dir/bounded.sh"
+
+_pr_base_ref_exists() {
+  git rev-parse --verify --quiet "$1" >/dev/null 2>&1
+}
+
+# Echoes origin/<name> if that remote-tracking ref exists, else <name> if it
+# resolves (branch, tag, SHA, or an explicit origin/... spelling), else nothing.
+_pr_base_resolve_ref() {
+  if _pr_base_ref_exists "refs/remotes/origin/$1"; then
+    echo "origin/$1"
+  elif _pr_base_ref_exists "$1"; then
+    echo "$1"
+  fi
+}
+
+# Records a degradation note: mirrored to stderr now, accumulated into the
+# caller's `notes` for the NOTES output key.
+_pr_base_note() {
+  echo "git-pr-base: $1" >&2
+  notes="${notes:+$notes; }$1"
+}
+
+# True when <ref> strictly narrows history beyond <default ref>: its
+# merge-base with HEAD must be a strict descendant of the default's. Equal
+# merge-bases mean a rewritten or stale parent; an older one means a parent
+# forked from older trunk, which would widen the range past trunk itself.
+# Treats an undeterminable merge-base as narrowing (nothing to compare).
+_pr_base_narrows() {
+  local ref="$1" default_ref="$2" mb_c="" mb_d=""
+  mb_c=$(git merge-base HEAD "$ref" 2>/dev/null) || mb_c=""
+  mb_d=$(git merge-base HEAD "$default_ref" 2>/dev/null) || mb_d=""
+  if [ -z "$mb_c" ] || [ -z "$mb_d" ]; then
+    return 0
+  fi
+  [ "$mb_c" != "$mb_d" ] && git merge-base --is-ancestor "$mb_d" "$mb_c" 2>/dev/null
+}
+
+# Vets a stack-metadata candidate (gt/config tiers): sets `vet_ref` to the
+# diffable ref and returns 0 on acceptance; records a note and returns 1 on
+# rejection. Candidates may be spelled with an origin/ prefix; comparison and
+# resolution use the bare name. Runs unsubshelled so its notes reach NOTES.
+# Args: $1 = candidate, $2 = current branch, $3 = default name, $4 = default ref
+_pr_base_vet() {
+  local candidate="${1#origin/}" branch="$2" default="$3" default_ref="$4"
+  if [ "$candidate" = "$branch" ]; then
+    _pr_base_note "ignoring recorded parent '$candidate' (it is the current branch)"
+    return 1
+  fi
+  if [ "$candidate" = "$default" ]; then
+    vet_ref="$default_ref"
+    return 0
+  fi
+  vet_ref=$(_pr_base_resolve_ref "$candidate")
+  if [ -z "$vet_ref" ]; then
+    _pr_base_note "ignoring recorded parent '$candidate' (no such ref; try 'git fetch origin $candidate')"
+    return 1
+  fi
+  if ! _pr_base_narrows "$vet_ref" "$default_ref"; then
+    _pr_base_note "ignoring recorded parent '$candidate' (does not narrow history beyond '$default'; rewritten or stale?)"
+    return 1
+  fi
+}
+
+get_pr_base() {
+  local override="" deadline="${GIT_PR_BASE_TIMEOUT:-5}"
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --parent | --parent=*)
+        if [ "$1" = "--parent" ]; then
+          override="${2:-}"
+          shift
+        else
+          override="${1#--parent=}"
+        fi
+        if [ -z "$override" ]; then
+          echo "git-pr-base: --parent requires a value (e.g. --parent main)" >&2
+          return 2
+        fi
+        shift
+        ;;
+      *)
+        echo "git-pr-base: unknown argument '$1'" >&2
+        return 2
+        ;;
+    esac
+  done
+
+  local default="" default_ref="" branch="" base="" ref="" source="" pr="" notes="" vet_ref=""
+  default=$(run_bounded "$deadline" get_default_branch) || default=""
+  [ -z "$default" ] && default="main"
+  default_ref=$(_pr_base_resolve_ref "$default")
+  default_ref="${default_ref:-$default}"
+  branch=$(git symbolic-ref --quiet --short HEAD 2>/dev/null) || branch=""
+
+  # 1. Explicit override: honored as given, preferring the ref exactly as
+  #    spelled (a local branch stays local); falls back to the origin/ form
+  #    only when the spelling doesn't resolve. Report facts, don't
+  #    second-guess the human.
+  if [ -n "$override" ]; then
+    if _pr_base_ref_exists "$override"; then
+      ref="$override"
+    else
+      ref=$(_pr_base_resolve_ref "$override")
+    fi
+    if [ -z "$ref" ]; then
+      echo "git-pr-base: --parent '$override' does not resolve to a ref" >&2
+      return 1
+    fi
+    base="$override"
+    source="override"
+    if [ "$ref" != "$default_ref" ] && ! _pr_base_narrows "$ref" "$default_ref"; then
+      echo "git-pr-base: note: '$override' does not narrow history beyond '$default'; proceeding as instructed" >&2
+    fi
+  fi
+
+  # 2. The open PR's base: what GitHub actually diffs and merges against. It
+  #    auto-retargets when a parent PR merges, and it is the only signal for
+  #    hand-created stacked PRs. `gh pr list --head` queries the API by branch
+  #    name, so it works in worktrees and after re-clones.
+  if [ -z "$base" ] && [ -n "$branch" ] && command -v gh >/dev/null 2>&1; then
+    local pr_line="" pr_rc=0 pr_base=""
+    pr_line=$(run_bounded "$deadline" env GH_PROMPT_DISABLED=1 GH_NO_UPDATE_NOTIFIER=1 \
+      gh pr list --head "$branch" --state open --json number,baseRefName \
+      --jq '.[0] // {} | [(.baseRefName // ""), (.number // "" | tostring)] | @tsv') || pr_rc=$?
+    if [ "$pr_rc" -ne 0 ]; then
+      _pr_base_note "warning: could not check GitHub for an open PR (gh failed or timed out); falling back to local signals"
+    else
+      pr_base="${pr_line%%$'\t'*}"
+      if [ -n "$pr_base" ]; then
+        ref=$(_pr_base_resolve_ref "$pr_base")
+        if [ -z "$ref" ] && [ "$pr_base" = "$default" ]; then
+          ref="$default_ref"
+        fi
+        if [ -n "$ref" ]; then
+          base="$pr_base"
+          source="pr"
+          pr="${pr_line#*$'\t'}"
+        else
+          _pr_base_note "open PR targets '$pr_base' but no local ref matches; run 'git fetch origin $pr_base' and retry"
+        fi
+      fi
+    fi
+  fi
+
+  # 3. gt's recorded parent. Current gt keeps stack metadata in
+  #    .git/.graphite_cache_persist, so `gt parent` on the current checkout is
+  #    the only reliable query. A non-zero exit is gt saying it has no answer;
+  #    a timeout is a degradation worth a note. Output that is not a valid
+  #    branch name (e.g. gt's own setup prose) is discarded.
+  if [ -z "$base" ] && [ -n "$branch" ] && command -v gt >/dev/null 2>&1; then
+    local gt_out="" gt_rc=0 gt_parent=""
+    gt_out=$(run_bounded "$deadline" gt parent) || gt_rc=$?
+    if [ "$gt_rc" -eq 124 ]; then
+      _pr_base_note "warning: 'gt parent' timed out; falling back to local signals"
+    elif [ "$gt_rc" -eq 0 ]; then
+      gt_parent=$(printf '%s' "$gt_out" | tr -d '[:space:]')
+      git check-ref-format --branch "$gt_parent" >/dev/null 2>&1 || gt_parent=""
+    fi
+    if [ -n "$gt_parent" ]; then
+      if _pr_base_vet "$gt_parent" "$branch" "$default" "$default_ref"; then
+        base="$gt_parent"
+        ref="$vet_ref"
+        source="graphite"
+      fi
+    fi
+  fi
+
+  # 4. branch.<name>.parent, written by older gt versions and by hand.
+  if [ -z "$base" ] && [ -n "$branch" ]; then
+    local cfg_parent=""
+    cfg_parent=$(git config --get "branch.$branch.parent" 2>/dev/null) || cfg_parent=""
+    if [ -n "$cfg_parent" ]; then
+      if _pr_base_vet "$cfg_parent" "$branch" "$default" "$default_ref"; then
+        base="$cfg_parent"
+        ref="$vet_ref"
+        source="config"
+      fi
+    fi
+  fi
+
+  # 5. The repo default branch.
+  if [ -z "$base" ]; then
+    base="$default"
+    ref="$default_ref"
+    source="default"
+  fi
+
+  # BASE is always the bare branch name; candidates may arrive origin/-prefixed.
+  base="${base#origin/}"
+
+  local ancestor=no
+  if git merge-base --is-ancestor "$ref" HEAD 2>/dev/null; then
+    ancestor=yes
+  fi
+  if [ "$ancestor" = "no" ] && [ "$base" != "$default" ]; then
+    _pr_base_note "note: '$ref' is not an ancestor of HEAD; the base may have been rewritten or advanced since this branch was cut (rebase needed?)"
+  fi
+
+  if [ "$source" != "default" ]; then
+    local via="$source"
+    [ "$source" = "pr" ] && via="open PR #$pr"
+    [ "$source" = "override" ] && via="--parent"
+    echo "git-pr-base: using '$ref' as the PR base (via $via)" >&2
+  fi
+
+  printf 'BASE=%q\n' "$base"
+  printf 'REF=%q\n' "$ref"
+  printf 'SOURCE=%q\n' "$source"
+  printf 'PR=%q\n' "$pr"
+  printf 'DEFAULT=%q\n' "$default"
+  printf 'ANCESTOR=%q\n' "$ancestor"
+  printf 'NOTES=%q\n' "$notes"
+}
+
+# Run directly if not being sourced
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  get_pr_base "$@"
+fi

--- a/bin/lib/test-git-pr-base.sh
+++ b/bin/lib/test-git-pr-base.sh
@@ -91,12 +91,12 @@ cd "$WORK" || exit 1
 # ── Runners ──────────────────────────────────────────────────────────────────
 
 # Runs the helper bounded, captures stdout, and evals it into fresh
-# BASE/REF/SOURCE/PR/DEFAULT/ANCESTOR/NOTES variables. Returns the helper's
-# exit status (124 if run_bounded had to kill it). Callers pass the full
-# command tail: env assignments first, then `bash "$BIN"` and any arguments.
+# BASE/REF/SOURCE/PR/DEFAULT/NOTES variables. Returns the helper's exit
+# status (124 if run_bounded had to kill it). Callers pass the full command
+# tail: env assignments first, then `bash "$BIN"` and any arguments.
 resolve() {  # resolve [VAR=value ...] bash "$BIN" [--parent <ref>]
   local out rc=0
-  BASE='' REF='' SOURCE='' PR='' DEFAULT='' ANCESTOR='' NOTES=''
+  BASE='' REF='' SOURCE='' PR='' DEFAULT='' NOTES=''
   out=$(run_bounded 10 env PATH="$SHIM_PATH" "$@") || rc=$?
   [ -n "$out" ] && eval "$out"
   return "$rc"
@@ -127,7 +127,6 @@ assert "default fallback: REF prefers the remote-tracking ref" test "$REF" = ori
 assert "default fallback: SOURCE" test "$SOURCE" = default
 assert "default fallback: PR is empty" test -z "$PR"
 assert "default fallback: DEFAULT" test "$DEFAULT" = main
-assert "default fallback: origin/main is an ancestor of HEAD" test "$ANCESTOR" = yes
 assert "default fallback: NOTES is empty" test -z "$NOTES"
 
 # ── Test: the open PR's baseRefName wins (the incident signal) ───────────────
@@ -139,7 +138,6 @@ assert "PR tier: BASE is bare" test "$BASE" = parent
 assert "PR tier: REF is the remote-tracking ref" test "$REF" = origin/parent
 assert "PR tier: PR carries the number" test "$PR" = 42
 assert "PR tier: DEFAULT still reports the default branch" test "$DEFAULT" = main
-assert "PR tier: parent tip is an ancestor of HEAD" test "$ANCESTOR" = yes
 assert "PR tier: NOTES is empty on a clean resolution" test -z "$NOTES"
 
 helper_stderr GH_TSV=$'parent\t42' bash "$BIN"
@@ -191,7 +189,15 @@ assert "gt tier: SOURCE" test "$SOURCE" = graphite
 assert "gt tier: BASE is bare" test "$BASE" = parent
 assert "gt tier: REF is the remote-tracking ref" test "$REF" = origin/parent
 assert "gt tier: PR is empty" test -z "$PR"
-assert "gt tier: parent tip is an ancestor of HEAD" test "$ANCESTOR" = yes
+assert "gt tier: NOTES is empty on a clean resolution" test -z "$NOTES"
+
+# ── Test: gt outranks branch.<name>.parent when both answer ──────────────────
+
+git config branch.child.parent main
+rc=0; resolve GT_PARENT=parent bash "$BIN" || rc=$?
+assert "gt beats config: SOURCE" test "$SOURCE" = graphite
+assert "gt beats config: BASE comes from gt" test "$BASE" = parent
+git config --unset branch.child.parent
 
 # ── Test: gt reporting the branch as its own parent is rejected ──────────────
 
@@ -215,16 +221,9 @@ assert "failing gt stays silent on stderr" test ! -s "$ERR"
 
 # ── Test: gt exiting 0 with non-branch prose is discarded ────────────────────
 
-# Whitespace-stripped setup prose (the real "Graphite has not been
-# initialized, attempting to set up now..." shape) fails check-ref-format and
-# must not reach the vet — no note, no stderr.
-rc=0; resolve GT_PARENT='Graphitehasnotbeeninitialized,attemptingtosetupnow...' bash "$BIN" || rc=$?
-assert "gt prose output exits 0" test "$rc" -eq 0
-assert "gt prose output is discarded" test "$SOURCE" = default
-assert "gt prose output: NOTES is empty" test -z "$NOTES"
-
-# ── Test: gt output that is not a branch name is discarded silently ──────────
-
+# Setup prose (the real "Graphite has not been initialized, attempting to set
+# up now..." shape) is whitespace-collapsed by the helper and then fails
+# check-ref-format — it must not reach the vet: no note, no stderr.
 rc=0; resolve GT_PARENT='Graphite has not been initialized, attempting to set up now... Welcome to Graphite!' bash "$BIN" || rc=$?
 assert "gt prose output exits 0" test "$rc" -eq 0
 assert "gt prose output falls through to default" test "$SOURCE" = default
@@ -236,6 +235,13 @@ rc=0; resolve GIT_PR_BASE_TIMEOUT=1 GT_SLEEP=3 bash "$BIN" || rc=$?
 assert "hung gt exits 0" test "$rc" -eq 0
 assert "hung gt degrades to default" test "$SOURCE" = default
 assert "hung gt: NOTES carries the timeout warning" notes_contain "'gt parent' timed out"
+
+# ── Test: two degradations accumulate in NOTES ────────────────────────────────
+
+rc=0; resolve GH_RC=1 GIT_PR_BASE_TIMEOUT=1 GT_SLEEP=3 bash "$BIN" || rc=$?
+assert "two degradations: exits 0" test "$rc" -eq 0
+assert "two degradations: gh warning present" notes_contain 'could not check GitHub'
+assert "two degradations: gt timeout present" notes_contain "'gt parent' timed out"
 
 # ── Test: git config branch.<name>.parent tier ───────────────────────────────
 
@@ -298,11 +304,11 @@ assert "older-trunk fork: NOTES records the rejection" notes_contain 'does not n
 git config --unset branch.child.parent
 make_shims
 
-# ── Test: parent advanced beyond the fork point → accepted, ANCESTOR=no ──────
+# ── Test: parent advanced beyond the fork point → accepted, with a note ──────
 
 # New commit on the upstream parent (review feedback the child has not rebased
 # onto): tip-ancestry now fails, but the merge-base still strictly narrows, so
-# the candidate must be accepted and the fact reported via ANCESTOR.
+# the candidate must be accepted and the fact reported via NOTES.
 git -C "$UPSTREAM" checkout -q parent
 up_commit p3
 git -C "$UPSTREAM" checkout -q main
@@ -313,7 +319,6 @@ assert "advanced parent exits 0" test "$rc" -eq 0
 assert "advanced parent is still accepted" test "$SOURCE" = graphite
 assert "advanced parent: BASE" test "$BASE" = parent
 assert "advanced parent: REF" test "$REF" = origin/parent
-assert "advanced parent: tip is no longer an ancestor" test "$ANCESTOR" = no
 assert "advanced parent: NOTES flags the non-ancestor base" notes_contain 'not an ancestor'
 
 # ── Test: --parent override ───────────────────────────────────────────────────
@@ -341,6 +346,18 @@ out=$(run_bounded 10 env PATH="$SHIM_PATH" bash "$BIN" --parent nonexistent) || 
 assert "unresolvable override exits 1" test "$rc" -eq 1
 assert "unresolvable override prints nothing" test -z "$out"
 
+# ── Test: bad arguments exit 2 with empty stdout ──────────────────────────────
+
+rc=0
+out=$(run_bounded 10 env PATH="$SHIM_PATH" bash "$BIN" --bogus) || rc=$?
+assert "unknown argument exits 2" test "$rc" -eq 2
+assert "unknown argument prints nothing" test -z "$out"
+
+rc=0
+out=$(run_bounded 10 env PATH="$SHIM_PATH" bash "$BIN" --parent) || rc=$?
+assert "valueless --parent exits 2" test "$rc" -eq 2
+assert "valueless --parent prints nothing" test -z "$out"
+
 # A non-narrowing override is honored (the human said so), with a note.
 rc=0; resolve bash "$BIN" --parent stale-fork || rc=$?
 assert "non-narrowing override exits 0" test "$rc" -eq 0
@@ -360,15 +377,15 @@ assert "detached HEAD ignores PR and gt answers" test "$SOURCE" = default
 assert "detached HEAD: BASE is the default branch" test "$BASE" = main
 git checkout -q child
 
-# ── Test: stdout is exactly the seven contract keys, in order ────────────────
+# ── Test: stdout is exactly the six contract keys, in order ──────────────────
 
 # On a stacked resolution the notes go to stderr and NOTES; stdout must stay
-# exactly the seven eval-safe assignments.
+# exactly the six eval-safe assignments.
 out=$(run_bounded 10 env PATH="$SHIM_PATH" GH_TSV=$'parent\t42' bash "$BIN") || true
-assert "stdout has exactly seven lines" \
-  test "$(printf '%s\n' "$out" | wc -l | tr -d '[:space:]')" -eq 7
+assert "stdout has exactly six lines" \
+  test "$(printf '%s\n' "$out" | wc -l | tr -d '[:space:]')" -eq 6
 assert "stdout keys and order match the contract" \
-  test "$(printf '%s\n' "$out" | cut -d= -f1 | paste -sd, -)" = "BASE,REF,SOURCE,PR,DEFAULT,ANCESTOR,NOTES"
+  test "$(printf '%s\n' "$out" | cut -d= -f1 | paste -sd, -)" = "BASE,REF,SOURCE,PR,DEFAULT,NOTES"
 
 # ── Test: GIT_PR_BASE_TIMEOUT bounds a hung gh ───────────────────────────────
 

--- a/bin/lib/test-git-pr-base.sh
+++ b/bin/lib/test-git-pr-base.sh
@@ -1,0 +1,359 @@
+#!/bin/bash
+# Tests for git-pr-base.sh: stack-aware resolution of the base branch a PR
+# from HEAD targets.
+#
+# Usage: test-git-pr-base.sh
+#
+# Builds a throwaway upstream repo with a stacked topology (main: m1,m2 →
+# parent: p1,p2 → child: c1,c2), clones it so origin/* refs exist, and drives
+# git-pr-base.sh as a subprocess from the clone with `child` checked out. The
+# helper's gh/gt calls hit PATH shims whose answers are driven by env vars
+# (GH_TSV/GH_RC/GH_SLEEP, GT_PARENT/GT_RC), so every case is fully offline;
+# the controlled PATH keeps system git visible and the real gh/gt invisible.
+# Cleans up on exit.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# shellcheck source=bin/lib/test-helpers.sh
+source "$SCRIPT_DIR/test-helpers.sh"
+
+BIN="$SCRIPT_DIR/git-pr-base.sh"
+
+# ── Fixture: stacked upstream, work clone, gh/gt shims ──────────────────────
+
+# Resolve through symlinks (macOS /var -> /private/var) so paths stay stable.
+TESTTMP="$(cd "$(mktemp -d)" && pwd -P)"
+trap 'rm -rf "$TESTTMP"' EXIT
+
+UPSTREAM="$TESTTMP/upstream"
+WORK="$TESTTMP/work"
+
+mkdir -p "$UPSTREAM"
+git -C "$UPSTREAM" init -q
+git -C "$UPSTREAM" config user.email test@example.com
+git -C "$UPSTREAM" config user.name "Test"
+git -C "$UPSTREAM" config commit.gpgsign false
+# A stable default branch name regardless of the host's init.defaultBranch.
+git -C "$UPSTREAM" checkout -q -b main
+
+up_commit() {  # $1 = file name, doubles as the commit message
+  echo "$1" > "$UPSTREAM/$1"
+  git -C "$UPSTREAM" add "$1"
+  git -C "$UPSTREAM" commit -qm "$1"
+}
+
+up_commit m1
+up_commit m2
+git -C "$UPSTREAM" checkout -q -b parent
+up_commit p1
+up_commit p2
+git -C "$UPSTREAM" checkout -q -b child
+up_commit c1
+up_commit c2
+# Checked out last so the clone's origin/HEAD points at main.
+git -C "$UPSTREAM" checkout -q main
+
+git clone -q "$UPSTREAM" "$WORK"
+git -C "$WORK" config user.email test@example.com
+git -C "$WORK" config user.name "Test"
+git -C "$WORK" config commit.gpgsign false
+git -C "$WORK" checkout -q child
+M1_SHA=$(git -C "$WORK" rev-parse origin/main~1)
+
+# gh/gt shims: canned answers driven by env vars, so each invocation controls
+# what the "network" says. GH_TSV is the post-jq TSV line the helper parses
+# (<baseRefName>\t<prNumber>); the shims ignore their arguments.
+SHIM_PATH="$TESTTMP/bin:/usr/bin:/bin"
+mkdir -p "$TESTTMP/bin"
+
+make_shims() {
+  cat > "$TESTTMP/bin/gh" <<'SHIM'
+#!/bin/bash
+[ -n "${GH_SLEEP-}" ] && sleep "$GH_SLEEP"
+[ -n "${GH_RC-}" ] && exit "$GH_RC"
+printf '%s\n' "${GH_TSV-}"
+SHIM
+  cat > "$TESTTMP/bin/gt" <<'SHIM'
+#!/bin/bash
+[ -n "${GT_SLEEP-}" ] && sleep "$GT_SLEEP"
+[ -n "${GT_RC-}" ] && exit "$GT_RC"
+printf '%s\n' "${GT_PARENT-}"
+SHIM
+  chmod +x "$TESTTMP/bin/gh" "$TESTTMP/bin/gt"
+}
+make_shims
+
+# The helper resolves the repo from the working directory.
+cd "$WORK" || exit 1
+
+# ── Runners ──────────────────────────────────────────────────────────────────
+
+# Runs the helper bounded, captures stdout, and evals it into fresh
+# BASE/REF/SOURCE/PR/DEFAULT/ANCESTOR/NOTES variables. Returns the helper's
+# exit status (124 if run_bounded had to kill it). Callers pass the full
+# command tail: env assignments first, then `bash "$BIN"` and any arguments.
+resolve() {  # resolve [VAR=value ...] bash "$BIN" [--parent <ref>]
+  local out rc=0
+  BASE='' REF='' SOURCE='' PR='' DEFAULT='' ANCESTOR='' NOTES=''
+  out=$(run_bounded 10 env PATH="$SHIM_PATH" "$@") || rc=$?
+  [ -n "$out" ] && eval "$out"
+  return "$rc"
+}
+
+# True when the last resolve()'s NOTES contains the given substring.
+notes_contain() {
+  case "$NOTES" in
+    *"$1"*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# Runs the helper directly and captures only its stderr into $ERR. Direct
+# because run_bounded discards stderr; the helper bounds its own gh/gt calls,
+# so these invocations cannot block on the shims.
+ERR="$TESTTMP/stderr"
+helper_stderr() {  # helper_stderr [VAR=value ...] bash "$BIN" [--parent <ref>]
+  env PATH="$SHIM_PATH" "$@" >/dev/null 2>"$ERR" || true
+}
+
+# ── Test: no PR, no gt parent, no config → default branch ───────────────────
+
+rc=0; resolve bash "$BIN" || rc=$?
+assert "default fallback exits 0" test "$rc" -eq 0
+assert "default fallback: BASE is the default branch" test "$BASE" = main
+assert "default fallback: REF prefers the remote-tracking ref" test "$REF" = origin/main
+assert "default fallback: SOURCE" test "$SOURCE" = default
+assert "default fallback: PR is empty" test -z "$PR"
+assert "default fallback: DEFAULT" test "$DEFAULT" = main
+assert "default fallback: origin/main is an ancestor of HEAD" test "$ANCESTOR" = yes
+assert "default fallback: NOTES is empty" test -z "$NOTES"
+
+# ── Test: the open PR's baseRefName wins (the incident signal) ───────────────
+
+rc=0; resolve GH_TSV=$'parent\t42' bash "$BIN" || rc=$?
+assert "PR tier exits 0" test "$rc" -eq 0
+assert "PR tier: SOURCE" test "$SOURCE" = pr
+assert "PR tier: BASE is bare" test "$BASE" = parent
+assert "PR tier: REF is the remote-tracking ref" test "$REF" = origin/parent
+assert "PR tier: PR carries the number" test "$PR" = 42
+assert "PR tier: DEFAULT still reports the default branch" test "$DEFAULT" = main
+assert "PR tier: parent tip is an ancestor of HEAD" test "$ANCESTOR" = yes
+assert "PR tier: NOTES is empty on a clean resolution" test -z "$NOTES"
+
+helper_stderr GH_TSV=$'parent\t42' bash "$BIN"
+assert "PR tier: resolution note on stderr names the base" grep -q parent "$ERR"
+
+# ── Test: a PR targeting the default branch stays SOURCE=pr ─────────────────
+
+rc=0; resolve GH_TSV=$'main\t43' bash "$BIN" || rc=$?
+assert "PR-to-default exits 0" test "$rc" -eq 0
+assert "PR-to-default: SOURCE stays pr" test "$SOURCE" = pr
+assert "PR-to-default: BASE is the default branch" test "$BASE" = main
+assert "PR-to-default: PR carries the number" test "$PR" = 43
+assert "PR-to-default: callers compute stacked=false" test "$BASE" = "$DEFAULT"
+
+# ── Test: PR base with no local ref falls through with a fetch hint ─────────
+
+rc=0; resolve GH_TSV=$'nosuchbase\t44' bash "$BIN" || rc=$?
+assert "unresolvable PR base exits 0" test "$rc" -eq 0
+assert "unresolvable PR base falls through to default" test "$SOURCE" = default
+assert "unresolvable PR base: BASE is the default branch" test "$BASE" = main
+assert "unresolvable PR base: PR stays empty" test -z "$PR"
+assert "unresolvable PR base: NOTES carries the fetch hint" notes_contain 'fetch origin nosuchbase'
+
+helper_stderr GH_TSV=$'nosuchbase\t44' bash "$BIN"
+assert "unresolvable PR base: fetch hint on stderr" grep -q 'fetch origin nosuchbase' "$ERR"
+
+# ── Test: gh failing warns; gh absent is silent ──────────────────────────────
+
+rc=0; resolve GH_RC=1 bash "$BIN" || rc=$?
+assert "failing gh exits 0" test "$rc" -eq 0
+assert "failing gh degrades to default" test "$SOURCE" = default
+assert "failing gh: NOTES carries the warning" notes_contain 'could not check GitHub'
+
+rm -f "$TESTTMP/bin/gh" "$TESTTMP/bin/gt"
+rc=0; resolve bash "$BIN" || rc=$?
+assert "absent gh/gt exits 0" test "$rc" -eq 0
+assert "absent gh/gt resolves to default" test "$SOURCE" = default
+assert "absent gh/gt: NOTES is empty" test -z "$NOTES"
+
+helper_stderr bash "$BIN"
+assert "absent gh/gt stays silent on stderr" test ! -s "$ERR"
+make_shims
+
+# ── Test: gt parent tier ─────────────────────────────────────────────────────
+
+rc=0; resolve GT_PARENT=parent bash "$BIN" || rc=$?
+assert "gt tier exits 0" test "$rc" -eq 0
+assert "gt tier: SOURCE" test "$SOURCE" = graphite
+assert "gt tier: BASE is bare" test "$BASE" = parent
+assert "gt tier: REF is the remote-tracking ref" test "$REF" = origin/parent
+assert "gt tier: PR is empty" test -z "$PR"
+assert "gt tier: parent tip is an ancestor of HEAD" test "$ANCESTOR" = yes
+
+# ── Test: gt reporting the branch as its own parent is rejected ──────────────
+
+rc=0; resolve GT_PARENT=child bash "$BIN" || rc=$?
+assert "gt self-parent exits 0" test "$rc" -eq 0
+assert "gt self-parent falls through to default" test "$SOURCE" = default
+assert "gt self-parent: NOTES records the rejection" notes_contain 'it is the current branch'
+
+# ── Test: gt output that is not a branch name is discarded silently ──────────
+
+rc=0; resolve GT_PARENT='Graphite has not been initialized, attempting to set up now... Welcome to Graphite!' bash "$BIN" || rc=$?
+assert "gt prose output exits 0" test "$rc" -eq 0
+assert "gt prose output falls through to default" test "$SOURCE" = default
+assert "gt prose output: NOTES stays empty" test -z "$NOTES"
+
+# ── Test: a hung gt is a degradation worth a note ─────────────────────────────
+
+rc=0; resolve GIT_PR_BASE_TIMEOUT=1 GT_SLEEP=3 bash "$BIN" || rc=$?
+assert "hung gt exits 0" test "$rc" -eq 0
+assert "hung gt degrades to default" test "$SOURCE" = default
+assert "hung gt: NOTES carries the timeout warning" notes_contain "'gt parent' timed out"
+
+# ── Test: git config branch.<name>.parent tier ───────────────────────────────
+
+rm -f "$TESTTMP/bin/gt"   # gt absent: the candidate must come from config
+git config branch.child.parent parent
+
+rc=0; resolve bash "$BIN" || rc=$?
+assert "config tier exits 0" test "$rc" -eq 0
+assert "config tier: SOURCE" test "$SOURCE" = config
+assert "config tier: BASE is bare" test "$BASE" = parent
+assert "config tier: REF is the remote-tracking ref" test "$REF" = origin/parent
+git config --unset branch.child.parent
+
+# ── Test: origin/-prefixed candidates vet by their bare name ─────────────────
+
+git config branch.child.parent origin/parent
+rc=0; resolve bash "$BIN" || rc=$?
+assert "origin-prefixed parent is accepted" test "$SOURCE" = config
+assert "origin-prefixed parent: BASE is bare" test "$BASE" = parent
+assert "origin-prefixed parent: REF" test "$REF" = origin/parent
+git config --unset branch.child.parent
+
+git config branch.child.parent origin/child
+rc=0; resolve bash "$BIN" || rc=$?
+assert "origin-prefixed self-parent is rejected" test "$SOURCE" = default
+assert "origin-prefixed self-parent: NOTES records the rejection" notes_contain 'it is the current branch'
+git config --unset branch.child.parent
+
+# ── Test: rewritten parent (merge-base collapses to the default's) ───────────
+
+# A "rewritten" parent shares no history with child beyond origin/main's tip,
+# so merge-base(HEAD, it) equals merge-base(HEAD, origin/main) and the
+# candidate must be rejected as not narrowing.
+git checkout -q -b rewritten-parent origin/main
+echo r1 > r1
+git add r1
+git commit -qm r1
+git checkout -q child
+git config branch.child.parent rewritten-parent
+
+rc=0; resolve bash "$BIN" || rc=$?
+assert "rewritten parent exits 0" test "$rc" -eq 0
+assert "rewritten parent is rejected: SOURCE=default" test "$SOURCE" = default
+assert "rewritten parent is rejected: BASE is the default branch" test "$BASE" = main
+assert "rewritten parent: NOTES records the rejection" notes_contain 'does not narrow'
+git config --unset branch.child.parent
+
+# ── Test: parent forked from older trunk (wider than trunk) ──────────────────
+
+# merge-base(HEAD, stale-fork) = m1 sits behind merge-base(HEAD, origin/main)
+# = m2: the merge-bases differ, so a bare equality check would accept it, yet
+# the candidate widens the range to include trunk commits.
+git branch stale-fork "$M1_SHA"
+git config branch.child.parent stale-fork
+
+rc=0; resolve bash "$BIN" || rc=$?
+assert "older-trunk fork exits 0" test "$rc" -eq 0
+assert "older-trunk fork is rejected: SOURCE=default" test "$SOURCE" = default
+assert "older-trunk fork: NOTES records the rejection" notes_contain 'does not narrow'
+git config --unset branch.child.parent
+make_shims
+
+# ── Test: parent advanced beyond the fork point → accepted, ANCESTOR=no ──────
+
+# New commit on the upstream parent (review feedback the child has not rebased
+# onto): tip-ancestry now fails, but the merge-base still strictly narrows, so
+# the candidate must be accepted and the fact reported via ANCESTOR.
+git -C "$UPSTREAM" checkout -q parent
+up_commit p3
+git -C "$UPSTREAM" checkout -q main
+git fetch -q origin
+
+rc=0; resolve GT_PARENT=parent bash "$BIN" || rc=$?
+assert "advanced parent exits 0" test "$rc" -eq 0
+assert "advanced parent is still accepted" test "$SOURCE" = graphite
+assert "advanced parent: BASE" test "$BASE" = parent
+assert "advanced parent: REF" test "$REF" = origin/parent
+assert "advanced parent: tip is no longer an ancestor" test "$ANCESTOR" = no
+assert "advanced parent: NOTES flags the non-ancestor base" notes_contain 'not an ancestor'
+
+# ── Test: --parent override ───────────────────────────────────────────────────
+
+# The override outranks an available PR answer.
+rc=0; resolve GH_TSV=$'main\t45' bash "$BIN" --parent origin/parent || rc=$?
+assert "override exits 0" test "$rc" -eq 0
+assert "override beats the PR tier" test "$SOURCE" = override
+assert "override: BASE is bare" test "$BASE" = parent
+assert "override: REF keeps the remote-tracking form" test "$REF" = origin/parent
+assert "override: PR is empty" test -z "$PR"
+
+# A bare spelling that names an existing local branch stays local, even when a
+# remote-tracking ref of the same name exists.
+git branch parent origin/parent~1
+rc=0; resolve bash "$BIN" --parent parent || rc=$?
+assert "local-branch override exits 0" test "$rc" -eq 0
+assert "local-branch override is honored as spelled" test "$REF" = parent
+assert "local-branch override: BASE" test "$BASE" = parent
+git branch -D parent >/dev/null
+
+# Unresolvable override: exit 1 with empty stdout, so eval'ing it is a no-op.
+rc=0
+out=$(run_bounded 10 env PATH="$SHIM_PATH" bash "$BIN" --parent nonexistent) || rc=$?
+assert "unresolvable override exits 1" test "$rc" -eq 1
+assert "unresolvable override prints nothing" test -z "$out"
+
+# A non-narrowing override is honored (the human said so), with a note.
+rc=0; resolve bash "$BIN" --parent stale-fork || rc=$?
+assert "non-narrowing override exits 0" test "$rc" -eq 0
+assert "non-narrowing override is honored" test "$SOURCE" = override
+assert "non-narrowing override: BASE" test "$BASE" = stale-fork
+assert "non-narrowing override: NOTES stays empty (explicit override)" test -z "$NOTES"
+
+helper_stderr bash "$BIN" --parent stale-fork
+assert "non-narrowing override: note on stderr" grep -q proceeding "$ERR"
+
+# ── Test: detached HEAD skips every branch-keyed tier ─────────────────────────
+
+git checkout -q --detach
+rc=0; resolve GH_TSV=$'parent\t99' GT_PARENT=parent bash "$BIN" || rc=$?
+assert "detached HEAD exits 0" test "$rc" -eq 0
+assert "detached HEAD ignores PR and gt answers" test "$SOURCE" = default
+assert "detached HEAD: BASE is the default branch" test "$BASE" = main
+git checkout -q child
+
+# ── Test: stdout is exactly the seven contract keys, in order ────────────────
+
+# On a stacked resolution the notes go to stderr and NOTES; stdout must stay
+# exactly the seven eval-safe assignments.
+out=$(run_bounded 10 env PATH="$SHIM_PATH" GH_TSV=$'parent\t42' bash "$BIN") || true
+assert "stdout has exactly seven lines" \
+  test "$(printf '%s\n' "$out" | wc -l | tr -d '[:space:]')" -eq 7
+assert "stdout keys and order match the contract" \
+  test "$(printf '%s\n' "$out" | cut -d= -f1 | paste -sd, -)" = "BASE,REF,SOURCE,PR,DEFAULT,ANCESTOR,NOTES"
+
+# ── Test: GIT_PR_BASE_TIMEOUT bounds a hung gh ───────────────────────────────
+
+rc=0; resolve GIT_PR_BASE_TIMEOUT=1 GH_SLEEP=3 bash "$BIN" || rc=$?
+assert "hung gh exits 0" test "$rc" -eq 0
+assert "hung gh degrades to default" test "$SOURCE" = default
+assert "hung gh: NOTES carries the warning" notes_contain 'could not check GitHub'
+
+# ── Results ──────────────────────────────────────────────────────────────────
+
+print_results

--- a/bin/lib/test-git-pr-base.sh
+++ b/bin/lib/test-git-pr-base.sh
@@ -78,8 +78,8 @@ SHIM
   cat > "$TESTTMP/bin/gt" <<'SHIM'
 #!/bin/bash
 [ -n "${GT_SLEEP-}" ] && sleep "$GT_SLEEP"
-[ -n "${GT_RC-}" ] && exit "$GT_RC"
 printf '%s\n' "${GT_PARENT-}"
+exit "${GT_RC:-0}"
 SHIM
   chmod +x "$TESTTMP/bin/gh" "$TESTTMP/bin/gt"
 }
@@ -199,6 +199,29 @@ rc=0; resolve GT_PARENT=child bash "$BIN" || rc=$?
 assert "gt self-parent exits 0" test "$rc" -eq 0
 assert "gt self-parent falls through to default" test "$SOURCE" = default
 assert "gt self-parent: NOTES records the rejection" notes_contain 'it is the current branch'
+
+# ── Test: gt exiting non-zero means "no answer" — silent fall-through ────────
+
+# The shim prints a valid branch name AND exits 1: the exit status must win
+# over the output, with no degradation note — unlike a timeout, a clean
+# non-zero exit is gt answering "not stacked".
+rc=0; resolve GT_PARENT=parent GT_RC=1 bash "$BIN" || rc=$?
+assert "failing gt exits 0" test "$rc" -eq 0
+assert "failing gt ignores gt's output and falls through" test "$SOURCE" = default
+assert "failing gt: NOTES is empty" test -z "$NOTES"
+
+helper_stderr GT_PARENT=parent GT_RC=1 bash "$BIN"
+assert "failing gt stays silent on stderr" test ! -s "$ERR"
+
+# ── Test: gt exiting 0 with non-branch prose is discarded ────────────────────
+
+# Whitespace-stripped setup prose (the real "Graphite has not been
+# initialized, attempting to set up now..." shape) fails check-ref-format and
+# must not reach the vet — no note, no stderr.
+rc=0; resolve GT_PARENT='Graphitehasnotbeeninitialized,attemptingtosetupnow...' bash "$BIN" || rc=$?
+assert "gt prose output exits 0" test "$rc" -eq 0
+assert "gt prose output is discarded" test "$SOURCE" = default
+assert "gt prose output: NOTES is empty" test -z "$NOTES"
 
 # ── Test: gt output that is not a branch name is discarded silently ──────────
 


### PR DESCRIPTION
Running /squash on a stacked branch (a PR targeting another PR's branch) computed its commit range against the default branch, which pulled the parent PR's commits into the history rewrite. The skills assumed every branch is based on trunk.

## What this does

`bin/lib/git-pr-base.sh` resolves the base a PR from HEAD targets, in this precedence: `--parent` override, the open PR's `baseRefName` (`gh pr list --head`, bounded), `gt parent` (bounded, output validated with `git check-ref-format`), `branch.<name>.parent` config, then the default branch. It emits eval-safe `BASE`/`REF`/`SOURCE`/`PR`/`DEFAULT`/`ANCESTOR`/`NOTES` assignments on stdout and nothing on failure, so callers eval it and check for empty vars.

An open PR's base is what GitHub actually diffs and merges against, so it outranks local stack metadata and only has to resolve to a local ref. gt/config candidates must strictly narrow `merge-base HEAD <ref>` beyond the default branch, which rejects rewritten or stale parents. `NOTES` is non-empty whenever resolution degraded (GitHub unreachable, gt timed out, a recorded parent ignored, a stacked base no longer an ancestor of HEAD); notes are mirrored on stderr.

The `squash`, `create-pr`, and `test-plan` skills now eval the helper instead of calling `git-default-branch.sh` directly, and each takes a `--parent <ref>` override. Squash stops for confirmation when `NOTES` is non-empty or the commit list looks like it contains another branch's work. create-pr keeps its bare-name uses (`gh pr create --base`, `git ls-remote`) on `BASE` and moves all log/diff commands to `REF`, and only retargets an existing PR's base when the user explicitly passed `--parent` and confirmed.

`git-default-branch.sh` is unchanged; `git-bclean-empty`, `git-delete-others`, and `tree-me` intentionally stay on it (they are trunk-scoped by design).

## Test plan

- `bash bin/lib/test-git-pr-base.sh` — 95 assertions, fully offline (throwaway stacked repo, PATH-shimmed gh/gt): all tiers, the narrowing guard (rewritten parent, wider-than-trunk fork), origin/-prefixed candidates, override spelling preference, detached HEAD, gh/gt absent vs failing vs hung, the seven-key eval contract.
- Verified against the real incident: on the stacked branch for PostHog/posthog PR #81575 the helper resolves `BASE=haacked/bulk-delete-replay-guard SOURCE=pr PR=81575` (previously the range wrongly included the parent PR's commits), and NOTES flags that the parent advanced since the branch was cut.
- `shellcheck -x` clean on both new files.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*