### PR TITLE
Add /followup skill for mid-session follow-up capture

### DIFF
--- a/ai/install.sh
+++ b/ai/install.sh
@@ -52,9 +52,23 @@ uninstall_claude_config() {
         fi
     fi
 
+    # Remove path-identifiable managed hooks (skill detect scripts, ai/bin
+    # helpers) from settings.json so uninstalled hooks stop firing. Inline
+    # lint/format hook commands carry no path marker and are left in place.
+    if [ "$INSTALL_HOOKS" = "true" ] && [ -f "$HOME/.claude/settings.json" ] && command -v jq >/dev/null 2>&1; then
+        tmp_settings=$(mktemp)
+        if jq '(.hooks // {}) |= with_entries(.value |= map(select([.hooks[]?.command // ""] | any(test("/\\.claude/skills/[^\"]*-detect\\.sh|/\\.dotfiles/ai/bin/")) | not)))' "$HOME/.claude/settings.json" > "$tmp_settings"; then
+            mv "$tmp_settings" "$HOME/.claude/settings.json"
+            success "Removed managed detect/bin hooks from settings.json"
+        else
+            rm -f "$tmp_settings"
+            warning "Could not update hooks in settings.json"
+        fi
+    fi
+
     echo ""
     success "Claude configuration uninstalled successfully!"
-    info "Note: MCP servers, hooks, and permissions are not removed by uninstall"
+    info "Note: MCP servers, permissions, and inline lint/format hooks are not removed by uninstall"
 }
 
 # Parse command line options

--- a/ai/install.sh
+++ b/ai/install.sh
@@ -473,6 +473,16 @@ if [ "$INSTALL_HOOKS" = "true" ]; then
             "timeout": 5
           }
         ]
+      },
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/skills/followup/scripts/followup-detect.sh",
+            "timeout": 5
+          }
+        ]
       }
     ]
   }

