### PR TITLE
Point non-PostHog notes and plans at the vault Dev/ area

### DIFF
--- a/ai/CLAUDE.md
+++ b/ai/CLAUDE.md
@@ -23,9 +23,9 @@ After 2 failed attempts, stop and use `bug-root-cause-analyzer`. Don't keep push
 ### Documentation Locations
 
 - **Plans (PostHog repos)**: `~/dev/haacked/notes/PostHog/repositories/{repo}/plans/{slug}.md`
-- **Notes (PostHog repos)**: `~/dev/haacked/notes/PostHog/repositories/{repo}/{topic}.md`
+- **Notes (PostHog repos)**: `~/dev/haacked/notes/PostHog/repositories/{repo}/{slug}.md`
 - **Plans (other repos)**: `~/dev/haacked/notes/Dev/repositories/{org}/{repo}/plans/{slug}.md`
-- **Notes (other repos)**: `~/dev/haacked/notes/Dev/repositories/{org}/{repo}/{topic}.md`
+- **Notes (other repos)**: `~/dev/haacked/notes/Dev/repositories/{org}/{repo}/{slug}.md`
 
 When a plan is implemented/merged, move it to `plans/archive/` within the same repo directory.
 

--- a/ai/CLAUDE.md
+++ b/ai/CLAUDE.md
@@ -24,8 +24,8 @@ After 2 failed attempts, stop and use `bug-root-cause-analyzer`. Don't keep push
 
 - **Plans (PostHog repos)**: `~/dev/haacked/notes/PostHog/repositories/{repo}/plans/{slug}.md`
 - **Notes (PostHog repos)**: `~/dev/haacked/notes/PostHog/repositories/{repo}/{topic}.md`
-- **Plans (other repos)**: `~/dev/ai/plans/{org}/{repo}/{slug}.md`
-- **Notes (other repos)**: `~/dev/ai/notes/`
+- **Plans (other repos)**: `~/dev/haacked/notes/Dev/repositories/{org}/{repo}/plans/{slug}.md`
+- **Notes (other repos)**: `~/dev/haacked/notes/Dev/repositories/{org}/{repo}/{topic}.md`
 
 When a plan is implemented/merged, move it to `plans/archive/` within the same repo directory.
 

--- a/ai/agents/implementation-planner.md
+++ b/ai/agents/implementation-planner.md
@@ -55,7 +55,7 @@ For each identified risk, specify:
 - **Mitigation Strategy**: Specific steps to prevent or handle the risk
 
 ### 5. **Implementation Plan Creation**
-Break the work into 3-5 logical stages. Always create an implementation plan file in `~/dev/ai/plans/{org}/{repo}/{issue-or-pr-or-branch-name-or-plan-slug}.md` (use issue/PR number when applicable, otherwise the branch name, otherwise use descriptive slug (for example, if we are working on more than one plan in the branch.))
+Break the work into 3-5 logical stages. Always create an implementation plan file in `~/dev/haacked/notes/Dev/repositories/{org}/{repo}/plans/{issue-or-pr-or-branch-name-or-plan-slug}.md` for non-PostHog repos, or `~/dev/haacked/notes/PostHog/repositories/{repo}/plans/…` for PostHog repos (use issue/PR number when applicable, otherwise the branch name, otherwise use descriptive slug (for example, if we are working on more than one plan in the branch.))
 
 ### 6. **Quality Gates Definition**
 For each stage, specify:

--- a/ai/agents/implementation-planner.md
+++ b/ai/agents/implementation-planner.md
@@ -55,7 +55,12 @@ For each identified risk, specify:
 - **Mitigation Strategy**: Specific steps to prevent or handle the risk
 
 ### 5. **Implementation Plan Creation**
-Break the work into 3-5 logical stages. Always create an implementation plan file in `~/dev/haacked/notes/Dev/repositories/{org}/{repo}/plans/{issue-or-pr-or-branch-name-or-plan-slug}.md` for non-PostHog repos, or `~/dev/haacked/notes/PostHog/repositories/{repo}/plans/…` for PostHog repos (use issue/PR number when applicable, otherwise the branch name, otherwise use descriptive slug (for example, if we are working on more than one plan in the branch.))
+Break the work into 3-5 logical stages. Always create an implementation plan file:
+
+- Non-PostHog repos: `~/dev/haacked/notes/Dev/repositories/{org}/{repo}/plans/{slug}.md`
+- PostHog repos: `~/dev/haacked/notes/PostHog/repositories/{repo}/plans/{slug}.md`
+
+For the `{slug}`, use the issue/PR number when applicable, otherwise the branch name, otherwise a descriptive slug (for example, when working on more than one plan in the branch).
 
 ### 6. **Quality Gates Definition**
 For each stage, specify:

--- a/ai/agents/support.md
+++ b/ai/agents/support.md
@@ -133,7 +133,7 @@ This agent creates **support notes** in `~/dev/ai/support/`. These are:
 - Time-bounded (organized by week)
 - Used for weekly support log summaries
 
-If during investigation you discover **reusable technical knowledge** that would benefit future development (not just this ticket), spawn the `note-taker` agent separately. That agent creates notes in `~/dev/ai/notes/{org}/{repo}/` for:
+If during investigation you discover **reusable technical knowledge** that would benefit future development (not just this ticket), spawn the `note-taker` agent separately. That agent creates notes in `~/dev/haacked/notes/Dev/repositories/{org}/{repo}/` (or `~/dev/haacked/notes/PostHog/repositories/{repo}/` for PostHog repos) for:
 
 - System behavior documentation
 - Non-obvious technical discoveries

