### PR TITLE
Add /vault skill for the ingest/lint/status knowledge loop

### DIFF
--- a/ai/skills/vault/SKILL.md
+++ b/ai/skills/vault/SKILL.md
@@ -7,7 +7,7 @@ model: sonnet
 
 # Vault Operations
 
-The knowledge loop over the notes vault at `~/dev/haacked/notes`. The schema (raw vs wiki vs working docs, the log rules) lives in `PostHog/CLAUDE.md` — read it before any operation. The operations log `PostHog/log.md` is both history and the ingest ledger.
+The knowledge loop over the PostHog work vault at `~/dev/haacked/notes/PostHog` (paths below are relative to `~/dev/haacked/notes`). The schema (raw vs wiki vs working docs, the log rules) lives in `PostHog/CLAUDE.md` — read it before any operation. The operations log `PostHog/log.md` is both history and the ingest ledger.
 
 ## Modes
 

--- a/ai/skills/vault/SKILL.md
+++ b/ai/skills/vault/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: vault
+description: Operate the notes vault knowledge loop — ingest raw sources (standups, ops reports, meeting transcripts, URLs) into interlinked wiki pages, lint vault health, or show the ingest backlog. Use when the user runs /vault, asks to turn meeting notes or reports into knowledge, or wants a vault health check.
+argument-hint: "[ingest [path|url|--tranche N] | lint [area] | status]"
+model: sonnet
+---
+
+# Vault Operations
+
+The knowledge loop over the notes vault at `~/dev/haacked/notes`. The schema (raw vs wiki vs working docs, the log rules) lives in `PostHog/CLAUDE.md` — read it before any operation. The operations log `PostHog/log.md` is both history and the ingest ledger.
+
+## Modes
+
+Parse the first argument from user input.
+
+| Argument | Mode |
+| --- | --- |
+| `ingest [path\|url\|--tranche N]` | **ingest** — distill raw sources into wiki pages |
+| `lint [area]` | **lint** — vault health check |
+| `status` | **status** — backlog and recent activity |
+
+## Ingest mode
+
+One source at a time — stay bounded, stay involved.
+
+1. Resolve the target: an explicit vault-relative path or URL from the argument, else run the helper to pick the oldest unprocessed raw source:
+
+```bash
+~/.claude/skills/vault/scripts/vault-next-source.sh
+```
+
+It prints the oldest raw file not yet named by an `ingest |` log entry (stderr shows the remaining backlog count). `--tranche N` mode: call with `N` to get the N oldest and process each one fully, with its own log entry, before starting the next.
+
+2. Read the source, then `PostHog/Home.md`, then only the wiki pages the source plausibly touches — index-first navigation, never a bulk scan.
+3. Rewrite or create the affected wiki pages, bounded to ~10-15 pages per source. Distill, don't transcribe: capture decisions, facts, and system knowledge, not meeting play-by-play. Add `[[wikilinks]]` in both directions. Update `Home.md` only if a new area appeared. **Never modify the raw source.**
+4. Append the ledger entry to `PostHog/log.md` — it MUST contain the source's vault-relative path (that string is what marks the source processed):
+
+```markdown
+## [YYYY-MM-DD] ingest | <short title>
+
+Source: `2026/07/Feature Flags - Growth Review.md`. Updated: [[page-one]], [[page-two]]. New: [[page-three]].
+```
+
+5. Report: source, pages updated/created, anything deliberately skipped.
+
+Sources with nothing durable in them (a standup that's all PR links already tracked elsewhere, a meeting with no decisions) still get their log entry — `Updated: none — no durable knowledge` — so the backlog shrinks honestly.
+
+## Lint mode
+
+Mechanical first, judgment second; scope judgment to `[area]` (a folder like `repositories/posthog` or `reference`) or pick a rotating slice — never the whole vault in one pass.
+
+1. Mechanical checks:
+
+```bash
+cd ~/dev/haacked/notes && markdownlint-cli2 "PostHog/**/*.md"
+~/.claude/skills/vault/scripts/vault-lint-links.sh
+```
+
+The links helper reports dead `[[wikilinks]]` and orphan wiki pages (no inbound links). Also check for loose files in vault roots and empty directories (convention violations per the schema).
+
+2. Judgment checks over the scoped area only: contradictions between wiki pages, stale claims (dated assertions that no longer hold), missing cross-links between obviously related pages.
+3. Fix mechanical issues after a y/n confirmation. Report judgment issues as a checklist; offer to capture deferred ones as `/followup` items.
+4. Append a `lint |` entry to `PostHog/log.md` summarizing what was checked and fixed.
+
+## Status mode
+
+Report, using one Bash call where possible:
+
+- Ingest backlog: `~/.claude/skills/vault/scripts/vault-next-source.sh all | grep -c .`
+- Pages touched in the last 7 days: recent `## [date]` entries in `PostHog/log.md`
+- Open follow-ups: `~/.claude/skills/followup/scripts/followup-open.sh | grep -c .`
+- Last lint: most recent `lint |` entry in `PostHog/log.md` (or "never")
+
+## Boundary: /vault vs /note vs /followup
+
+| `/vault` | `/note` | `/followup` |
+| --- | --- | --- |
+| In-vault operations loop (ingest, lint) | Capture from a code-repo session into the vault | Capture a "do this later" item |
+| Works the raw → wiki pipeline | Writes one topic note | Writes one checklist line |

--- a/ai/skills/vault/SKILL.md
+++ b/ai/skills/vault/SKILL.md
@@ -33,7 +33,7 @@ It prints the oldest raw file not yet named by an `ingest |` log entry (stderr s
 
 2. Read the source, then `PostHog/Home.md`, then only the wiki pages the source plausibly touches — index-first navigation, never a bulk scan.
 3. Rewrite or create the affected wiki pages, bounded to ~10-15 pages per source. Distill, don't transcribe: capture decisions, facts, and system knowledge, not meeting play-by-play. Add `[[wikilinks]]` in both directions. Update `Home.md` only if a new area appeared. **Never modify the raw source.**
-4. Append the ledger entry to `PostHog/log.md` — it MUST contain the source's vault-relative path (that string is what marks the source processed):
+4. Append the ledger entry to `PostHog/log.md` — it MUST contain the source's backtick-wrapped vault-relative path, extension included (that exact token is what marks the source processed):
 
 ```markdown
 ## [YYYY-MM-DD] ingest | <short title>
@@ -67,7 +67,7 @@ The links helper reports dead `[[wikilinks]]` and orphan wiki pages (no inbound 
 Report, using one Bash call where possible:
 
 - Ingest backlog: `~/.claude/skills/vault/scripts/vault-next-source.sh all | grep -c .`
-- Pages touched in the last 7 days: recent `## [date]` entries in `PostHog/log.md`
+- Recent activity: the latest few `## [date]` entries in `PostHog/log.md`
 - Open follow-ups: `~/.claude/skills/followup/scripts/followup-open.sh 2>/dev/null | grep -c .` (reports 0 when the followup skill isn't installed)
 - Last lint: most recent `lint |` entry in `PostHog/log.md` (or "never")
 

--- a/ai/skills/vault/SKILL.md
+++ b/ai/skills/vault/SKILL.md
@@ -68,7 +68,7 @@ Report, using one Bash call where possible:
 
 - Ingest backlog: `~/.claude/skills/vault/scripts/vault-next-source.sh all | grep -c .`
 - Pages touched in the last 7 days: recent `## [date]` entries in `PostHog/log.md`
-- Open follow-ups: `~/.claude/skills/followup/scripts/followup-open.sh | grep -c .`
+- Open follow-ups: `~/.claude/skills/followup/scripts/followup-open.sh 2>/dev/null | grep -c .` (reports 0 when the followup skill isn't installed)
 - Last lint: most recent `lint |` entry in `PostHog/log.md` (or "never")
 
 ## Boundary: /vault vs /note vs /followup

--- a/ai/skills/vault/scripts/tests/test-vault.sh
+++ b/ai/skills/vault/scripts/tests/test-vault.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Tests for vault-next-source.sh (ledger matching) and vault-lint-links.sh (link extraction).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+NEXT="${SCRIPT_DIR}/../vault-next-source.sh"
+LINT="${SCRIPT_DIR}/../vault-lint-links.sh"
+
+passes=0
+failures=0
+
+check() { # desc actual expected
+    if [[ "$2" == "$3" ]]; then
+        passes=$((passes + 1))
+    else
+        echo "FAIL: $1"
+        echo "  expected [$3], got [$2]"
+        failures=$((failures + 1))
+    fi
+}
+
+V=$(mktemp -d)
+trap 'rm -rf "$V"' EXIT
+
+# --- vault-next-source.sh: ledger matching ---
+mkdir -p "$V/standup" "$V/daily"
+printf 'x\n' > "$V/standup/2026-08-10.md"
+printf 'y\n' > "$V/standup/2026-08-10-part2.md"
+printf 'z\n' > "$V/daily/2026-08-11.md"
+cat > "$V/log.md" <<'EOF'
+# Operations Log
+
+## [2026-08-11] ingest | recap
+
+Source: `standup/2026-08-10-part2.md`. Updated: [[a]].
+EOF
+
+check "prefix sibling stays in backlog" "$(VAULT="$V" "$NEXT" all 2>/dev/null | grep -cF 'standup/2026-08-10.md')" "1"
+check "ingested source marked processed" "$(VAULT="$V" "$NEXT" all 2>/dev/null | grep -cF 'standup/2026-08-10-part2.md' || true)" "0"
+check "backlog count" "$(VAULT="$V" "$NEXT" all 2>/dev/null | grep -c .)" "2"
+check "bad count rejected" "$(VAULT="$V" "$NEXT" banana 2>&1 | grep -c 'Error' || true)" "1"
+
+# --- vault-lint-links.sh: extraction and orphan exclusions ---
+mkdir -p "$V/reference"
+cat > "$V/reference/page-a.md" <<'EOF'
+Links to [[page-b]] (exists) and [[ghost-page]] (dead).
+
+```bash
+if [[ -n "$x" ]]; then :; fi
+```
+
+~~~bash
+[[tilde-fenced]] not a link
+~~~
+
+Inline `[[not-a-link]]` here.
+EOF
+printf 'back to [[page-a]]\n' > "$V/reference/page-b.md"
+
+out=$("$LINT" "$V")
+check "reports the real dead link" "$(grep -c 'ghost-page' <<< "$out")" "1"
+check "backtick-fenced [[ ]] excluded" "$(grep -c '\-n' <<< "$out" || true)" "0"
+check "tilde-fenced [[ ]] excluded" "$(grep -c 'tilde-fenced' <<< "$out" || true)" "0"
+check "inline-code [[ ]] excluded" "$(grep -c 'not-a-link' <<< "$out" || true)" "0"
+check "raw-area file not an orphan" "$(grep -c 'standup/2026-08-10' <<< "$out" || true)" "0"
+
+echo ""
+echo "Passed: ${passes}, Failed: ${failures}"
+[[ "${failures}" -eq 0 ]]

--- a/ai/skills/vault/scripts/vault-lint-links.sh
+++ b/ai/skills/vault/scripts/vault-lint-links.sh
@@ -46,6 +46,8 @@ echo ""
 echo "== Orphan wiki pages (no inbound wikilinks) =="
 orphans=0
 while IFS= read -r f; do
+    # Raw areas (keep in sync with vault-next-source.sh's find list) plus
+    # working docs and structural files not expected to have inbound links.
     case "$f" in
         standup/*|ops-reports/*|daily/*|support/*|2[0-9][0-9][0-9]/*|*/plans/*|*/archive/*|Followups.md|log.md|CLAUDE.md|Home.md) continue ;;
     esac

--- a/ai/skills/vault/scripts/vault-lint-links.sh
+++ b/ai/skills/vault/scripts/vault-lint-links.sh
@@ -26,7 +26,7 @@ find . -type f -name '*.md' -not -path './.obsidian/*' | sed 's|^\./||' > "$tmpd
 : > "$tmpdir/links"
 while IFS= read -r f; do
     # shellcheck disable=SC2016  # backticks in the sed pattern are literal, not expansions
-    awk '/^[[:space:]]*```/ { infence = !infence; next } !infence { print }' "$f" 2>/dev/null | sed 's/`[^`]*`//g' | grep -o '\[\[[^]]*\]\]' | sed -e 's/^\[\[//' -e 's/\]\]$//' -e 's/|.*//' -e 's/#.*//' | while IFS= read -r target; do
+    awk '/^[[:space:]]*(```|~~~)/ { infence = !infence; next } !infence { print }' "$f" 2>/dev/null | sed 's/`[^`]*`//g' | grep -o '\[\[[^]]*\]\]' | sed -e 's/^\[\[//' -e 's/\]\]$//' -e 's/|.*//' -e 's/#.*//' | while IFS= read -r target; do
         [[ -n "$target" ]] && printf '%s\t%s\n' "$f" "$target" >> "$tmpdir/links"
     done
 done < "$tmpdir/files"
@@ -51,7 +51,8 @@ while IFS= read -r f; do
     case "$f" in
         standup/*|ops-reports/*|daily/*|support/*|2[0-9][0-9][0-9]/*|*/plans/*|*/archive/*|Followups.md|log.md|CLAUDE.md|Home.md) continue ;;
     esac
-    base=$(basename "$f" .md)
+    base="${f##*/}"
+    base="${base%.md}"
     if ! awk -F'\t' -v b="$base" '$2 == b || $2 ~ ("/" b "$") { found = 1; exit } END { exit !found }' "$tmpdir/links"; then
         orphans=$((orphans + 1))
         [[ "$orphans" -le 20 ]] && printf '%s\n' "$f"

--- a/ai/skills/vault/scripts/vault-lint-links.sh
+++ b/ai/skills/vault/scripts/vault-lint-links.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Report dead [[wikilinks]] and orphan wiki pages (no inbound wikilinks).
+#
+# Usage: vault-lint-links.sh [vault-dir]
+#
+# Report-only; always exits 0 (no -e: a file with zero wikilinks makes the
+# extraction pipeline "fail", which must not kill the report). Obsidian
+# resolves [[Name]] by basename anywhere in the vault and [[dir/Name]] by
+# path, so a link is dead only when neither resolves. Raw areas, plans, and
+# structural files are excluded from the orphan check (they aren't expected
+# to have inbound links).
+
+set -uo pipefail
+
+VAULT="${1:-$HOME/dev/haacked/notes/PostHog}"
+cd "$VAULT" || exit 1
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+find . -type f -name '*.md' -not -path './.obsidian/*' | sed 's|^\./||' > "$tmpdir/files"
+
+# Extract file<TAB>target pairs, stripping |aliases and #headings. Fenced
+# code blocks and inline code are excluded — bash [[ conditionals ]] in
+# code samples are not wikilinks.
+: > "$tmpdir/links"
+while IFS= read -r f; do
+    # shellcheck disable=SC2016  # backticks in the sed pattern are literal, not expansions
+    awk '/^[[:space:]]*```/ { infence = !infence; next } !infence { print }' "$f" 2>/dev/null | sed 's/`[^`]*`//g' | grep -o '\[\[[^]]*\]\]' | sed -e 's/^\[\[//' -e 's/\]\]$//' -e 's/|.*//' -e 's/#.*//' | while IFS= read -r target; do
+        [[ -n "$target" ]] && printf '%s\t%s\n' "$f" "$target" >> "$tmpdir/links"
+    done
+done < "$tmpdir/files"
+
+echo "== Dead wikilinks =="
+dead=0
+while IFS=$'\t' read -r f target; do
+    base="${target##*/}"
+    if ! grep -qxF "${target}.md" "$tmpdir/files" && ! grep -qxF "${base}.md" "$tmpdir/files" && ! grep -qF "/${base}.md" "$tmpdir/files"; then
+        printf '%s -> [[%s]]\n' "$f" "$target"
+        dead=$((dead + 1))
+    fi
+done < "$tmpdir/links"
+[[ "$dead" -eq 0 ]] && echo "(none)"
+
+echo ""
+echo "== Orphan wiki pages (no inbound wikilinks) =="
+orphans=0
+while IFS= read -r f; do
+    case "$f" in
+        standup/*|ops-reports/*|daily/*|support/*|2[0-9][0-9][0-9]/*|*/plans/*|*/archive/*|Followups.md|log.md|CLAUDE.md|Home.md) continue ;;
+    esac
+    base=$(basename "$f" .md)
+    if ! awk -F'\t' -v b="$base" '$2 == b || $2 ~ ("/" b "$") { found = 1; exit } END { exit !found }' "$tmpdir/links"; then
+        orphans=$((orphans + 1))
+        [[ "$orphans" -le 20 ]] && printf '%s\n' "$f"
+    fi
+done < "$tmpdir/files"
+if [[ "$orphans" -eq 0 ]]; then
+    echo "(none)"
+elif [[ "$orphans" -gt 20 ]]; then
+    echo "(+$((orphans - 20)) more — ${orphans} orphans total)"
+fi

--- a/ai/skills/vault/scripts/vault-lint-links.sh
+++ b/ai/skills/vault/scripts/vault-lint-links.sh
@@ -3,8 +3,9 @@
 #
 # Usage: vault-lint-links.sh [vault-dir]
 #
-# Report-only; always exits 0 (no -e: a file with zero wikilinks makes the
-# extraction pipeline "fail", which must not kill the report). Obsidian
+# Report-only; exits 0 except when the vault dir can't be entered (no -e: a
+# file with zero wikilinks makes the extraction pipeline "fail", which must
+# not kill the report). Obsidian
 # resolves [[Name]] by basename anywhere in the vault and [[dir/Name]] by
 # path, so a link is dead only when neither resolves. Raw areas, plans, and
 # structural files are excluded from the orphan check (they aren't expected
@@ -53,7 +54,9 @@ while IFS= read -r f; do
     esac
     base="${f##*/}"
     base="${base%.md}"
-    if ! awk -F'\t' -v b="$base" '$2 == b || $2 ~ ("/" b "$") { found = 1; exit } END { exit !found }' "$tmpdir/links"; then
+    # Pure string suffix check — a regex here would let metacharacters in page
+    # names (dots, parens) misclassify orphans.
+    if ! awk -F'\t' -v b="$base" '$2 == b || substr($2, length($2) - length(b)) == "/" b { found = 1; exit } END { exit !found }' "$tmpdir/links"; then
         orphans=$((orphans + 1))
         [[ "$orphans" -le 20 ]] && printf '%s\n' "$f"
     fi

--- a/ai/skills/vault/scripts/vault-next-source.sh
+++ b/ai/skills/vault/scripts/vault-next-source.sh
@@ -28,8 +28,8 @@ fi
 
 cd "$VAULT"
 
-# Raw areas per the schema in CLAUDE.md; year dirs (Granola exports) match 2###.
-# Keep in sync with the raw-area case pattern in vault-lint-links.sh.
+# Raw areas per the schema in CLAUDE.md; year dirs (Granola exports) match the
+# 2[0-9][0-9][0-9] glob. Keep in sync with the case pattern in vault-lint-links.sh.
 # BSD stat: this setup is macOS-only.
 raw_list=$(find standup ops-reports daily support 2[0-9][0-9][0-9] -type f -name '*.md' -print0 2>/dev/null | xargs -0 stat -f '%m|%N' 2>/dev/null | sort -n | cut -d'|' -f2- || true)
 

--- a/ai/skills/vault/scripts/vault-next-source.sh
+++ b/ai/skills/vault/scripts/vault-next-source.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Print raw-area sources not yet named by an "ingest |" entry in the operations
+# log, oldest first (by mtime).
+#
+# Usage: vault-next-source.sh [count|all]
+#
+# Prints one vault-relative path per line (default: 1). The backlog count goes
+# to stderr so stdout stays machine-consumable. A source counts as processed
+# when its extensionless vault-relative path appears anywhere in log.md.
+
+set -euo pipefail
+
+VAULT="${VAULT:-$HOME/dev/haacked/notes/PostHog}"
+LOG_FILE="$VAULT/log.md"
+count="${1:-1}"
+
+if [[ ! -f "$LOG_FILE" ]]; then
+    echo "Error: $LOG_FILE not found" >&2
+    exit 1
+fi
+
+cd "$VAULT"
+
+# Raw areas per the schema in CLAUDE.md; year dirs (Granola exports) match 2###.
+raw_list=$(find standup ops-reports daily support 2[0-9][0-9][0-9] -type f -name '*.md' -print0 2>/dev/null | xargs -0 stat -f '%m|%N' 2>/dev/null | sort -n | cut -d'|' -f2- || true)
+
+if [[ -z "$raw_list" ]]; then
+    echo "No raw sources found under $VAULT" >&2
+    exit 0
+fi
+
+pending=$(printf '%s\n' "$raw_list" | while IFS= read -r f; do
+    grep -qF "${f%.md}" "$LOG_FILE" || printf '%s\n' "$f"
+done)
+
+if [[ -z "$pending" ]]; then
+    echo "Backlog empty: every raw source appears in an ingest entry." >&2
+    exit 0
+fi
+
+total=$(printf '%s\n' "$pending" | grep -c . || true)
+
+if [[ "$count" == "all" ]]; then
+    printf '%s\n' "$pending"
+else
+    printf '%s\n' "$pending" | head -n "$count"
+fi
+echo "(backlog: ${total} unprocessed raw sources)" >&2

--- a/ai/skills/vault/scripts/vault-next-source.sh
+++ b/ai/skills/vault/scripts/vault-next-source.sh
@@ -19,9 +19,15 @@ if [[ ! -f "$LOG_FILE" ]]; then
     exit 1
 fi
 
+if ! [[ "$count" == "all" || "$count" =~ ^[0-9]+$ ]]; then
+    echo "Error: count must be a number or 'all'" >&2
+    exit 1
+fi
+
 cd "$VAULT"
 
 # Raw areas per the schema in CLAUDE.md; year dirs (Granola exports) match 2###.
+# Keep in sync with the raw-area case pattern in vault-lint-links.sh.
 raw_list=$(find standup ops-reports daily support 2[0-9][0-9][0-9] -type f -name '*.md' -print0 2>/dev/null | xargs -0 stat -f '%m|%N' 2>/dev/null | sort -n | cut -d'|' -f2- || true)
 
 if [[ -z "$raw_list" ]]; then
@@ -29,6 +35,8 @@ if [[ -z "$raw_list" ]]; then
     exit 0
 fi
 
+# One grep fork per raw file (~1s at 260 files, fork-bound not size-bound);
+# an awk lookup-set join only pays off once the backlog reaches the thousands.
 pending=$(printf '%s\n' "$raw_list" | while IFS= read -r f; do
     grep -qF "${f%.md}" "$LOG_FILE" || printf '%s\n' "$f"
 done)

--- a/ai/skills/vault/scripts/vault-next-source.sh
+++ b/ai/skills/vault/scripts/vault-next-source.sh
@@ -6,7 +6,9 @@
 #
 # Prints one vault-relative path per line (default: 1). The backlog count goes
 # to stderr so stdout stays machine-consumable. A source counts as processed
-# when its extensionless vault-relative path appears anywhere in log.md.
+# when its backtick-wrapped vault-relative path (extension included) appears in
+# log.md — the exact token ingest entries write, so one source's path can't
+# substring-match another's (Granola exports produce prefix-sibling filenames).
 
 set -euo pipefail
 
@@ -28,6 +30,7 @@ cd "$VAULT"
 
 # Raw areas per the schema in CLAUDE.md; year dirs (Granola exports) match 2###.
 # Keep in sync with the raw-area case pattern in vault-lint-links.sh.
+# BSD stat: this setup is macOS-only.
 raw_list=$(find standup ops-reports daily support 2[0-9][0-9][0-9] -type f -name '*.md' -print0 2>/dev/null | xargs -0 stat -f '%m|%N' 2>/dev/null | sort -n | cut -d'|' -f2- || true)
 
 if [[ -z "$raw_list" ]]; then
@@ -38,7 +41,7 @@ fi
 # One grep fork per raw file (~1s at 260 files, fork-bound not size-bound);
 # an awk lookup-set join only pays off once the backlog reaches the thousands.
 pending=$(printf '%s\n' "$raw_list" | while IFS= read -r f; do
-    grep -qF "${f%.md}" "$LOG_FILE" || printf '%s\n' "$f"
+    grep -qF "\`${f}\`" "$LOG_FILE" || printf '%s\n' "$f"
 done)
 
 if [[ -z "$pending" ]]; then


### PR DESCRIPTION
Implements the Karpathy-style knowledge loop over the notes vault, working with the three-layer schema now documented in PostHog/CLAUDE.md (raw areas are immutable records, wiki pages get rewritten in place, working docs have their own lifecycle).

- `ingest [path|url|--tranche N]` distills one raw source at a time into ~10-15 interlinked wiki pages and appends a ledger entry to PostHog/log.md naming the source path. The log doubles as the ingest ledger: `vault-next-source.sh` picks the oldest raw file whose path appears in no ingest entry (current backlog: 260 sources). Sources with nothing durable still get a ledger entry so the backlog shrinks honestly.
- `lint [area]` runs markdownlint-cli2 plus `vault-lint-links.sh`, which reports dead wikilinks and orphan pages while excluding fenced/inline code (bash `[[ conditionals ]]` in code samples are not wikilinks) and skipping raw areas and plans in the orphan check. Judgment checks (contradictions, stale claims, missing cross-links) stay bounded to the named area. Fixes apply after a y/n; deferred items can become /followup entries.
- `status` reports backlog count, recent log activity, open follow-ups, and last lint.

## Test plan

- `shellcheck` clean on both scripts.
- `vault-next-source.sh` against the real vault returns the oldest unprocessed source with a 260-source backlog count on stderr; tranche mode returns the N oldest; ledger matching verified via the extensionless-path grep.
- `vault-lint-links.sh` runs in ~2.5s over 470 files, exit 0, and after the code-block exclusion reports only true positives (an ambiguous `#`-containing link target and a flag name typed in double brackets) plus a capped orphan list.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*