--- a/ai/install.sh
+++ b/ai/install.sh
@@ -53,11 +53,13 @@ uninstall_claude_config() {
     fi
 
     # Remove path-identifiable managed hooks (skill detect scripts, ai/bin
-    # helpers) from settings.json so uninstalled hooks stop firing. Inline
-    # lint/format hook commands carry no path marker and are left in place.
+    # helpers) from settings.json so uninstalled hooks stop firing. Filtering
+    # happens at the individual hook level, so a hand-added hook sharing an
+    # element with a managed one survives; elements left empty are dropped.
+    # Inline lint/format hook commands carry no path marker and stay in place.
     if [ "$INSTALL_HOOKS" = "true" ] && [ -f "$HOME/.claude/settings.json" ] && command -v jq >/dev/null 2>&1; then
         tmp_settings=$(mktemp)
-        if jq '(.hooks // {}) |= with_entries(.value |= map(select([.hooks[]?.command // ""] | any(test("/\\.claude/skills/[^\"]*-detect\\.sh|/\\.dotfiles/ai/bin/")) | not)))' "$HOME/.claude/settings.json" > "$tmp_settings"; then
+        if jq 'if .hooks then .hooks |= with_entries(.value |= (map(.hooks |= map(select((.command // "") | test("/\\.claude/skills/[^\"]*-detect\\.sh|/\\.dotfiles/ai/bin/") | not))) | map(select((.hooks | length) > 0)))) else . end' "$HOME/.claude/settings.json" > "$tmp_settings"; then
             mv "$tmp_settings" "$HOME/.claude/settings.json"
             success "Removed managed detect/bin hooks from settings.json"
         else

--- a/ai/skills/followup/SKILL.md
+++ b/ai/skills/followup/SKILL.md
@@ -41,11 +41,11 @@ Speed is the point: one script call, at most one Edit, done.
 ~/.claude/skills/followup/scripts/followup-add.sh "<text>"
 ```
 
-It inserts the item at the top of `## Open` (creating the file when missing) and prints a capture summary.
+Pass the text as one quoted argument. It inserts the item at the top of `## Open` (creating the file when missing) and prints a capture summary.
 
 2. If the conversation has an obvious source the text doesn't already carry — the PR under discussion, a `file:line` — weave it into the just-added line as a markdown link with one Edit. Skip this when nothing obvious exists; never research to find a link.
 
-3. Relay the script's summary to the user.
+3. Relay the script's summary to the user. If the script errors, surface the error — never report a capture that didn't land.
 
 ## List mode
 

--- a/ai/skills/followup/SKILL.md
+++ b/ai/skills/followup/SKILL.md
@@ -17,7 +17,7 @@ Mid-session capture for things that must not fall through the cracks. Items live
 - [ ] 2026-08-14 · [PostHog/posthog · haacked/flags-foo] Check p99 after canary rollout ([PR #37211](https://github.com/PostHog/posthog/pull/37211), `rust/feature-flags/src/lib.rs:412`)
 ```
 
-`- [ ]` open, `- [x]` done, `- [-]` dropped. Closed items carry a `— closed YYYY-MM-DD` or `— dropped YYYY-MM-DD` suffix. `~/.claude/skills/followup/scripts/followup-open.sh [org/repo]` prints open items — the single owner of the open-item grammar. Non-GitHub contexts use `[no-repo]`.
+`- [ ]` open, `- [x]` done, `- [-]` dropped. Closed items carry a `— closed YYYY-MM-DD` or `— dropped YYYY-MM-DD` suffix; the marker is always the final such fragment at the end of the line, since item text may contain its own em dashes. `~/.claude/skills/followup/scripts/followup-open.sh [org/repo]` prints open items — the single owner of the open-item grammar. Non-GitHub contexts use `[no-repo]`.
 
 ## Modes
 
@@ -65,7 +65,7 @@ The deliberate sweep (standup surfacing is the passive one):
 
 1. List every open item with its age; flag items older than 14 days as stale.
 2. Ask the user for keep/done/drop decisions in one batch — a compact numbered prompt, not one question per item.
-3. Apply the flips, then move all `- [x]` and `- [-]` lines from `## Open` to the top of `## Archive`, preserving their order.
+3. Apply the flips, then move all `- [x]` and `- [-]` lines from `## Open` to the top of `## Archive`, preserving their order — directly under the heading and its blank line, creating the blank line (or the section) if missing.
 4. Report: kept, done, dropped counts and the oldest remaining item.
 
 ## Boundary: /followup vs /handoff vs /note

--- a/ai/skills/followup/SKILL.md
+++ b/ai/skills/followup/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: followup
+description: Capture a follow-up item mid-session in seconds, list open items, close one, or run a review pass. Use when the user says "follow up on this later", "add a followup", "don't let me forget", or runs /followup.
+argument-hint: "[list|done <match>|drop <match>|review] <free text>"
+model: haiku
+---
+
+# Follow-ups
+
+Mid-session capture for things that must not fall through the cracks. Items live in one central file and resurface via the SessionStart hook (`followup-detect.sh`) and `/standup`.
+
+## The file
+
+`~/dev/haacked/notes/PostHog/Followups.md` — `## Open` and `## Archive` sections, newest first, one line per item, never hard-wrapped:
+
+```markdown
+- [ ] 2026-08-14 · [PostHog/posthog · haacked/flags-foo] Check p99 after canary rollout ([PR #37211](https://github.com/PostHog/posthog/pull/37211), `rust/feature-flags/src/lib.rs:412`)
+```
+
+`- [ ]` open, `- [x]` done, `- [-]` dropped. Closed items carry a `— closed YYYY-MM-DD` or `— dropped YYYY-MM-DD` suffix. `~/.claude/skills/followup/scripts/followup-open.sh [org/repo]` prints open items — the single owner of the open-item grammar. Non-GitHub contexts use `[no-repo]`.
+
+## Modes
+
+Parse the first argument from user input.
+
+| Argument | Mode |
+| --- | --- |
+| anything else (default) | **add** — capture the text as a new item |
+| `list` | print open items, current repo first |
+| `done <match>` | close an item as done |
+| `drop <match>` | close an item as dropped |
+| `review` | review pass over all open items |
+
+## Add mode (default)
+
+Speed is the point: one script call, at most one Edit, done.
+
+1. Run the helper with the follow-up text:
+
+```bash
+~/.claude/skills/followup/scripts/followup-add.sh "<text>"
+```
+
+It inserts the item at the top of `## Open` (creating the file when missing) and prints a capture summary.
+
+2. If the conversation has an obvious source the text doesn't already carry — the PR under discussion, a `file:line` — weave it into the just-added line as a markdown link with one Edit. Skip this when nothing obvious exists; never research to find a link.
+
+3. Relay the script's summary to the user.
+
+## List mode
+
+Run `followup-open.sh` and print its output grouped: current repo first (derive `org/repo` from `git remote get-url origin`), then the rest, each with its age in days. No file changes.
+
+## Done / drop mode
+
+1. Find open lines matching `<match>` (case-insensitive substring over `followup-open.sh` output).
+2. Exactly one match: flip `- [ ]` to `- [x]` (done) or `- [-]` (drop) in place and append ` — closed YYYY-MM-DD` (or ` — dropped YYYY-MM-DD`).
+3. Multiple matches: show them numbered and ask which one. Zero: say so and suggest `/followup list`.
+
+Closed items stay under `## Open` until the next `review` sweeps them to `## Archive` — the flip is the fast path.
+
+## Review mode
+
+The deliberate sweep (standup surfacing is the passive one):
+
+1. List every open item with its age; flag items older than 14 days as stale.
+2. Ask the user for keep/done/drop decisions in one batch — a compact numbered prompt, not one question per item.
+3. Apply the flips, then move all `- [x]` and `- [-]` lines from `## Open` to the top of `## Archive`, preserving their order.
+4. Report: kept, done, dropped counts and the oldest remaining item.
+
+## Boundary: /followup vs /handoff vs /note
+
+| `/followup` | `/handoff` | `/note` |
+| --- | --- | --- |
+| Discrete "do this later" items | Mid-task session bridge | Durable technical knowledge |
+| Central checklist, cross-repo | One doc per repo, current task | Slug-named notes per repo |
+| Surfaces at session start + standup | Surfaces at session start in that repo | Found when searched |

--- a/ai/skills/followup/SKILL.md
+++ b/ai/skills/followup/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: followup
 description: Capture a follow-up item mid-session in seconds, list open items, close one, or run a review pass. Use when the user says "follow up on this later", "add a followup", "don't let me forget", or runs /followup.
-argument-hint: "[list|done <match>|drop <match>|review] <free text>"
+argument-hint: "<text to capture> | list | done <match> | drop <match> | review"
 model: haiku
 ---
 
@@ -17,11 +17,11 @@ Mid-session capture for things that must not fall through the cracks. Items live
 - [ ] 2026-08-14 · [PostHog/posthog · haacked/flags-foo] Check p99 after canary rollout ([PR #37211](https://github.com/PostHog/posthog/pull/37211), `rust/feature-flags/src/lib.rs:412`)
 ```
 
-`- [ ]` open, `- [x]` done, `- [-]` dropped. Closed items carry a `— closed YYYY-MM-DD` or `— dropped YYYY-MM-DD` suffix; the marker is always the final such fragment at the end of the line, since item text may contain its own em dashes. `~/.claude/skills/followup/scripts/followup-open.sh [org/repo]` prints open items — the single owner of the open-item grammar. Non-GitHub contexts use `[no-repo]`.
+`- [ ]` open, `- [x]` done, `- [-]` dropped. Closed items carry a `— closed YYYY-MM-DD` or `— dropped YYYY-MM-DD` suffix; the marker is always the final such fragment at the end of the line, since item text may contain its own em dashes. `~/.claude/skills/followup/scripts/followup-open.sh [org/repo]` prints open items — the single owner of open-item selection. Non-GitHub contexts use `[no-repo]`.
 
 ## Modes
 
-Parse the first argument from user input.
+Parse the first argument from user input. A keyword selects a mode only when the input reads as that command — bare `list`/`review`, or `done`/`drop` plus short match text. Text that reads as a task to remember ("review the flag cleanup PR") is add-mode text; prefer add when unsure, since a stray capture is visible and cheap.
 
 | Argument | Mode |
 | --- | --- |
@@ -63,7 +63,7 @@ Closed items stay under `## Open` until the next `review` sweeps them to `## Arc
 
 The deliberate sweep (standup surfacing is the passive one):
 
-1. List every open item with its age; flag items older than 14 days as stale.
+1. List every open item with its age; flag items older than 14 days as stale (keep in sync with `STALE_DAYS` in `followup-detect.sh`).
 2. Ask the user for keep/done/drop decisions in one batch — a compact numbered prompt, not one question per item.
 3. Apply the flips, then move all `- [x]` and `- [-]` lines from `## Open` to the top of `## Archive`, preserving their order — directly under the heading and its blank line, creating the blank line (or the section) if missing.
 4. Report: kept, done, dropped counts and the oldest remaining item.

--- a/ai/skills/followup/scripts/followup-add.sh
+++ b/ai/skills/followup/scripts/followup-add.sh
@@ -57,7 +57,8 @@ fi
 # Insert at the top of the Open section, keeping the item list contiguous and
 # the blank lines around headings intact (including when the section is empty).
 # The text rides in via ENVIRON because awk -v and sed both mangle backslashes.
-tmp=$(mktemp)
+# The temp file sits beside the target so the mv stays an atomic same-volume rename.
+tmp=$(mktemp "${FOLLOWUPS_FILE}.XXXXXX")
 FOLLOWUP_LINE="$line" awk '
     {
         print
@@ -76,12 +77,21 @@ FOLLOWUP_LINE="$line" awk '
 ' "$FOLLOWUPS_FILE" > "$tmp"
 mv "$tmp" "$FOLLOWUPS_FILE"
 
-open_helper="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/followup-open.sh"
-open_total=$("$open_helper" | grep -c . || true)
+# A mangled heading (e.g. a stray CR) can slip past the grep guard yet miss the
+# awk match; verify the insert actually landed rather than reporting a phantom capture.
+if ! grep -qF -- "$line" "$FOLLOWUPS_FILE"; then
+    echo "Error: failed to insert item under '## Open' in $FOLLOWUPS_FILE" >&2
+    exit 1
+fi
+
 echo "Captured: ${line}"
-if [[ -n "$repo" ]]; then
-    open_repo=$("$open_helper" "$repo" | grep -c . || true)
-    echo "Open for ${repo}: ${open_repo} · total open: ${open_total}"
-else
-    echo "Total open: ${open_total}"
+open_helper="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/followup-open.sh"
+if [[ -x "$open_helper" ]]; then
+    open_total=$("$open_helper" | grep -c . || true)
+    if [[ -n "$repo" ]]; then
+        open_repo=$("$open_helper" "$repo" | grep -c . || true)
+        echo "Open for ${repo}: ${open_repo} · total open: ${open_total}"
+    else
+        echo "Total open: ${open_total}"
+    fi
 fi

--- a/ai/skills/followup/scripts/followup-add.sh
+++ b/ai/skills/followup/scripts/followup-add.sh
@@ -18,7 +18,7 @@ fi
 
 text="$*"
 
-# Derive the [org/repo · branch] context; outside a git repo, record [no-repo].
+# Derive the [org/repo · branch] context; record [no-repo] when there is no parseable GitHub origin.
 context="no-repo"
 repo=""
 if git rev-parse --git-dir > /dev/null 2>&1; then
@@ -77,8 +77,8 @@ FOLLOWUP_LINE="$line" awk '
 ' "$FOLLOWUPS_FILE" > "$tmp"
 mv "$tmp" "$FOLLOWUPS_FILE"
 
-# A mangled heading (e.g. a stray CR) can slip past the grep guard yet miss the
-# awk match; verify the insert actually landed rather than reporting a phantom capture.
+# Belt and braces: verify the insert actually landed rather than reporting a
+# phantom capture (awk can exit 0 on a partial write, e.g. disk full).
 if ! grep -qF -- "$line" "$FOLLOWUPS_FILE"; then
     echo "Error: failed to insert item under '## Open' in $FOLLOWUPS_FILE" >&2
     exit 1

--- a/ai/skills/followup/scripts/followup-add.sh
+++ b/ai/skills/followup/scripts/followup-add.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Add a follow-up item to the central followups file.
+#
+# Usage: followup-add.sh <text...>
+#
+# Derives the date, org/repo, and branch from the current directory's git
+# state, inserts the item at the top of the "## Open" section (newest first),
+# creates the file from a skeleton when missing, and prints a capture summary.
+
+set -euo pipefail
+
+export FOLLOWUPS_FILE="${FOLLOWUPS_FILE:-$HOME/dev/haacked/notes/PostHog/Followups.md}"
+
+if [[ $# -lt 1 ]]; then
+    echo "Usage: followup-add.sh <text>" >&2
+    exit 1
+fi
+
+text="$*"
+
+# Derive the [org/repo · branch] context; outside a git repo, record [no-repo].
+context="no-repo"
+repo=""
+if git rev-parse --git-dir > /dev/null 2>&1; then
+    remote_url=$(git remote get-url origin 2>/dev/null || echo "")
+    if [[ "$remote_url" =~ github\.com[:/]([^/]+)/([^/.]+)(\.git)?$ ]]; then
+        repo="${BASH_REMATCH[1]}/${BASH_REMATCH[2]}"
+        branch=$(git branch --show-current 2>/dev/null || echo "")
+        if [[ -n "$branch" ]]; then
+            context="${repo} · ${branch}"
+        else
+            context="$repo"
+        fi
+    fi
+fi
+
+line="- [ ] $(date +%Y-%m-%d) · [${context}] ${text}"
+
+if [[ ! -f "$FOLLOWUPS_FILE" ]]; then
+    mkdir -p "$(dirname "$FOLLOWUPS_FILE")"
+    cat > "$FOLLOWUPS_FILE" <<'EOF'
+# Followups
+
+Captured mid-session via /followup. Open items surface at session start and in /standup. Newest first. `- [ ]` open, `- [x]` done, `- [-]` dropped.
+
+## Open
+
+## Archive
+EOF
+fi
+
+if ! grep -q '^## Open$' "$FOLLOWUPS_FILE"; then
+    echo "Error: no '## Open' section in $FOLLOWUPS_FILE" >&2
+    exit 1
+fi
+
+# Insert at the top of the Open section, keeping the item list contiguous and
+# the blank lines around headings intact (including when the section is empty).
+# The text rides in via ENVIRON because awk -v and sed both mangle backslashes.
+tmp=$(mktemp)
+FOLLOWUP_LINE="$line" awk '
+    {
+        print
+        if (!done && $0 == "## Open") {
+            print ""
+            print ENVIRON["FOLLOWUP_LINE"]
+            done = 1
+            while ((getline nxt) > 0) {
+                if (nxt == "") continue
+                if (nxt ~ /^#/) print ""
+                print nxt
+                break
+            }
+        }
+    }
+' "$FOLLOWUPS_FILE" > "$tmp"
+mv "$tmp" "$FOLLOWUPS_FILE"
+
+open_helper="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/followup-open.sh"
+open_total=$("$open_helper" | grep -c . || true)
+echo "Captured: ${line}"
+if [[ -n "$repo" ]]; then
+    open_repo=$("$open_helper" "$repo" | grep -c . || true)
+    echo "Open for ${repo}: ${open_repo} · total open: ${open_total}"
+else
+    echo "Total open: ${open_total}"
+fi

--- a/ai/skills/followup/scripts/followup-detect.sh
+++ b/ai/skills/followup/scripts/followup-detect.sh
@@ -9,7 +9,7 @@ set -uo pipefail
 MAX_SHOWN=3
 STALE_DAYS=14
 
-open_helper="${HOME}/.claude/skills/followup/scripts/followup-open.sh"
+open_helper="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)/followup-open.sh"
 [[ -x "$open_helper" ]] || exit 0
 
 # Only surface inside a git repo with a parseable GitHub origin.
@@ -21,15 +21,16 @@ repo="${BASH_REMATCH[1]}/${BASH_REMATCH[2]}"
 open_lines=$("$open_helper" 2>/dev/null) || exit 0
 [[ -n "$open_lines" ]] || exit 0
 
-here=$(printf '%s\n' "$open_lines" | grep -F "[${repo}" || true)
-other=$(printf '%s\n' "$open_lines" | grep -vF "[${repo}" | grep -c . || true)
+here=$("$open_helper" "$repo" 2>/dev/null) || true
+total=$(grep -c . <<< "$open_lines" || true)
 
 if [[ -z "$here" ]]; then
-    [[ "$other" -gt 0 ]] && echo "[followup] ${other} open follow-up(s) in other repos — /followup list"
+    [[ "$total" -gt 0 ]] && echo "[followup] ${total} open follow-up(s) in other repos — /followup list"
     exit 0
 fi
 
-here_count=$(printf '%s\n' "$here" | grep -c . || true)
+here_count=$(grep -c . <<< "$here" || true)
+other=$((total - here_count))
 
 echo "[followup] Open follow-ups for ${repo}:"
 printf '%s\n' "$here" | head -n "$MAX_SHOWN" | sed 's/^- \[ \] /  • /'

--- a/ai/skills/followup/scripts/followup-detect.sh
+++ b/ai/skills/followup/scripts/followup-detect.sh
@@ -13,7 +13,7 @@ open_helper="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)/followup-
 [[ -x "$open_helper" ]] || exit 0
 
 # Only surface inside a git repo with a parseable GitHub origin.
-git rev-parse --git-dir > /dev/null 2>&1 || exit 0
+# `git remote get-url` also fails outside a repo, so it doubles as the repo guard.
 remote_url=$(git remote get-url origin 2>/dev/null) || exit 0
 [[ "$remote_url" =~ github\.com[:/]([^/]+)/([^/.]+)(\.git)?$ ]] || exit 0
 repo="${BASH_REMATCH[1]}/${BASH_REMATCH[2]}"

--- a/ai/skills/followup/scripts/followup-detect.sh
+++ b/ai/skills/followup/scripts/followup-detect.sh
@@ -40,10 +40,11 @@ summary=""
 [[ "$other" -gt 0 ]] && summary="${summary:+${summary} · }${other} open in other repos"
 [[ -n "$summary" ]] && echo "  (${summary} — /followup list)"
 
-# Staleness nudge: the file is newest-first, so the oldest item here is the last line.
-oldest="${here##*$'\n'}"
-if [[ "$oldest" =~ ^-\ \[\ \]\ ([0-9]{4}-[0-9]{2}-[0-9]{2}) ]]; then
-    oldest_epoch=$(date -j -f %Y-%m-%d "${BASH_REMATCH[1]}" +%s 2>/dev/null || echo "")
+# Staleness nudge: scan every line for the minimum date rather than trusting
+# file order, so a reordered Open section can't produce a silently wrong age.
+oldest_date=$(printf '%s\n' "$here" | sed -nE 's/^- \[ \] ([0-9]{4}-[0-9]{2}-[0-9]{2}).*/\1/p' | sort | head -n 1)
+if [[ "$oldest_date" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
+    oldest_epoch=$(date -j -f %Y-%m-%d "$oldest_date" +%s 2>/dev/null || echo "")
     if [[ -n "$oldest_epoch" ]]; then
         age_days=$(( ($(date +%s) - oldest_epoch) / 86400 ))
         if [[ "$age_days" -gt "$STALE_DAYS" ]]; then

--- a/ai/skills/followup/scripts/followup-detect.sh
+++ b/ai/skills/followup/scripts/followup-detect.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# SessionStart hook: surface open follow-up items for the current repo without
+# loading their full context. Silent when there is nothing to surface.
+#
+# This script is best-effort: any error must not block session start.
+
+set -uo pipefail
+
+MAX_SHOWN=3
+STALE_DAYS=14
+
+open_helper="${HOME}/.claude/skills/followup/scripts/followup-open.sh"
+[[ -x "$open_helper" ]] || exit 0
+
+# Only surface inside a git repo with a parseable GitHub origin.
+git rev-parse --git-dir > /dev/null 2>&1 || exit 0
+remote_url=$(git remote get-url origin 2>/dev/null) || exit 0
+[[ "$remote_url" =~ github\.com[:/]([^/]+)/([^/.]+)(\.git)?$ ]] || exit 0
+repo="${BASH_REMATCH[1]}/${BASH_REMATCH[2]}"
+
+open_lines=$("$open_helper" 2>/dev/null) || exit 0
+[[ -n "$open_lines" ]] || exit 0
+
+here=$(printf '%s\n' "$open_lines" | grep -F "[${repo}" || true)
+other=$(printf '%s\n' "$open_lines" | grep -vF "[${repo}" | grep -c . || true)
+
+if [[ -z "$here" ]]; then
+    [[ "$other" -gt 0 ]] && echo "[followup] ${other} open follow-up(s) in other repos — /followup list"
+    exit 0
+fi
+
+here_count=$(printf '%s\n' "$here" | grep -c . || true)
+
+echo "[followup] Open follow-ups for ${repo}:"
+printf '%s\n' "$here" | head -n "$MAX_SHOWN" | sed 's/^- \[ \] /  • /'
+
+summary=""
+[[ "$here_count" -gt "$MAX_SHOWN" ]] && summary="+$((here_count - MAX_SHOWN)) more here"
+[[ "$other" -gt 0 ]] && summary="${summary:+${summary} · }${other} open in other repos"
+[[ -n "$summary" ]] && echo "  (${summary} — /followup list)"
+
+# Staleness nudge: the file is newest-first, so the oldest item here is the last line.
+oldest="${here##*$'\n'}"
+if [[ "$oldest" =~ ^-\ \[\ \]\ ([0-9]{4}-[0-9]{2}-[0-9]{2}) ]]; then
+    oldest_epoch=$(date -j -f %Y-%m-%d "${BASH_REMATCH[1]}" +%s 2>/dev/null || echo "")
+    if [[ -n "$oldest_epoch" ]]; then
+        age_days=$(( ($(date +%s) - oldest_epoch) / 86400 ))
+        if [[ "$age_days" -gt "$STALE_DAYS" ]]; then
+            echo "  ⚠ oldest open follow-up here is ${age_days}d old — consider /followup review"
+        fi
+    fi
+fi
+
+exit 0

--- a/ai/skills/followup/scripts/followup-open.sh
+++ b/ai/skills/followup/scripts/followup-open.sh
@@ -3,7 +3,7 @@
 #
 # Usage: followup-open.sh [org/repo]
 #
-# The single owner of the open-item grammar (`- [ ]` lines in the followups
+# The single owner of open-item selection (`- [ ]` lines in the followups
 # file) — other scripts and skills call this instead of re-deriving the grep.
 # Prints nothing (exit 0) when the file is missing or no items match.
 
@@ -14,8 +14,11 @@ FOLLOWUPS_FILE="${FOLLOWUPS_FILE:-$HOME/dev/haacked/notes/PostHog/Followups.md}"
 [[ -f "$FOLLOWUPS_FILE" ]] || exit 0
 
 if [[ $# -ge 1 && -n "$1" ]]; then
-    # Anchor on " ·" or "]" so one repo name can't prefix-match another (posthog vs posthog-js).
-    grep '^- \[ \]' "$FOLLOWUPS_FILE" | grep -F -e "[${1} ·" -e "[${1}]" || true
+    # Anchor the context bracket to its fixed position after the date so a repo
+    # name in an item's body can't cross-match another repo's filter, and one
+    # repo name can't prefix-match another (posthog vs posthog-js).
+    re_repo=${1//./\\.}
+    grep -E "^- \[ \] [0-9]{4}-[0-9]{2}-[0-9]{2} · \[${re_repo}( ·|\])" "$FOLLOWUPS_FILE" || true
 else
     grep '^- \[ \]' "$FOLLOWUPS_FILE" || true
 fi

--- a/ai/skills/followup/scripts/followup-open.sh
+++ b/ai/skills/followup/scripts/followup-open.sh
@@ -14,7 +14,8 @@ FOLLOWUPS_FILE="${FOLLOWUPS_FILE:-$HOME/dev/haacked/notes/PostHog/Followups.md}"
 [[ -f "$FOLLOWUPS_FILE" ]] || exit 0
 
 if [[ $# -ge 1 && -n "$1" ]]; then
-    grep '^- \[ \]' "$FOLLOWUPS_FILE" | grep -F "[${1}" || true
+    # Anchor on " ·" or "]" so one repo name can't prefix-match another (posthog vs posthog-js).
+    grep '^- \[ \]' "$FOLLOWUPS_FILE" | grep -F -e "[${1} ·" -e "[${1}]" || true
 else
     grep '^- \[ \]' "$FOLLOWUPS_FILE" || true
 fi

--- a/ai/skills/followup/scripts/followup-open.sh
+++ b/ai/skills/followup/scripts/followup-open.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Print open follow-up items, newest first, optionally filtered to one org/repo.
+#
+# Usage: followup-open.sh [org/repo]
+#
+# The single owner of the open-item grammar (`- [ ]` lines in the followups
+# file) — other scripts and skills call this instead of re-deriving the grep.
+# Prints nothing (exit 0) when the file is missing or no items match.
+
+set -euo pipefail
+
+FOLLOWUPS_FILE="${FOLLOWUPS_FILE:-$HOME/dev/haacked/notes/PostHog/Followups.md}"
+
+[[ -f "$FOLLOWUPS_FILE" ]] || exit 0
+
+if [[ $# -ge 1 && -n "$1" ]]; then
+    grep '^- \[ \]' "$FOLLOWUPS_FILE" | grep -F "[${1}" || true
+else
+    grep '^- \[ \]' "$FOLLOWUPS_FILE" || true
+fi

--- a/ai/skills/followup/scripts/followup-open.sh
+++ b/ai/skills/followup/scripts/followup-open.sh
@@ -16,9 +16,10 @@ FOLLOWUPS_FILE="${FOLLOWUPS_FILE:-$HOME/dev/haacked/notes/PostHog/Followups.md}"
 if [[ $# -ge 1 && -n "$1" ]]; then
     # Anchor the context bracket to its fixed position after the date so a repo
     # name in an item's body can't cross-match another repo's filter, and one
-    # repo name can't prefix-match another (posthog vs posthog-js).
+    # repo name can't prefix-match another (posthog vs posthog-js). Matching is
+    # case-insensitive because GitHub treats org/repo casing as equivalent.
     re_repo=${1//./\\.}
-    grep -E "^- \[ \] [0-9]{4}-[0-9]{2}-[0-9]{2} · \[${re_repo}( ·|\])" "$FOLLOWUPS_FILE" || true
+    grep -iE "^- \[ \] [0-9]{4}-[0-9]{2}-[0-9]{2} · \[${re_repo}( ·|\])" "$FOLLOWUPS_FILE" || true
 else
     grep '^- \[ \]' "$FOLLOWUPS_FILE" || true
 fi

--- a/ai/skills/followup/scripts/tests/test-followup.sh
+++ b/ai/skills/followup/scripts/tests/test-followup.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 OPEN="${SCRIPT_DIR}/../followup-open.sh"
 ADD="${SCRIPT_DIR}/../followup-add.sh"
+DETECT="${SCRIPT_DIR}/../followup-detect.sh"
 
 passes=0
 failures=0
@@ -33,6 +34,19 @@ fixture \
     '- [ ] 2026-08-12 · [PostHog/posthog] no-branch'
 check "posthog filter excludes posthog-js" "$("$OPEN" PostHog/posthog | grep -c .)" "2"
 check "posthog-js filter matches only js" "$("$OPEN" PostHog/posthog-js | grep -c .)" "1"
+check "filter is case-insensitive" "$("$OPEN" posthog/POSTHOG | grep -c .)" "2"
+
+# Staleness nudge: min date across items, independent of file order. The detect
+# hook only speaks inside a repo with a GitHub origin, so fake one.
+R=$(mktemp -d)
+git -C "$R" init -q
+git -C "$R" remote add origin git@github.com:PostHog/posthog.git
+fixture \
+    '- [ ] 2026-01-01 · [PostHog/posthog · b] ancient but not last' \
+    '- [ ] 2099-01-01 · [PostHog/posthog · b] future item sorts last'
+out=$(cd "$R" && FOLLOWUPS_FILE="$FOLLOWUPS_FILE" "$DETECT")
+check "staleness uses min date not last line" "$(grep -c 'consider /followup review' <<< "$out")" "1"
+rm -rf "$R"
 
 # Position anchor: a context-style bracket in the body must not cross-match.
 fixture \

--- a/ai/skills/followup/scripts/tests/test-followup.sh
+++ b/ai/skills/followup/scripts/tests/test-followup.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Tests for followup-open.sh (open-item selection) and followup-add.sh (insert contract).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+OPEN="${SCRIPT_DIR}/../followup-open.sh"
+ADD="${SCRIPT_DIR}/../followup-add.sh"
+
+passes=0
+failures=0
+
+check() { # desc actual expected
+    if [[ "$2" == "$3" ]]; then
+        passes=$((passes + 1))
+    else
+        echo "FAIL: $1"
+        echo "  expected [$3], got [$2]"
+        failures=$((failures + 1))
+    fi
+}
+
+fixture() { # writes $FOLLOWUPS_FILE with the given item lines
+    { printf '# Followups\n\n## Open\n\n'; printf '%s\n' "$@"; printf '\n## Archive\n'; } > "$FOLLOWUPS_FILE"
+}
+
+export FOLLOWUPS_FILE
+FOLLOWUPS_FILE=$(mktemp)
+
+# Anchored filter: one repo name must not prefix-match another.
+fixture \
+    '- [ ] 2026-08-10 · [PostHog/posthog · b1] core' \
+    '- [ ] 2026-08-11 · [PostHog/posthog-js · b2] js' \
+    '- [ ] 2026-08-12 · [PostHog/posthog] no-branch'
+check "posthog filter excludes posthog-js" "$("$OPEN" PostHog/posthog | grep -c .)" "2"
+check "posthog-js filter matches only js" "$("$OPEN" PostHog/posthog-js | grep -c .)" "1"
+
+# Position anchor: a context-style bracket in the body must not cross-match.
+fixture \
+    '- [ ] 2026-08-13 · [haacked/notes · main] mentions [PostHog/posthog] in body' \
+    '- [ ] 2026-08-14 · [PostHog/posthog · main] real item'
+check "body-text bracket does not cross-match" "$("$OPEN" PostHog/posthog | grep -c .)" "1"
+
+# Closed items are not open.
+fixture \
+    '- [ ] 2026-08-14 · [PostHog/posthog · b] open one' \
+    '- [x] 2026-08-01 · [PostHog/posthog · b] done — closed 2026-08-02'
+check "closed item excluded from open" "$("$OPEN" | grep -c .)" "1"
+
+# Insert contract: fresh skeleton, newest-first, blank lines intact.
+FOLLOWUPS_FILE=$(mktemp) && rm -f "$FOLLOWUPS_FILE"
+"$ADD" "first" > /dev/null
+"$ADD" "second" > /dev/null
+check "two items present" "$(grep -c '^- \[ \]' "$FOLLOWUPS_FILE")" "2"
+check "newest first" "$(grep '^- \[ \]' "$FOLLOWUPS_FILE" | head -1 | grep -c second)" "1"
+check "blank line kept after ## Open" "$(grep -A1 '^## Open$' "$FOLLOWUPS_FILE" | sed -n '2p')" ""
+check "blank line kept before ## Archive" "$(grep -B1 '^## Archive$' "$FOLLOWUPS_FILE" | sed -n '1p')" ""
+
+# Item text containing '## Open' must not create a second insert point.
+FOLLOWUPS_FILE=$(mktemp) && rm -f "$FOLLOWUPS_FILE"
+"$ADD" 'reword the ## Open heading' > /dev/null
+"$ADD" 'x' > /dev/null
+check "no double insert on heading-like text" "$(grep -c '^- \[ \]' "$FOLLOWUPS_FILE")" "2"
+
+# Escaping: backslashes, ampersands, and slashes survive the awk insert.
+FOLLOWUPS_FILE=$(mktemp) && rm -f "$FOLLOWUPS_FILE"
+"$ADD" 'tricky \back & amp /sl/ash' > /dev/null
+check "escaping survives" "$(grep -cF 'tricky \back & amp /sl/ash' "$FOLLOWUPS_FILE")" "1"
+
+echo ""
+echo "Passed: ${passes}, Failed: ${failures}"
+[[ "${failures}" -eq 0 ]]

--- a/ai/skills/go/SKILL.md
+++ b/ai/skills/go/SKILL.md
@@ -177,5 +177,6 @@ Tell the user what happened:
 - The PR URL (`gh pr view --json url -q .url`)
 - Any outstanding findings — check `.notes/review-skipped.md` for Claude's deferred items and the Copilot state file under `~/.local/state/copilot-review-loop/` for low-confidence Copilot items flagged for human review.
 - Any drafted replies to human reviewers the loop printed under "Human Reviewer Replies to Post" — these are not posted automatically; surface them so the user can review and post.
+- Offer to capture any outstanding findings the user wants to keep as `/followup` items.
 
 If any step exited non-zero, tell the user which one and where the logs are (`.notes/` for Claude, `~/.local/state/copilot-review-loop/` for Copilot).

--- a/ai/skills/go/SKILL.md
+++ b/ai/skills/go/SKILL.md
@@ -175,8 +175,7 @@ Tell the user what happened:
 
 - Commits added during the run (`git log @{u}..HEAD --oneline` or the range since the initial commit from Step 4)
 - The PR URL (`gh pr view --json url -q .url`)
-- Any outstanding findings — check `.notes/review-skipped.md` for Claude's deferred items and the Copilot state file under `~/.local/state/copilot-review-loop/` for low-confidence Copilot items flagged for human review.
+- Any outstanding findings — check `.notes/review-skipped.md` for Claude's deferred items and the Copilot state file under `~/.local/state/copilot-review-loop/` for low-confidence Copilot items flagged for human review. Offer to capture any the user wants to keep as `/followup` items.
 - Any drafted replies to human reviewers the loop printed under "Human Reviewer Replies to Post" — these are not posted automatically; surface them so the user can review and post.
-- Offer to capture any outstanding findings the user wants to keep as `/followup` items.
 
 If any step exited non-zero, tell the user which one and where the logs are (`.notes/` for Claude, `~/.local/state/copilot-review-loop/` for Copilot).

--- a/ai/skills/standup/SKILL.md
+++ b/ai/skills/standup/SKILL.md
@@ -97,6 +97,16 @@ gh api search/issues --method GET -f q="author:haacked org:PostHog is:pr is:open
 
 Note: This single query replaces per-repo `gh pr list` calls and also covers the "recently updated" signal via `updatedAt`. Filter to items updated since `last_standup_date` to identify PRs with recent activity. Route core (feature-flags domain) open PRs to **Working on**; route non-core open PRs to **Side quests** with state **In progress**. The search API does not return review requests; for non-draft open PRs, batch-fetch them (`--json reviewRequests --jq '[.reviewRequests[].login] | join(",")'`).
 
+### Step 3b: Read Open Follow-ups
+
+Read open follow-up items for the Step 5 display:
+
+```bash
+~/.claude/skills/followup/scripts/followup-open.sh 2>/dev/null || true
+```
+
+Note each item's age from its leading date. These are personal working state for the Step 5 report only — they never go into the standup file or the clipboard HTML.
+
 ### Step 4: Compose and Save Standup Notes
 
 Build standup content and produce two outputs: a plain text archive file and HTML for the clipboard.
@@ -171,3 +181,4 @@ Display:
 1. The generated standup notes (plain text version for review)
 2. The file path for easy access
 3. A message: "✅ Copied to clipboard as rich text; paste directly into Slack!"
+4. An **Open follow-ups** section from Step 3b: each open item with its age in days, flagging any older than 14 days. Display-only — it is not part of the standup file or the clipboard HTML. When an item matches a Working on PR, note that inline.

--- a/ai/skills/standup/SKILL.md
+++ b/ai/skills/standup/SKILL.md
@@ -181,4 +181,4 @@ Display:
 1. The generated standup notes (plain text version for review)
 2. The file path for easy access
 3. A message: "✅ Copied to clipboard as rich text; paste directly into Slack!"
-4. An **Open follow-ups** section from Step 3b: each open item with its age in days, flagging any older than 14 days. Display-only — it is not part of the standup file or the clipboard HTML. When an item matches a Working on PR, note that inline.
+4. An **Open follow-ups** section from Step 3b: each open item with its age in days, flagging any older than 14 days. Display-only — it is not part of the standup file or the clipboard HTML. When an item references the same PR or branch as a Working on entry, note that inline.

--- a/ai/skills/standup/SKILL.md
+++ b/ai/skills/standup/SKILL.md
@@ -181,4 +181,4 @@ Display:
 1. The generated standup notes (plain text version for review)
 2. The file path for easy access
 3. A message: "✅ Copied to clipboard as rich text; paste directly into Slack!"
-4. An **Open follow-ups** section from Step 3b: each open item with its age in days, flagging any older than 14 days. Display-only — it is not part of the standup file or the clipboard HTML. When an item references the same PR or branch as a Working on entry, note that inline.
+4. An **Open follow-ups** section from Step 3b: each open item with its age in days, flagging any older than 14 days (`STALE_DAYS` in followup-detect.sh). Display-only — it is not part of the standup file or the clipboard HTML. When an item references the same PR or branch as a Working on entry, note that inline.


### PR DESCRIPTION
- `/followup <text>` captures an item into `PostHog/Followups.md` in the notes vault with date, org/repo, and branch context. `list`, `done <match>`, `drop <match>`, and `review` modes manage the same file; closed items get swept to an Archive section during review.
- A SessionStart hook (`followup-detect.sh`) prints up to 3 open items for the current repo plus a count of the rest, with a staleness nudge past 14 days. It's registered as a new element in `HOOKS_CONFIG` rather than a second command in the handoff element, because the jq deep-merge dedupes whole array elements: editing the existing element would leave the old copy behind in existing installs and fire handoff twice.
- `followup-open.sh` owns the open-item grammar. The detect hook, `followup-add.sh`, and the standup skill read through it instead of re-deriving the grep. `/standup` now displays open follow-ups (display only, never in the archived standup file or the clipboard HTML) and `/go` step 9 offers to capture leftover review findings.

## Test plan

- `shellcheck` clean on all three scripts.
- Add path exercised against a temp file: empty-section insert keeps blank lines markdownlint-clean, newest-first ordering holds, `[no-repo]` is used outside git, and text with backslashes, ampersands, slashes, and quotes survives intact (awk reads the text via ENVIRON because sed and `awk -v` both mangle escapes).
- Detect path: prints items in the matching repo, a summary line from other repos, and stays silent outside git or with zero items; the truncation summary and 14-day stale nudge both verified.
- `bash -n ai/install.sh` passes and `HOOKS_CONFIG` parses as JSON with handoff and followup as separate SessionStart elements.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*