--- a/ai/skills/go/SKILL.md
+++ b/ai/skills/go/SKILL.md
@@ -54,7 +54,7 @@ repo=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null || echo "
 branch=$(git branch --show-current)
 case "$repo" in
   PostHog/*) plan_dir="$HOME/dev/haacked/notes/PostHog/repositories/${repo#PostHog/}/plans" ;;
-  */*)       plan_dir="$HOME/dev/ai/plans/$repo" ;;
+  */*)       plan_dir="$HOME/dev/haacked/notes/Dev/repositories/$repo/plans" ;;
   *)         plan_dir="" ;;
 esac
 ```

--- a/ai/skills/note/SKILL.md
+++ b/ai/skills/note/SKILL.md
@@ -83,7 +83,7 @@ status=$(echo "$result" | cut -f1)
 note_path=$(echo "$result" | cut -f2)
 ```
 
-Never construct paths manually — the script derives org/repo from the current git repository, builds the path `~/dev/ai/notes/{org}/{repo}/{slug}.md`, and validates the slug format.
+Never construct paths manually — the script derives org/repo from the current git repository, builds the path (`~/dev/haacked/notes/PostHog/repositories/{repo}/{slug}.md` for PostHog repos, `~/dev/haacked/notes/Dev/repositories/{org}/{repo}/{slug}.md` otherwise), and validates the slug format.
 
 If `status` is `found`: tell the user the existing note path and that you're updating it, then read the current content and add new discoveries while preserving existing knowledge.
 

--- a/ai/skills/note/scripts/note-find-or-create.sh
+++ b/ai/skills/note/scripts/note-find-or-create.sh
@@ -57,7 +57,7 @@ if [[ "$org_lower" == "posthog" ]]; then
     notes_base="$HOME/dev/haacked/notes/PostHog/repositories"
     note_path="${notes_base}/${repo}/${slug}.md"
 else
-    notes_base="$HOME/dev/ai/notes"
+    notes_base="$HOME/dev/haacked/notes/Dev/repositories"
     note_path="${notes_base}/${org}/${repo}/${slug}.md"
 fi
 

--- a/ai/skills/note/scripts/note-find.sh
+++ b/ai/skills/note/scripts/note-find.sh
@@ -56,7 +56,7 @@ if [[ "$org_lower" == "posthog" ]]; then
     notes_base="$HOME/dev/haacked/notes/PostHog/repositories"
     note_path="${notes_base}/${repo}/${slug}.md"
 else
-    notes_base="$HOME/dev/ai/notes"
+    notes_base="$HOME/dev/haacked/notes/Dev/repositories"
     note_path="${notes_base}/${org}/${repo}/${slug}.md"
 fi
 

--- a/ai/skills/note/scripts/note-list.sh
+++ b/ai/skills/note/scripts/note-list.sh
@@ -40,7 +40,7 @@ org_lower=$(echo "$org" | tr '[:upper:]' '[:lower:]')
 if [[ "$org_lower" == "posthog" ]]; then
     notes_dir="$HOME/dev/haacked/notes/PostHog/repositories/${repo}"
 else
-    notes_dir="$HOME/dev/ai/notes/${org}/${repo}"
+    notes_dir="$HOME/dev/haacked/notes/Dev/repositories/${org}/${repo}"
 fi
 
 # Check if notes directory exists

--- a/ai/skills/support/SKILL.md
+++ b/ai/skills/support/SKILL.md
@@ -137,4 +137,4 @@ Save the log to `~/dev/ai/support/HIGHLIGHTS-{monday}.md`. Then offer to copy it
 | Time-bounded support work | Knowledge persisting beyond a ticket |
 | Customer-specific investigation | Cross-cutting insights from multiple cases |
 
-If you discover something during support that should be permanent technical docs, spawn `note-taker` separately to capture it under `~/dev/ai/notes/`.
+If you discover something during support that should be permanent technical docs, spawn `note-taker` separately to capture it in the notes vault (`~/dev/haacked/notes/Dev/repositories/` or `PostHog/repositories/`).

--- a/ai/skills/support/SKILL.md
+++ b/ai/skills/support/SKILL.md
@@ -137,4 +137,4 @@ Save the log to `~/dev/ai/support/HIGHLIGHTS-{monday}.md`. Then offer to copy it
 | Time-bounded support work | Knowledge persisting beyond a ticket |
 | Customer-specific investigation | Cross-cutting insights from multiple cases |
 
-If you discover something during support that should be permanent technical docs, spawn `note-taker` separately to capture it in the notes vault (`~/dev/haacked/notes/Dev/repositories/` or `PostHog/repositories/`).
+If you discover something during support that should be permanent technical docs, spawn `note-taker` separately to capture it in the notes vault (`~/dev/haacked/notes/Dev/repositories/` or `~/dev/haacked/notes/PostHog/repositories/`).


### PR DESCRIPTION
The knowledge content from ~/dev/ai (notes, plans, the postmortem, NOTES.md) moved into the notes vault under Dev/repositories/{org}/{repo}/, mirroring the PostHog vault shape, so it's git-backed and one tree with everything agents search. This PR updates every path reference: the three note scripts, /go's plan_dir, implementation-planner's plan location, and the CLAUDE.md documentation-locations table.

Two things deliberately stay at ~/dev/ai and keep their existing references: reviews/ (code-review tooling state: ~800 generated artifacts plus the live context files the review-code skill reads) and support/ (its own git repository with active zendesk worktrees; moving it would break them). A tombstone README at ~/dev/ai documents both.

## Test plan

- `shellcheck` clean on the three note scripts.
- `note-find-or-create.sh secretive-commit-signing` from the dotfiles repo returns `found` at the new vault path.
- `note-list.sh` from the dotfiles repo lists both migrated notes.
- `grep -rln "dev/ai" ai/` returns only the support skill/agent and code-reviewer files, whose targets did not move.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*