### PR TITLE
Make /go idempotent and replace Copilot with ReviewHog

### DIFF
--- a/ai/agents/bug-root-cause-analyzer.md
+++ b/ai/agents/bug-root-cause-analyzer.md
@@ -1,7 +1,7 @@
 ---
 name: bug-root-cause-analyzer
 description: "Use this agent when you encounter a failing test, unexpected behavior, or need to investigate the underlying cause of a software defect. Examples: <example>Context: User is debugging a failing integration test that worked yesterday but now fails intermittently. user: \"This test keeps failing randomly - sometimes it passes, sometimes it doesn't. Can you help me figure out what's going on?\" assistant: \"I'll use the bug-root-cause-analyzer agent to systematically investigate this intermittent test failure and identify the underlying cause.\" <commentary>Since the user has a failing test with unclear cause, use the bug-root-cause-analyzer agent to methodically diagnose the issue.</commentary></example> <example>Context: User reports that a feature that worked in development is behaving differently in production. user: \"Users are reporting that the payment processing is failing, but it works fine on my local machine\" assistant: \"Let me use the bug-root-cause-analyzer agent to investigate this environment-specific issue and determine why payment processing behaves differently between development and production.\" <commentary>Since there's a production bug with unclear environmental factors, use the bug-root-cause-analyzer agent to systematically investigate.</commentary></example>"
-model: sonnet
+model: inherit
 color: red
 ---
 

--- a/ai/agents/implementation-planner.md
+++ b/ai/agents/implementation-planner.md
@@ -1,7 +1,7 @@
 ---
 name: implementation-planner
 description: "Use this agent when you need to break down complex software features or requirements into actionable implementation stages, create technical specifications, or design system architecture before coding begins. Examples: <example>Context: User wants to add a new authentication system to their web application. user: 'I need to implement OAuth2 authentication with Google and GitHub providers for my Node.js app' assistant: 'I'll use the implementation-planner agent to create a detailed implementation plan for your OAuth2 authentication system.' <commentary>Since the user needs a complex feature planned out, use the implementation-planner agent to break this down into stages with clear deliverables and success criteria.</commentary></example> <example>Context: User is starting work on a new microservice and needs architectural guidance. user: 'I'm building a notification service that needs to handle email, SMS, and push notifications with retry logic and rate limiting' assistant: 'Let me use the implementation-planner agent to design the architecture and create an implementation roadmap for your notification service.' <commentary>This is a complex system that requires careful planning of components, data flow, and implementation stages.</commentary></example>"
-model: opus
+model: inherit
 color: purple
 ---
 

--- a/ai/agents/unit-test-writer.md
+++ b/ai/agents/unit-test-writer.md
@@ -1,7 +1,7 @@
 ---
 name: unit-test-writer
 description: "Use this agent when you need to write comprehensive unit tests for existing code, when implementing test-driven development, when code coverage needs improvement, or when refactoring requires test safety nets. Examples: <example>Context: User has just written a new function and wants unit tests for it. user: 'I just wrote this authentication function, can you help me test it?' assistant: 'I'll use the unit-test-writer agent to create comprehensive unit tests for your authentication function.' <commentary>Since the user needs unit tests written for their code, use the unit-test-writer agent to analyze the function and create thorough test coverage.</commentary></example> <example>Context: User is working on a feature and wants to follow TDD practices. user: 'I want to add a user validation feature using test-driven development' assistant: 'I'll use the unit-test-writer agent to help you write the tests first, then implement the feature.' <commentary>The user wants to follow TDD, so use the unit-test-writer agent to create the test suite before implementation.</commentary></example>"
-model: sonnet
+model: inherit
 color: yellow
 ---
 

--- a/ai/skills/go/SKILL.md
+++ b/ai/skills/go/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: go
-description: Plan, implement, and iteratively review a task end-to-end using Claude + Copilot reviewers in a linear flow.
+description: Plan, implement, and iteratively review a task end-to-end using Claude + Copilot reviewers in a linear flow. Idempotent — re-running reports where the pipeline stands and resumes from the first incomplete step.
 argument-hint: "<task description> [--skip-planner] [--skip-copilot] [--plan-file <path>]"
 ---
 
@@ -8,14 +8,36 @@ argument-hint: "<task description> [--skip-planner] [--skip-copilot] [--plan-fil
 
 End-to-end orchestrator: plan → implement → simplify → commit → open draft PR → Claude review loop → Copilot review loop → one final Claude review pass to catch anything Copilot's fixes introduced.
 
+The pipeline is idempotent. `.notes/go-state.md` tracks progress, so re-running `/go` reports where the pipeline stands and resumes from the first incomplete or stale step. On a branch `/go` never drove, it infers position from the working tree, branch commits, and PR, then proceeds as if it had been running all along.
+
 The expensive steps (`review-fix-loop.sh`, `copilot-review-loop.sh`) run each round in a fresh `claude -p` subprocess, so the main context only carries planning and the initial implementation.
 
 ## Arguments
 
-- `<task description>` — what to build/fix. Required unless the branch already has uncommitted/unpushed work (see Step 1) or `--plan-file` is given.
+- `<task description>` — what to build/fix. Omit to resume: `/go` detects the branch's position and continues from there (see Step 2).
 - `--skip-planner` — skip the `implementation-planner` sub-agent; implement directly from the description.
 - `--skip-copilot` — skip the Copilot rounds and the final Claude pass. Useful when there's no PR yet or Copilot is unavailable.
 - `--plan-file <path>` — use an already-approved plan file directly (e.g. one written by Plan Mode) instead of looking up or generating one. Implies skipping the planner.
+
+## State file
+
+`.notes/go-state.md` records pipeline progress for the branch. Every step appends its entry the moment it completes, so an interrupted run resumes exactly where it stopped:
+
+```markdown
+# /go state
+branch: haacked/add-dark-mode-toggle
+slug: add-dark-mode-toggle
+plan: ~/dev/ai/plans/haacked/dotfiles/add-dark-mode-toggle.md
+
+- implement: done
+- simplify-commit: a1b2c3d
+- pr: 123
+- claude-review: e4f5a6b
+- copilot-review: f7a8b9c
+- final-review: f7a8b9c
+```
+
+Step values are `git rev-parse --short HEAD` captured when the step finished (`done` for `implement`, the PR number for `pr`). If `branch:` doesn't match the current branch, ignore the file and re-infer per Step 2.
 
 ## Steps
 
@@ -27,24 +49,53 @@ Extract from `$ARGUMENTS`:
 - `SKIP_COPILOT` — boolean, true if `--skip-copilot` is present.
 - `PLAN_FILE` — the path following `--plan-file`, if present.
 - `TASK` — everything else, joined with spaces.
-- `SLUG` — short kebab-case identifier derived from `TASK` (e.g. "add dark mode toggle" → "add-dark-mode-toggle"). Used in commit messages and planner descriptions. If `TASK` is empty and `PLAN_FILE` is set, `SLUG` is derived in Step 2 from the plan file instead.
+- `SLUG` — short kebab-case identifier derived from `TASK` (e.g. "add dark mode toggle" → "add-dark-mode-toggle"). Used in commit messages and planner descriptions. If `TASK` is empty, `SLUG` comes from the state file, the plan file's first heading, or the branch name — resolved in Step 2.
 
-If `PLAN_FILE` is set and `TASK` is empty, skip the in-flight-work check below and go straight to Step 2 — the plan file is the entry point, not a task description.
+### Step 2: Determine position
 
-If `TASK` is empty and `PLAN_FILE` is not set, check for in-flight work:
+Gather the facts in one round trip:
 
 ```bash
+git check-ignore -q .notes 2>/dev/null || echo '.notes/' >> "$(git rev-parse --git-common-dir)/info/exclude"
 git status --porcelain
-git log @{u}..HEAD --oneline 2>/dev/null || git log -5 --oneline
+git log @{u}..HEAD --oneline 2>/dev/null | head -20
+git rev-parse --short HEAD
+cat .notes/go-state.md 2>/dev/null
+gh pr list --head "$(git branch --show-current)" --json number,state,isDraft --jq '.[0] // empty'
 ```
 
-If the working tree is dirty or there are unpushed commits, set `CONTINUING=true`, derive `SLUG` from the most recent commit subject, and jump to Step 4. Otherwise stop and ask the user what to build.
+**Fresh cycle or resume?** If `TASK` or `PLAN_FILE` is given and the state file is missing or names a different slug, this is a new cycle: write a fresh `.notes/go-state.md` header (branch, slug, plan pending), apply the work branch guard below, and run everything from Step 3. If `TASK` matches the state file's slug, or no `TASK` was given, resume.
 
-### Step 2: Plan
+**Resuming without a state file** (a session `/go` didn't drive): infer entries from the world and write them to a new state file:
 
-If `PLAN_FILE` was supplied via `--plan-file`, skip the planner and the existing-plan search below entirely: read the plan file with the Read tool, and derive `SLUG` from its first `#` heading (kebab-cased) if `TASK` wasn't otherwise provided — fall back to slugifying `TASK` or the current branch name if the plan has no clear heading. Still compute `plan_dir` using the snippet below, then copy the plan file to `$plan_dir/$SLUG.md` (creating the directory if needed) so it participates in the same archival convention as planner-authored plans and a later `/go` re-invocation on this branch still finds it — unless `plan_dir` comes back empty (unrecognized repo), in which case skip the copy and just proceed with the original `PLAN_FILE` path. Tell the user which plan you're using, then go to Step 3.
+- Commits ahead of upstream/base, or a dirty tree → `implement: done`. Derive `SLUG` from the branch name (minus any `owner/` prefix), or from the latest commit subject when the branch name carries no signal (default branch, detached HEAD).
+- Clean tree with branch commits → also `simplify-commit: <HEAD sha>`.
+- Open PR on the branch → `pr: <number>`.
+- Review steps are never inferred — leave them pending. The loops converge quickly when there's nothing to find.
+- If the adopted diff (dirty files plus commits since the merge-base with the default branch) touches testable code but no test files, dispatch `unit-test-writer` in the background now, prompted with the diff: write tests for the changed behavior, match existing test conventions, report which fail. Note the gap in the position report. Fold the results in at the next commit — resuming at Step 5, collect after `/simplify` so the tests ride the same commit; resuming later, collect before Step 7 starts, reconcile guessed names against the real code, run the suite, and commit via `Skill("commit", args: "--force Add tests for $SLUG")`. Skip the dispatch for diffs with no testable behavior (docs, config).
+- Nothing to resume (clean tree, no branch commits, no PR, no `TASK`) → stop and ask the user what to build.
 
-If `SKIP_PLANNER` is true, skip the planner but still write a brief: one paragraph covering goal, files in scope, definition of done, and out of scope. Without it, every subagent spawned later interprets the raw task description independently and they diverge. Use the brief as the spec wherever later steps reference the plan, then go to Step 3.
+**Work branch guard.** If HEAD is detached or the current branch is the repo's default branch, create and switch to `haacked/$SLUG` before anything commits — uncommitted work carries over with the checkout. If the default branch also had local commits its upstream lacks, they're on the new branch now; point the default branch back at its upstream (`git branch -f main origin/main`) so the work lives only on the feature branch, and say so in the position report. A branch created here has no PR yet — leave `pr` pending regardless of what the earlier lookup returned.
+
+**Compute the resume point.** If `final-review` equals current HEAD (or `claude-review` does and `SKIP_COPILOT` is set), the pipeline is complete — report the all-done checklist and stop. Otherwise the resume point is the first step in pipeline order that is missing from the state file or stale:
+
+| Step | Done when | Stale when |
+| --- | --- | --- |
+| plan | `plan:` recorded, or `implement` is done | never |
+| implement | entry present | never |
+| simplify-commit | sha recorded and the tree is clean | tree is dirty — new work needs simplify + commit |
+| pr | number recorded, or an open PR exists on the branch | PR closed or merged → report it and stop; this branch is finished |
+| claude-review | sha equals current HEAD | HEAD has moved since the last clean pass |
+| copilot-review | sha equals current HEAD | HEAD has moved |
+| final-review | sha equals current HEAD | HEAD has moved |
+
+Report the position to the user as a short checklist before continuing — ✓ done (with its sha or PR number), → resume point (with why it's pending or stale), · not yet run. Then run linearly from the resume point; every later step executes as normal.
+
+### Step 3: Plan
+
+If `PLAN_FILE` was supplied via `--plan-file`, skip the planner and the existing-plan search below entirely: read the plan file with the Read tool, and derive `SLUG` from its first `#` heading (kebab-cased) if `TASK` wasn't otherwise provided — fall back to slugifying `TASK` or the current branch name if the plan has no clear heading. Still compute `plan_dir` using the snippet below, then copy the plan file to `$plan_dir/$SLUG.md` (creating the directory if needed) so it participates in the same archival convention as planner-authored plans and a later `/go` re-invocation on this branch still finds it — unless `plan_dir` comes back empty (unrecognized repo), in which case skip the copy and just proceed with the original `PLAN_FILE` path. Tell the user which plan you're using, record it, and go to Step 4.
+
+If `SKIP_PLANNER` is true, skip the planner but still write a brief: one paragraph covering goal, files in scope, definition of done, and out of scope. Without it, every subagent spawned later interprets the raw task description independently and they diverge. Use the brief as the spec wherever later steps reference the plan, record `plan: brief`, then go to Step 4.
 
 First, check whether a plan already exists for this work. Compute the plan directory based on `~/CLAUDE.md` conventions:
 
@@ -64,7 +115,7 @@ If `$plan_dir` is set, look for an existing plan in this preference order:
 2. `$plan_dir/${branch##*/}.md` (branch name minus any `owner/` prefix)
 3. If the directory contains exactly one `.md` file, use it
 
-If a plan was found, read its first 100 lines with the Read tool (read specific later sections only when a step needs them), briefly tell the user which plan you're using, and skip to Step 3.
+If a plan was found, read its first 100 lines with the Read tool (read specific later sections only when a step needs them), briefly tell the user which plan you're using, record it, and skip to Step 4.
 
 Otherwise spawn the planner as a sub-agent so its research stays out of the main context:
 
@@ -77,7 +128,9 @@ Agent tool with:
 
 The planner writes a plan file per its own contract.
 
-### Step 3: Implement
+When the plan is settled — found, copied, generated, or a brief — record `plan: <path>` (or `plan: brief`) in the state file header.
+
+### Step 4: Implement
 
 First, dispatch the test writer in the background so tests are designed from the spec, not the implementation:
 
@@ -86,7 +139,7 @@ Agent tool with:
   subagent_type: unit-test-writer
   description: "Tests: $SLUG"
   run_in_background: true
-  prompt: the plan file contents (or the Step 2 brief) — and nothing else.
+  prompt: the plan file contents (or the Step 3 brief) — and nothing else.
     Instruct it to write tests for the behavior the spec defines, match
     existing test conventions, and report which tests fail. Failures are
     expected: the implementation doesn't exist yet.
@@ -96,7 +149,7 @@ Tests written with the implementation in view tend to mirror it instead of testi
 
 Then implement the change in the current context. Follow the plan file if one exists, otherwise work directly from `TASK`. This step is conversational — check in with the user on judgment calls.
 
-**Preserve context aggressively.** The review loops in Steps 6–8 run in fresh subprocesses, but Step 3 stays in main context through the rest of the run. Every file read and search compounds. Push expensive reads into subagents that return summaries instead of raw content:
+**Preserve context aggressively.** The review loops in Steps 7–9 run in fresh subprocesses, but Step 4 stays in main context through the rest of the run. Every file read and search compounds. Push expensive reads into subagents that return summaries instead of raw content:
 
 - **Codebase exploration** (anything that would take more than ~3 greps/reads to answer): spawn `Explore`. Ask for the specific answer, not a file dump — e.g. "where is auth middleware registered and what's its call signature?" rather than "show me the auth code".
 - **Writing tests**: already running in the background from the dispatch above. Only spawn another `unit-test-writer` for behavior discovered during implementation that the spec didn't cover. Don't read the test file into main context first — the subagent will.
@@ -107,22 +160,24 @@ The edits themselves must happen in main context (so the user sees the diffs), b
 
 When the implementation is done, collect the background test agent's results and reconcile. The tester worked from the spec alone, so fix any guessed names, signatures, or import paths to match the real implementation — keep the test intent. Then run the suite. A test that still fails points at an implementation gap: fix the implementation, not the test, unless the test misreads the spec.
 
-### Step 4: Simplify and commit
+Append `- implement: done` to the state file.
+
+### Step 5: Simplify and commit
 
 Invoke `/simplify` (bundled Claude slash command — not a skill). It applies its own fixes.
 
 Then commit. Use a message that matches the situation:
 
-- If Step 3 produced a fresh implementation: `"Initial implementation: $SLUG"`
-- If `CONTINUING=true` from Step 1: `"Continue work on $SLUG"`
+- If this run produced a fresh implementation in Step 4: `"Initial implementation: $SLUG"`
+- If resuming or adopting work that predates this run: `"Continue work on $SLUG"`
 
 ```text
 Skill("commit", args: "--force <message>")
 ```
 
-If `/simplify` made no changes and there's nothing to commit, skip this step.
+Append `- simplify-commit: <short HEAD sha>` to the state file — also when `/simplify` made no changes and there was nothing to commit, so the step doesn't rerun.
 
-### Step 5: Open a draft PR (if needed)
+### Step 6: Open a draft PR (if needed)
 
 Check for an existing PR on the current branch:
 
@@ -136,7 +191,9 @@ If the output is non-empty, a PR already exists — leave it alone and move on. 
 Skill("create-pr", args: "--force")
 ```
 
-### Step 6: Claude review loop (until convergence)
+Append `- pr: <number>` to the state file.
+
+### Step 7: Claude review loop (until convergence)
 
 Run the existing fresh-context review loop via the Bash tool:
 
@@ -146,9 +203,11 @@ Run the existing fresh-context review loop via the Bash tool:
 
 It iterates Claude review → fix → simplify → commit until a round comes back clean (or hits its own max-iterations). Exits 0 on clean, non-zero if findings remain.
 
-### Step 7: Copilot review loop (until convergence)
+On exit 0, append `- claude-review: <short HEAD sha>` (HEAD after the loop's commits). On non-zero exit, leave the entry unrecorded so the next `/go` retries this step, and continue.
 
-If `SKIP_COPILOT` is true, skip to Step 9.
+### Step 8: Copilot review loop (until convergence)
+
+If `SKIP_COPILOT` is true, skip to Step 10.
 
 Otherwise run the Copilot loop against the current branch's PR:
 
@@ -158,7 +217,9 @@ Otherwise run the Copilot loop against the current branch's PR:
 
 It auto-detects the PR from the current branch, fetches Copilot's review, fixes legit findings, replies to and resolves dismissed Copilot threads, pushes, and repeats until Copilot has no new comments. Replies to human reviewers are never auto-posted; the loop drafts them and prints them at the end for you to review and post.
 
-### Step 8: Final Claude pass
+On convergence, append `- copilot-review: <short HEAD sha>`.
+
+### Step 9: Final Claude pass
 
 Rerun the Claude review loop once more to catch anything Copilot's fixes introduced:
 
@@ -168,13 +229,17 @@ Rerun the Claude review loop once more to catch anything Copilot's fixes introdu
 
 `review-fix-cycle` uses `--append` internally, so this pass only surfaces new findings. It typically exits clean on the first iteration.
 
-### Step 9: Report
+On exit 0, append `- final-review: <short HEAD sha>`.
+
+### Step 10: Report
 
 Tell the user what happened:
 
-- Commits added during the run (`git log @{u}..HEAD --oneline` or the range since the initial commit from Step 4)
+- Commits added during the run (`git log @{u}..HEAD --oneline` or the range since the initial commit from Step 5)
 - The PR URL (`gh pr view --json url -q .url`)
 - Any outstanding findings — check `.notes/review-skipped.md` for Claude's deferred items and the Copilot state file under `~/.local/state/copilot-review-loop/` for low-confidence Copilot items flagged for human review.
 - Any drafted replies to human reviewers the loop printed under "Human Reviewer Replies to Post" — these are not posted automatically; surface them so the user can review and post.
 
 If any step exited non-zero, tell the user which one and where the logs are (`.notes/` for Claude, `~/.local/state/copilot-review-loop/` for Copilot).
+
+The state file now records the full pipeline at HEAD, so re-running `/go` reports all-done and stops — until new commits or edits land, which mark the affected steps stale again.

--- a/ai/skills/go/SKILL.md
+++ b/ai/skills/go/SKILL.md
@@ -2,7 +2,6 @@
 name: go
 description: Plan, implement, and iteratively review a task end-to-end using Claude + Copilot reviewers in a linear flow.
 argument-hint: "<task description> [--skip-planner] [--skip-copilot] [--plan-file <path>]"
-model: sonnet
 ---
 
 # /go

--- a/ai/skills/go/SKILL.md
+++ b/ai/skills/go/SKILL.md
@@ -1,22 +1,22 @@
 ---
 name: go
-description: Plan, implement, and review a task end-to-end — review-code + ReviewHog in parallel, every review addressed, open items explained. Idempotent — re-running reports where the pipeline stands and resumes from the first incomplete step.
+description: Plan, implement, and review a task end-to-end — review-code + ReviewHog in parallel, every review addressed, CI watched to green, open items explained. Idempotent — re-running reports where the pipeline stands and resumes from the first incomplete step.
 argument-hint: "<task description> [--skip-planner] [--skip-reviewhog] [--plan-file <path>]"
 ---
 
 # /go
 
-End-to-end orchestrator: plan → implement → simplify → commit → open draft PR → request a ReviewHog round → run `review-code --fix` while ReviewHog works → address every review comment → explain the open items that need the user's judgment.
+End-to-end orchestrator: plan → implement → simplify → commit → open draft PR → request a ReviewHog round → run `review-code --fix` while ReviewHog works → address every review comment → watch CI to green → explain the open items that need the user's judgment.
 
 The pipeline is idempotent. `.notes/go-state.md` tracks progress, so re-running `/go` reports where the pipeline stands and resumes from the first incomplete or stale step. On a branch `/go` never drove, it infers position from the session conversation, working tree, branch commits, and PR, then proceeds as if it had been running all along.
 
-The review phase delegates to skills that fan out their own subagents (`review-code`'s reviewer fleet, `wait-for-pr-reviews` chaining `address-pr-reviews`), so the main context carries orchestration, planning, and the initial implementation.
+The review phase delegates to skills that fan out their own subagents (`review-code`'s reviewer fleet, `wait-for-pr-reviews` chaining `address-pr-reviews`, `ci-monitor` babysitting checks), so the main context carries orchestration, planning, and the initial implementation.
 
 ## Arguments
 
 - `<task description>` — what to build/fix. Omit to resume: `/go` detects the branch's position and continues from there (see Step 2).
 - `--skip-planner` — skip the `implementation-planner` sub-agent; implement directly from the description.
-- `--skip-reviewhog` — don't request or wait on a ReviewHog round; `review-code` and the explain-open wrap-up still run. Applied automatically when the `reviewhog` label can't be added (the repo doesn't have it).
+- `--skip-reviewhog` — don't request or wait on a ReviewHog round; `review-code` and the explain-open wrap-up still run. Applied automatically outside the PostHog org (ReviewHog is PostHog-internal) and when the `reviewhog` label can't be added.
 - `--plan-file <path>` — use an already-approved plan file directly (e.g. one written by Plan Mode) instead of looking up or generating one. Implies skipping the planner.
 
 ## State file
@@ -32,12 +32,13 @@ plan: ~/dev/ai/plans/haacked/dotfiles/add-dark-mode-toggle.md
 - implement: done
 - simplify-commit: a1b2c3d
 - pr: 123
-- reviewhog-requested: done
+- reviewhog-requested: d3e4f5a
 - review-code: e4f5a6b
 - reviews-addressed: f7a8b9c
+- ci: f7a8b9c
 ```
 
-Step values are `git rev-parse --short HEAD` captured when the step finished (`done` for `implement`, the PR number for `pr`, `done` or `skipped` for `reviewhog-requested`). If `branch:` doesn't match the current branch, ignore the file and re-infer per Step 2.
+Step values are `git rev-parse --short HEAD` captured when the step finished (`done` for `implement`, the PR number for `pr`, the sha at request time or `skipped` for `reviewhog-requested`). If `branch:` doesn't match the current branch, ignore the file and re-infer per Step 2.
 
 ## Steps
 
@@ -64,12 +65,14 @@ cat .notes/go-state.md 2>/dev/null
 gh pr list --head "$(git branch --show-current)" --json number,state,isDraft,labels --jq '.[0] // empty'
 ```
 
-**Fresh cycle or resume?** If `TASK` or `PLAN_FILE` is given and the state file is missing or names a different slug, this is a new cycle: write a fresh `.notes/go-state.md` header (branch, slug, plan pending), apply the work branch guard below, and run everything from Step 3. If `TASK` matches the state file's slug, or no `TASK` was given, resume.
+When the branch has no upstream, `@{u}` yields nothing — count branch commits against the merge-base with the default branch instead (`git log "$(git merge-base HEAD origin/<default>)"..HEAD --oneline`).
+
+**Fresh cycle or resume?** If `TASK` or `PLAN_FILE` is given and the state file is missing or names a different slug (for `--plan-file` runs without a `TASK`, read the plan's first `#` heading now to derive the `SLUG` this comparison needs), this is a new cycle: write a fresh `.notes/go-state.md` header (branch, slug, plan pending), apply the work branch guard below, and run everything from Step 3. If `TASK` matches the state file's slug, or no `TASK` was given, resume.
 
 **Resuming without a state file** (a session `/go` didn't drive): infer entries from the world and write them to a new state file:
 
 - Commits ahead of upstream/base, or a dirty tree → an implementation exists. Derive `SLUG` from the branch name (minus any `owner/` prefix), or from the latest commit subject when the branch name carries no signal (default branch, detached HEAD).
-- Judge whether that implementation is finished. The original ask is usually in the session conversation — compare it against what the diff delivers — and the diff itself signals incompleteness: TODO/FIXME markers it introduces, stubbed or never-wired functions, failures mentioned in the session but never fixed. If work remains, write a brief (goal from the original ask, what's already in place, what remains, definition of done), record `plan: brief`, and leave `implement` unrecorded so the resume point lands on Step 4 to finish the job — and skip the test-gap dispatch below, since Step 4 dispatches its own tester with that brief. If the work looks complete, or there's no evidence either way, record `implement: done` — simplify and the review loops take it from there.
+- Judge whether that implementation is finished. The original ask is usually in the session conversation — compare it against what the diff delivers — and the diff itself signals incompleteness: TODO/FIXME markers it introduces, stubbed or never-wired functions, failures mentioned in the session but never fixed. If work remains, write a brief (goal from the original ask, what's already in place, what remains, definition of done), record `plan: brief` and put the brief's text under a `## Brief` section at the end of the state file (a later resume in a fresh session has no other copy), and leave `implement` unrecorded so the resume point lands on Step 4 to finish the job — and skip the test-gap dispatch below, since Step 4 dispatches its own tester with that brief. If the work looks complete, or there's no evidence either way, record `implement: done` — simplify and the review loops take it from there.
 - If `implement` was recorded done and the tree is clean with branch commits → also `simplify-commit: <HEAD sha>`.
 - Open PR on the branch → `pr: <number>`.
 - Review steps are never inferred — leave them pending. Re-reviewing already-reviewed work is cheap; skipping an un-run review isn't.
@@ -78,7 +81,7 @@ gh pr list --head "$(git branch --show-current)" --json number,state,isDraft,lab
 
 **Work branch guard.** If HEAD is detached or the current branch is the repo's default branch, create and switch to `haacked/$SLUG` before anything commits — uncommitted work carries over with the checkout. If the default branch also had local commits its upstream lacks, they're on the new branch now; point the default branch back at its upstream (`git branch -f main origin/main`) so the work lives only on the feature branch, and say so in the position report. A branch created here has no PR yet — leave `pr` pending regardless of what the earlier lookup returned.
 
-**Compute the resume point.** If `reviews-addressed` equals current HEAD (or `review-code` does and ReviewHog was skipped — `SKIP_REVIEWHOG` or `reviewhog-requested: skipped`), the pipeline is complete — report the all-done checklist and stop. Otherwise the resume point is the first step in pipeline order that is missing from the state file or stale:
+**Compute the resume point.** If `ci` equals current HEAD and the working tree is clean, the pipeline is complete — report the all-done checklist and stop. Otherwise the resume point is the first step in pipeline order that is missing from the state file or stale:
 
 | Step | Done when | Stale when |
 | --- | --- | --- |
@@ -86,9 +89,10 @@ gh pr list --head "$(git branch --show-current)" --json number,state,isDraft,lab
 | implement | entry present | never |
 | simplify-commit | sha recorded and the tree is clean | tree is dirty — new work needs simplify + commit |
 | pr | number recorded, or an open PR exists on the branch | PR closed or merged → report it and stop; this branch is finished |
-| reviewhog-requested | `done`/`skipped` recorded, or the `reviewhog` label is already on the PR | never — the label persists; new rounds are ReviewHog's own behavior |
+| reviewhog-requested | sha recorded or `skipped`, or the `reviewhog` label is on the PR right now (a round is in flight) | HEAD has moved since the request and no round is in flight — label present wins over HEAD-moved; never re-request into a running round. One label add buys one round at one head, so new commits need a fresh add |
 | review-code | sha equals current HEAD | HEAD has moved since the last pass |
-| reviews-addressed | sha equals current HEAD (not required when ReviewHog was skipped) | HEAD has moved |
+| reviews-addressed | sha equals current HEAD | HEAD has moved |
+| ci | sha equals current HEAD | HEAD has moved |
 
 Report the position to the user as a short checklist before continuing — ✓ done (with its sha or PR number), → resume point (with why it's pending or stale), · not yet run. Then run linearly from the resume point; every later step executes as normal.
 
@@ -96,7 +100,7 @@ Report the position to the user as a short checklist before continuing — ✓ d
 
 If `PLAN_FILE` was supplied via `--plan-file`, skip the planner and the existing-plan search below entirely: read the plan file with the Read tool, and derive `SLUG` from its first `#` heading (kebab-cased) if `TASK` wasn't otherwise provided — fall back to slugifying `TASK` or the current branch name if the plan has no clear heading. Still compute `plan_dir` using the snippet below, then copy the plan file to `$plan_dir/$SLUG.md` (creating the directory if needed) so it participates in the same archival convention as planner-authored plans and a later `/go` re-invocation on this branch still finds it — unless `plan_dir` comes back empty (unrecognized repo), in which case skip the copy and just proceed with the original `PLAN_FILE` path. Tell the user which plan you're using, record it, and go to Step 4.
 
-If `SKIP_PLANNER` is true, skip the planner but still write a brief: one paragraph covering goal, files in scope, definition of done, and out of scope. Without it, every subagent spawned later interprets the raw task description independently and they diverge. Use the brief as the spec wherever later steps reference the plan, record `plan: brief`, then go to Step 4.
+If `SKIP_PLANNER` is true, skip the planner but still write a brief: one paragraph covering goal, files in scope, definition of done, and out of scope. Without it, every subagent spawned later interprets the raw task description independently and they diverge. Use the brief as the spec wherever later steps reference the plan, record `plan: brief` with the brief's text under a `## Brief` section at the end of the state file (a later resume in a fresh session has no other copy), then go to Step 4.
 
 First, check whether a plan already exists for this work. Compute the plan directory based on `~/CLAUDE.md` conventions:
 
@@ -150,7 +154,7 @@ Tests written with the implementation in view tend to mirror it instead of testi
 
 Then implement the change in the current context. Follow the plan file if one exists, otherwise work directly from `TASK`. This step is conversational — check in with the user on judgment calls.
 
-**Preserve context aggressively.** The review phase in Steps 7–9 delegates its heavy lifting to skills and subagents, but Step 4 stays in main context through the rest of the run. Every file read and search compounds. Push expensive reads into subagents that return summaries instead of raw content:
+**Preserve context aggressively.** The review phase in Steps 7–10 delegates its heavy lifting to skills and subagents, but Step 4 stays in main context through the rest of the run. Every file read and search compounds. Push expensive reads into subagents that return summaries instead of raw content:
 
 - **Codebase exploration** (anything that would take more than ~3 greps/reads to answer): spawn `Explore`. Ask for the specific answer, not a file dump — e.g. "where is auth middleware registered and what's its call signature?" rather than "show me the auth code".
 - **Writing tests**: already running in the background from the dispatch above. Only spawn another `unit-test-writer` for behavior discovered during implementation that the spec didn't cover. Don't read the test file into main context first — the subagent will.
@@ -165,11 +169,11 @@ Append `- implement: done` to the state file.
 
 ### Step 5: Simplify and commit
 
-Invoke `/simplify` (bundled Claude slash command — not a skill). It applies its own fixes. Note anything it flags but declines to change — those items feed the explain-open wrap-up in Step 10.
+Invoke `/simplify` (bundled Claude slash command — not a skill). It applies its own fixes. Note anything it flags but declines to change — those items feed the explain-open wrap-up in Step 11. If a Step 2 test-gap dispatch is outstanding, collect it now so the tests ride this commit.
 
 Then commit. Use a message that matches the situation:
 
-- If this run produced a fresh implementation in Step 4: `"Initial implementation: $SLUG"`
+- If this run produced a fresh implementation in Step 4: `"Implement $SLUG"`
 - If resuming or adopting work that predates this run: `"Continue work on $SLUG"`
 
 ```text
@@ -192,32 +196,39 @@ If the output is non-empty, a PR already exists — leave it alone and move on. 
 Skill("create-pr", args: "--force")
 ```
 
-Append `- pr: <number>` to the state file.
+Append `- pr: <number>` to the state file either way — the existing PR's number when one was found.
 
 ### Step 7: Request a ReviewHog round
 
-If `SKIP_REVIEWHOG` is true, record `- reviewhog-requested: skipped` and go to Step 8.
+If a Step 2 test-gap dispatch is still outstanding, collect and fold it in now (per Step 2) before requesting the round.
 
-Push any unpushed commits first so ReviewHog reviews the branch's current state, then add the label that triggers its round:
+ReviewHog is PostHog-internal — only request it on PostHog-org repos. If `SKIP_REVIEWHOG` is true, or the repo owner isn't the PostHog org (`gh repo view --json owner -q .owner.login`), set `SKIP_REVIEWHOG=true`, record `- reviewhog-requested: skipped`, and go to Step 8.
+
+Push any unpushed commits first so ReviewHog reviews the branch's current state — if the push fails, resolve it before adding the label, or the round reviews a stale head. Then add the label that triggers the round (draft PRs are fine — ReviewHog reviews drafts):
 
 ```bash
-git push 2>/dev/null
+git push
+PR_NUMBER=$(gh pr view --json number -q .number)
 gh pr edit "$PR_NUMBER" --add-label reviewhog
 ```
 
-If the label add fails (the repo has no `reviewhog` label), tell the user, set `SKIP_REVIEWHOG=true`, and record `- reviewhog-requested: skipped`. Otherwise record `- reviewhog-requested: done`. Either way, continue immediately — ReviewHog works in the background while Step 8 runs.
+If the label add fails (the repo has no `reviewhog` label — as of 2026-08 ReviewHog's allowlist is only `posthog/posthog`, so other PostHog repos land here), tell the user, set `SKIP_REVIEWHOG=true`, and record `- reviewhog-requested: skipped`. Otherwise record `- reviewhog-requested: <short HEAD sha>`. Either way, continue immediately — ReviewHog works in the background while Step 8 runs.
+
+One label add buys exactly one round at the current head: ReviewHog removes the label when the round finishes, and pushes never retrigger it. That's why re-adding on a resume is always safe — at an already-reviewed head the round no-ops server-side, and while a round is in flight the trigger joins it rather than starting a second one.
 
 ### Step 8: Review our own side while ReviewHog works
 
-Run the full reviewer fleet against the PR and apply the clean fixes:
+Run the full reviewer fleet against the PR and apply the clean fixes, passing the PR URL from `gh pr view --json url -q .url`:
 
 ```text
 Skill("review-code", args: "<pr-url> --fix")
 ```
 
-Its Fix Summary lists what was fixed, what needs a judgment call, and what it declined to fix — keep that in reach: Step 9 compares it against ReviewHog's round and Step 10 explains the open items.
+Its Fix Summary lists what was fixed, what needs a judgment call, and what it declined to fix — keep that in reach: Step 9 compares it against ReviewHog's round and Step 11 explains the open items.
 
-Commit the fixes but **don't push** — a mid-round push can retrigger ReviewHog and extend the wait; `wait-for-pr-reviews` owns the single push at the end of Step 9:
+Run the test suite before committing — reviewer-driven fixes break code like any other change. A failure the fixes introduced means fixing the fix, not skipping the test.
+
+Then commit the fixes but **don't push** — `wait-for-pr-reviews` owns the single push at the end of Step 9 (ReviewHog never retriggers on pushes, but other reviewers watching the PR can):
 
 ```text
 Skill("commit", args: "--force Address review findings")
@@ -227,9 +238,9 @@ Append `- review-code: <short HEAD sha>`. If ReviewHog was skipped, push now (`g
 
 ### Step 9: Wait for ReviewHog, address every review
 
-If `SKIP_REVIEWHOG` is true, go to Step 10.
+If `SKIP_REVIEWHOG` is true: invoke `Skill("address-pr-reviews")` once — a resumed PR can carry human or other-bot feedback, and it handles the no-comments case itself. No wait, no gap logging (there's no ReviewHog round to compare against). Run the test suite if it made fixes. Append `- reviews-addressed: <short HEAD sha>` either way and go to Step 10.
 
-Hand the wait and the comment processing to the skill built for it:
+Otherwise hand the wait and the comment processing to the skill built for it:
 
 ```text
 Skill("wait-for-pr-reviews")
@@ -237,33 +248,51 @@ Skill("wait-for-pr-reviews")
 
 It detects the in-flight ReviewHog round (and any other pending reviewers), runs `address-pr-reviews` on comments that already exist while waiting, re-runs it when the round lands, and pushes once at the end. Replies to human reviewers surface for approval per that skill's own rules — never auto-posted.
 
-**Then log ReviewHog's misses.** Compare `review-code`'s legit findings from Step 8 — the fixed ones plus real-but-deferred items from its Fix Summary — against everything ReviewHog raised this round. Append each legit finding ReviewHog didn't also flag to `~/dev/haacked/notes/PostHog/reviewhog-gaps.md` (create the file if needed), one dated entry per run:
+When it finishes, run the test suite — its fixes are code changes like any other. If the suite is red, fix, commit, and push.
+
+**Then log ReviewHog's misses and false positives.** Both directions of disagreement feed ReviewHog improvements later, and both come from work already done this round:
+
+- **Misses** (recall): `review-code`'s legit findings from Step 8 — the fixed ones plus real-but-deferred items from its Fix Summary — that ReviewHog didn't also flag.
+- **False positives** (precision): ReviewHog comments `address-pr-reviews` dismissed as not-legit, with the dismissal reason.
+
+Append them to `~/dev/haacked/notes/PostHog/reviewhog-gaps.md` (create the file if needed), one dated entry per run:
 
 ```markdown
 ## 2026-08-15 · PostHog/posthog#123 · e4f5a6b
 - [correctness] `plugin-server/src/worker.ts:42` — off-by-one in retry backoff (fixed)
 - [testing] `frontend/src/lib/api.test.ts` — new endpoint has no error-path test (deferred)
+- [false-positive] `plugin-server/src/worker.ts:88` — claimed unhandled rejection; the caller awaits it
 ```
 
-This file aggregates across repos and runs to feed ReviewHog improvements later — keep entries one line each, tagged with the review dimension, and note whether the finding was fixed or deferred. If ReviewHog never delivered a round (the wait timed out), say so in the entry header instead of logging misses — no round means no basis for comparison.
+Keep entries one line each — misses tagged with the review dimension plus fixed/deferred, false positives tagged `[false-positive]` plus why the claim was wrong. If ReviewHog never delivered a round (the wait timed out), say so in the entry header instead of logging — no round means no basis for comparison.
 
 Append `- reviews-addressed: <short HEAD sha>`.
 
-### Step 10: Explain open items and report
+### Step 10: Watch CI to green
 
-Gather every loose end the run accumulated: items `/simplify` flagged but didn't change, `review-code` Fix Summary items needing judgment or declined, entries in `.notes/review-skipped.md` (if present), and comments `address-pr-reviews` held for the user rather than acting on. Then have them explained:
+First make sure everything is actually pushed — Step 9's deferred push may not have covered every commit. If `git log @{u}..HEAD --oneline` lists anything, `git push`. Then watch the checks:
 
 ```text
-Skill("explain-open")
+Skill("ci-monitor")
+```
+
+It watches the PR's checks, reruns flaky failures, and fixes legit ones — committing and pushing as needed. If ci-monitor committed fixes, update the `reviewhog-requested`, `review-code`, and `reviews-addressed` entries to the new HEAD — mechanical CI repairs don't reopen the review phase, and this keeps a later resume pointed at `ci` instead of rewinding to Step 7. When the checks are green, append `- ci: <short HEAD sha>`. If it can't reach green, leave `ci` unrecorded and carry the failure into the report — the next `/go` resumes here.
+
+### Step 11: Explain open items and report
+
+Gather every loose end the run accumulated: items `/simplify` flagged but didn't change, `review-code` Fix Summary items needing judgment or declined, entries in `.notes/review-skipped.md` (written only by older `review-fix-cycle` runs — usually absent), and comments `address-pr-reviews` held for the user rather than acting on. Then have them explained, passing the PR URL so it reads the saved review artifacts rather than relying on this conversation — a long run may have compacted the review out of context:
+
+```text
+Skill("explain-open", args: "<pr-url>")
 ```
 
 It translates each open or skipped item into plain English, weighs both sides, and recommends a call — this is the part of the report that needs the user's judgment, so lead with it.
 
 Then report the rest:
 
-- Commits added during the run (`git log @{u}..HEAD --oneline` or the range since the initial commit from Step 5)
-- The PR URL (`gh pr view --json url -q .url`)
-- ReviewHog gaps logged this run (count and the `reviewhog-gaps.md` path), or that ReviewHog was skipped/timed out
+- Commits added during the run — `git log <simplify-commit sha>^..HEAD --oneline` using the state file's first recorded sha (everything is pushed by now, so `@{u}..HEAD` comes back empty)
+- The PR URL (`gh pr view --json url -q .url`) and CI status
+- Gap entries logged this run — misses and false positives, with the `reviewhog-gaps.md` path — or that ReviewHog was skipped/timed out
 - Any drafted replies to human reviewers awaiting approval — these are never posted automatically
 
 If any step failed, tell the user which one and what's needed to finish it; the state file keeps it as the resume point for the next `/go`.

--- a/ai/skills/go/SKILL.md
+++ b/ai/skills/go/SKILL.md
@@ -57,7 +57,7 @@ Extract from `$ARGUMENTS`:
 Gather the facts in one round trip:
 
 ```bash
-git check-ignore -q .notes 2>/dev/null || echo '.notes/' >> "$(git rev-parse --git-common-dir)/info/exclude"
+git check-ignore -q .notes/go-state.md 2>/dev/null || echo '.notes/' >> "$(git rev-parse --git-common-dir)/info/exclude"
 git status --porcelain
 git log @{u}..HEAD --oneline 2>/dev/null | head -20
 git rev-parse --short HEAD
@@ -79,7 +79,7 @@ When the branch has no upstream, `@{u}` yields nothing — count branch commits 
 - If the adopted diff (dirty files plus commits since the merge-base with the default branch) touches testable code but no test files, dispatch `unit-test-writer` in the background now, prompted with the diff: write tests for the changed behavior, match existing test conventions, report which fail. Note the gap in the position report. Fold the results in at the next commit — resuming at Step 5, collect after `/simplify` so the tests ride the same commit; resuming later, collect before Step 7 starts, reconcile guessed names against the real code, run the suite, and commit via `Skill("commit", args: "--force Add tests for $SLUG")`. Skip the dispatch for diffs with no testable behavior (docs, config).
 - Nothing to resume (clean tree, no branch commits, no PR, no `TASK`) → stop and ask the user what to build.
 
-**Work branch guard.** If HEAD is detached or the current branch is the repo's default branch, create and switch to `haacked/$SLUG` before anything commits — uncommitted work carries over with the checkout. If the default branch also had local commits its upstream lacks, they're on the new branch now; point the default branch back at its upstream (`git branch -f main origin/main`) so the work lives only on the feature branch, and say so in the position report. A branch created here has no PR yet — leave `pr` pending regardless of what the earlier lookup returned.
+**Work branch guard.** If HEAD is detached or the current branch is the repo's default branch, create and switch to `haacked/$SLUG` before anything commits — uncommitted work carries over with the checkout. If the default branch also had local commits its upstream lacks, they're on the new branch now; point the default branch back at its upstream (`git branch -f <default> origin/<default>`) so the work lives only on the feature branch, and say so in the position report. A branch created here has no PR yet — leave `pr` pending regardless of what the earlier lookup returned.
 
 **Compute the resume point.** If `ci` equals current HEAD and the working tree is clean, the pipeline is complete — report the all-done checklist and stop. Otherwise the resume point is the first step in pipeline order that is missing from the state file or stale:
 

--- a/ai/skills/go/SKILL.md
+++ b/ai/skills/go/SKILL.md
@@ -8,7 +8,7 @@ argument-hint: "<task description> [--skip-planner] [--skip-copilot] [--plan-fil
 
 End-to-end orchestrator: plan → implement → simplify → commit → open draft PR → Claude review loop → Copilot review loop → one final Claude review pass to catch anything Copilot's fixes introduced.
 
-The pipeline is idempotent. `.notes/go-state.md` tracks progress, so re-running `/go` reports where the pipeline stands and resumes from the first incomplete or stale step. On a branch `/go` never drove, it infers position from the working tree, branch commits, and PR, then proceeds as if it had been running all along.
+The pipeline is idempotent. `.notes/go-state.md` tracks progress, so re-running `/go` reports where the pipeline stands and resumes from the first incomplete or stale step. On a branch `/go` never drove, it infers position from the session conversation, working tree, branch commits, and PR, then proceeds as if it had been running all along.
 
 The expensive steps (`review-fix-loop.sh`, `copilot-review-loop.sh`) run each round in a fresh `claude -p` subprocess, so the main context only carries planning and the initial implementation.
 
@@ -68,8 +68,9 @@ gh pr list --head "$(git branch --show-current)" --json number,state,isDraft --j
 
 **Resuming without a state file** (a session `/go` didn't drive): infer entries from the world and write them to a new state file:
 
-- Commits ahead of upstream/base, or a dirty tree → `implement: done`. Derive `SLUG` from the branch name (minus any `owner/` prefix), or from the latest commit subject when the branch name carries no signal (default branch, detached HEAD).
-- Clean tree with branch commits → also `simplify-commit: <HEAD sha>`.
+- Commits ahead of upstream/base, or a dirty tree → an implementation exists. Derive `SLUG` from the branch name (minus any `owner/` prefix), or from the latest commit subject when the branch name carries no signal (default branch, detached HEAD).
+- Judge whether that implementation is finished. The original ask is usually in the session conversation — compare it against what the diff delivers — and the diff itself signals incompleteness: TODO/FIXME markers it introduces, stubbed or never-wired functions, failures mentioned in the session but never fixed. If work remains, write a brief (goal from the original ask, what's already in place, what remains, definition of done), record `plan: brief`, and leave `implement` unrecorded so the resume point lands on Step 4 to finish the job — and skip the test-gap dispatch below, since Step 4 dispatches its own tester with that brief. If the work looks complete, or there's no evidence either way, record `implement: done` — simplify and the review loops take it from there.
+- If `implement` was recorded done and the tree is clean with branch commits → also `simplify-commit: <HEAD sha>`.
 - Open PR on the branch → `pr: <number>`.
 - Review steps are never inferred — leave them pending. The loops converge quickly when there's nothing to find.
 - If the adopted diff (dirty files plus commits since the merge-base with the default branch) touches testable code but no test files, dispatch `unit-test-writer` in the background now, prompted with the diff: write tests for the changed behavior, match existing test conventions, report which fail. Note the gap in the position report. Fold the results in at the next commit — resuming at Step 5, collect after `/simplify` so the tests ride the same commit; resuming later, collect before Step 7 starts, reconcile guessed names against the real code, run the suite, and commit via `Skill("commit", args: "--force Add tests for $SLUG")`. Skip the dispatch for diffs with no testable behavior (docs, config).

--- a/ai/skills/go/SKILL.md
+++ b/ai/skills/go/SKILL.md
@@ -1,22 +1,22 @@
 ---
 name: go
-description: Plan, implement, and iteratively review a task end-to-end using Claude + Copilot reviewers in a linear flow. Idempotent — re-running reports where the pipeline stands and resumes from the first incomplete step.
-argument-hint: "<task description> [--skip-planner] [--skip-copilot] [--plan-file <path>]"
+description: Plan, implement, and review a task end-to-end — review-code + ReviewHog in parallel, every review addressed, open items explained. Idempotent — re-running reports where the pipeline stands and resumes from the first incomplete step.
+argument-hint: "<task description> [--skip-planner] [--skip-reviewhog] [--plan-file <path>]"
 ---
 
 # /go
 
-End-to-end orchestrator: plan → implement → simplify → commit → open draft PR → Claude review loop → Copilot review loop → one final Claude review pass to catch anything Copilot's fixes introduced.
+End-to-end orchestrator: plan → implement → simplify → commit → open draft PR → request a ReviewHog round → run `review-code --fix` while ReviewHog works → address every review comment → explain the open items that need the user's judgment.
 
 The pipeline is idempotent. `.notes/go-state.md` tracks progress, so re-running `/go` reports where the pipeline stands and resumes from the first incomplete or stale step. On a branch `/go` never drove, it infers position from the session conversation, working tree, branch commits, and PR, then proceeds as if it had been running all along.
 
-The expensive steps (`review-fix-loop.sh`, `copilot-review-loop.sh`) run each round in a fresh `claude -p` subprocess, so the main context only carries planning and the initial implementation.
+The review phase delegates to skills that fan out their own subagents (`review-code`'s reviewer fleet, `wait-for-pr-reviews` chaining `address-pr-reviews`), so the main context carries orchestration, planning, and the initial implementation.
 
 ## Arguments
 
 - `<task description>` — what to build/fix. Omit to resume: `/go` detects the branch's position and continues from there (see Step 2).
 - `--skip-planner` — skip the `implementation-planner` sub-agent; implement directly from the description.
-- `--skip-copilot` — skip the Copilot rounds and the final Claude pass. Useful when there's no PR yet or Copilot is unavailable.
+- `--skip-reviewhog` — don't request or wait on a ReviewHog round; `review-code` and the explain-open wrap-up still run. Applied automatically when the `reviewhog` label can't be added (the repo doesn't have it).
 - `--plan-file <path>` — use an already-approved plan file directly (e.g. one written by Plan Mode) instead of looking up or generating one. Implies skipping the planner.
 
 ## State file
@@ -32,12 +32,12 @@ plan: ~/dev/ai/plans/haacked/dotfiles/add-dark-mode-toggle.md
 - implement: done
 - simplify-commit: a1b2c3d
 - pr: 123
-- claude-review: e4f5a6b
-- copilot-review: f7a8b9c
-- final-review: f7a8b9c
+- reviewhog-requested: done
+- review-code: e4f5a6b
+- reviews-addressed: f7a8b9c
 ```
 
-Step values are `git rev-parse --short HEAD` captured when the step finished (`done` for `implement`, the PR number for `pr`). If `branch:` doesn't match the current branch, ignore the file and re-infer per Step 2.
+Step values are `git rev-parse --short HEAD` captured when the step finished (`done` for `implement`, the PR number for `pr`, `done` or `skipped` for `reviewhog-requested`). If `branch:` doesn't match the current branch, ignore the file and re-infer per Step 2.
 
 ## Steps
 
@@ -46,7 +46,7 @@ Step values are `git rev-parse --short HEAD` captured when the step finished (`d
 Extract from `$ARGUMENTS`:
 
 - `SKIP_PLANNER` — boolean, true if `--skip-planner` is present.
-- `SKIP_COPILOT` — boolean, true if `--skip-copilot` is present.
+- `SKIP_REVIEWHOG` — boolean, true if `--skip-reviewhog` is present.
 - `PLAN_FILE` — the path following `--plan-file`, if present.
 - `TASK` — everything else, joined with spaces.
 - `SLUG` — short kebab-case identifier derived from `TASK` (e.g. "add dark mode toggle" → "add-dark-mode-toggle"). Used in commit messages and planner descriptions. If `TASK` is empty, `SLUG` comes from the state file, the plan file's first heading, or the branch name — resolved in Step 2.
@@ -61,7 +61,7 @@ git status --porcelain
 git log @{u}..HEAD --oneline 2>/dev/null | head -20
 git rev-parse --short HEAD
 cat .notes/go-state.md 2>/dev/null
-gh pr list --head "$(git branch --show-current)" --json number,state,isDraft --jq '.[0] // empty'
+gh pr list --head "$(git branch --show-current)" --json number,state,isDraft,labels --jq '.[0] // empty'
 ```
 
 **Fresh cycle or resume?** If `TASK` or `PLAN_FILE` is given and the state file is missing or names a different slug, this is a new cycle: write a fresh `.notes/go-state.md` header (branch, slug, plan pending), apply the work branch guard below, and run everything from Step 3. If `TASK` matches the state file's slug, or no `TASK` was given, resume.
@@ -72,13 +72,13 @@ gh pr list --head "$(git branch --show-current)" --json number,state,isDraft --j
 - Judge whether that implementation is finished. The original ask is usually in the session conversation — compare it against what the diff delivers — and the diff itself signals incompleteness: TODO/FIXME markers it introduces, stubbed or never-wired functions, failures mentioned in the session but never fixed. If work remains, write a brief (goal from the original ask, what's already in place, what remains, definition of done), record `plan: brief`, and leave `implement` unrecorded so the resume point lands on Step 4 to finish the job — and skip the test-gap dispatch below, since Step 4 dispatches its own tester with that brief. If the work looks complete, or there's no evidence either way, record `implement: done` — simplify and the review loops take it from there.
 - If `implement` was recorded done and the tree is clean with branch commits → also `simplify-commit: <HEAD sha>`.
 - Open PR on the branch → `pr: <number>`.
-- Review steps are never inferred — leave them pending. The loops converge quickly when there's nothing to find.
+- Review steps are never inferred — leave them pending. Re-reviewing already-reviewed work is cheap; skipping an un-run review isn't.
 - If the adopted diff (dirty files plus commits since the merge-base with the default branch) touches testable code but no test files, dispatch `unit-test-writer` in the background now, prompted with the diff: write tests for the changed behavior, match existing test conventions, report which fail. Note the gap in the position report. Fold the results in at the next commit — resuming at Step 5, collect after `/simplify` so the tests ride the same commit; resuming later, collect before Step 7 starts, reconcile guessed names against the real code, run the suite, and commit via `Skill("commit", args: "--force Add tests for $SLUG")`. Skip the dispatch for diffs with no testable behavior (docs, config).
 - Nothing to resume (clean tree, no branch commits, no PR, no `TASK`) → stop and ask the user what to build.
 
 **Work branch guard.** If HEAD is detached or the current branch is the repo's default branch, create and switch to `haacked/$SLUG` before anything commits — uncommitted work carries over with the checkout. If the default branch also had local commits its upstream lacks, they're on the new branch now; point the default branch back at its upstream (`git branch -f main origin/main`) so the work lives only on the feature branch, and say so in the position report. A branch created here has no PR yet — leave `pr` pending regardless of what the earlier lookup returned.
 
-**Compute the resume point.** If `final-review` equals current HEAD (or `claude-review` does and `SKIP_COPILOT` is set), the pipeline is complete — report the all-done checklist and stop. Otherwise the resume point is the first step in pipeline order that is missing from the state file or stale:
+**Compute the resume point.** If `reviews-addressed` equals current HEAD (or `review-code` does and ReviewHog was skipped — `SKIP_REVIEWHOG` or `reviewhog-requested: skipped`), the pipeline is complete — report the all-done checklist and stop. Otherwise the resume point is the first step in pipeline order that is missing from the state file or stale:
 
 | Step | Done when | Stale when |
 | --- | --- | --- |
@@ -86,9 +86,9 @@ gh pr list --head "$(git branch --show-current)" --json number,state,isDraft --j
 | implement | entry present | never |
 | simplify-commit | sha recorded and the tree is clean | tree is dirty — new work needs simplify + commit |
 | pr | number recorded, or an open PR exists on the branch | PR closed or merged → report it and stop; this branch is finished |
-| claude-review | sha equals current HEAD | HEAD has moved since the last clean pass |
-| copilot-review | sha equals current HEAD | HEAD has moved |
-| final-review | sha equals current HEAD | HEAD has moved |
+| reviewhog-requested | `done`/`skipped` recorded, or the `reviewhog` label is already on the PR | never — the label persists; new rounds are ReviewHog's own behavior |
+| review-code | sha equals current HEAD | HEAD has moved since the last pass |
+| reviews-addressed | sha equals current HEAD (not required when ReviewHog was skipped) | HEAD has moved |
 
 Report the position to the user as a short checklist before continuing — ✓ done (with its sha or PR number), → resume point (with why it's pending or stale), · not yet run. Then run linearly from the resume point; every later step executes as normal.
 
@@ -150,7 +150,7 @@ Tests written with the implementation in view tend to mirror it instead of testi
 
 Then implement the change in the current context. Follow the plan file if one exists, otherwise work directly from `TASK`. This step is conversational — check in with the user on judgment calls.
 
-**Preserve context aggressively.** The review loops in Steps 7–9 run in fresh subprocesses, but Step 4 stays in main context through the rest of the run. Every file read and search compounds. Push expensive reads into subagents that return summaries instead of raw content:
+**Preserve context aggressively.** The review phase in Steps 7–9 delegates its heavy lifting to skills and subagents, but Step 4 stays in main context through the rest of the run. Every file read and search compounds. Push expensive reads into subagents that return summaries instead of raw content:
 
 - **Codebase exploration** (anything that would take more than ~3 greps/reads to answer): spawn `Explore`. Ask for the specific answer, not a file dump — e.g. "where is auth middleware registered and what's its call signature?" rather than "show me the auth code".
 - **Writing tests**: already running in the background from the dispatch above. Only spawn another `unit-test-writer` for behavior discovered during implementation that the spec didn't cover. Don't read the test file into main context first — the subagent will.
@@ -165,7 +165,7 @@ Append `- implement: done` to the state file.
 
 ### Step 5: Simplify and commit
 
-Invoke `/simplify` (bundled Claude slash command — not a skill). It applies its own fixes.
+Invoke `/simplify` (bundled Claude slash command — not a skill). It applies its own fixes. Note anything it flags but declines to change — those items feed the explain-open wrap-up in Step 10.
 
 Then commit. Use a message that matches the situation:
 
@@ -194,53 +194,78 @@ Skill("create-pr", args: "--force")
 
 Append `- pr: <number>` to the state file.
 
-### Step 7: Claude review loop (until convergence)
+### Step 7: Request a ReviewHog round
 
-Run the existing fresh-context review loop via the Bash tool:
+If `SKIP_REVIEWHOG` is true, record `- reviewhog-requested: skipped` and go to Step 8.
 
-```bash
-~/.dotfiles/bin/review-fix-loop.sh
-```
-
-It iterates Claude review → fix → simplify → commit until a round comes back clean (or hits its own max-iterations). Exits 0 on clean, non-zero if findings remain.
-
-On exit 0, append `- claude-review: <short HEAD sha>` (HEAD after the loop's commits). On non-zero exit, leave the entry unrecorded so the next `/go` retries this step, and continue.
-
-### Step 8: Copilot review loop (until convergence)
-
-If `SKIP_COPILOT` is true, skip to Step 10.
-
-Otherwise run the Copilot loop against the current branch's PR:
+Push any unpushed commits first so ReviewHog reviews the branch's current state, then add the label that triggers its round:
 
 ```bash
-~/.dotfiles/bin/copilot-review-loop.sh
+git push 2>/dev/null
+gh pr edit "$PR_NUMBER" --add-label reviewhog
 ```
 
-It auto-detects the PR from the current branch, fetches Copilot's review, fixes legit findings, replies to and resolves dismissed Copilot threads, pushes, and repeats until Copilot has no new comments. Replies to human reviewers are never auto-posted; the loop drafts them and prints them at the end for you to review and post.
+If the label add fails (the repo has no `reviewhog` label), tell the user, set `SKIP_REVIEWHOG=true`, and record `- reviewhog-requested: skipped`. Otherwise record `- reviewhog-requested: done`. Either way, continue immediately — ReviewHog works in the background while Step 8 runs.
 
-On convergence, append `- copilot-review: <short HEAD sha>`.
+### Step 8: Review our own side while ReviewHog works
 
-### Step 9: Final Claude pass
+Run the full reviewer fleet against the PR and apply the clean fixes:
 
-Rerun the Claude review loop once more to catch anything Copilot's fixes introduced:
-
-```bash
-~/.dotfiles/bin/review-fix-loop.sh
+```text
+Skill("review-code", args: "<pr-url> --fix")
 ```
 
-`review-fix-cycle` uses `--append` internally, so this pass only surfaces new findings. It typically exits clean on the first iteration.
+Its Fix Summary lists what was fixed, what needs a judgment call, and what it declined to fix — keep that in reach: Step 9 compares it against ReviewHog's round and Step 10 explains the open items.
 
-On exit 0, append `- final-review: <short HEAD sha>`.
+Commit the fixes but **don't push** — a mid-round push can retrigger ReviewHog and extend the wait; `wait-for-pr-reviews` owns the single push at the end of Step 9:
 
-### Step 10: Report
+```text
+Skill("commit", args: "--force Address review findings")
+```
 
-Tell the user what happened:
+Append `- review-code: <short HEAD sha>`. If ReviewHog was skipped, push now (`git push`) since Step 9's wait won't run.
+
+### Step 9: Wait for ReviewHog, address every review
+
+If `SKIP_REVIEWHOG` is true, go to Step 10.
+
+Hand the wait and the comment processing to the skill built for it:
+
+```text
+Skill("wait-for-pr-reviews")
+```
+
+It detects the in-flight ReviewHog round (and any other pending reviewers), runs `address-pr-reviews` on comments that already exist while waiting, re-runs it when the round lands, and pushes once at the end. Replies to human reviewers surface for approval per that skill's own rules — never auto-posted.
+
+**Then log ReviewHog's misses.** Compare `review-code`'s legit findings from Step 8 — the fixed ones plus real-but-deferred items from its Fix Summary — against everything ReviewHog raised this round. Append each legit finding ReviewHog didn't also flag to `~/dev/haacked/notes/PostHog/reviewhog-gaps.md` (create the file if needed), one dated entry per run:
+
+```markdown
+## 2026-08-15 · PostHog/posthog#123 · e4f5a6b
+- [correctness] `plugin-server/src/worker.ts:42` — off-by-one in retry backoff (fixed)
+- [testing] `frontend/src/lib/api.test.ts` — new endpoint has no error-path test (deferred)
+```
+
+This file aggregates across repos and runs to feed ReviewHog improvements later — keep entries one line each, tagged with the review dimension, and note whether the finding was fixed or deferred. If ReviewHog never delivered a round (the wait timed out), say so in the entry header instead of logging misses — no round means no basis for comparison.
+
+Append `- reviews-addressed: <short HEAD sha>`.
+
+### Step 10: Explain open items and report
+
+Gather every loose end the run accumulated: items `/simplify` flagged but didn't change, `review-code` Fix Summary items needing judgment or declined, entries in `.notes/review-skipped.md` (if present), and comments `address-pr-reviews` held for the user rather than acting on. Then have them explained:
+
+```text
+Skill("explain-open")
+```
+
+It translates each open or skipped item into plain English, weighs both sides, and recommends a call — this is the part of the report that needs the user's judgment, so lead with it.
+
+Then report the rest:
 
 - Commits added during the run (`git log @{u}..HEAD --oneline` or the range since the initial commit from Step 5)
 - The PR URL (`gh pr view --json url -q .url`)
-- Any outstanding findings — check `.notes/review-skipped.md` for Claude's deferred items and the Copilot state file under `~/.local/state/copilot-review-loop/` for low-confidence Copilot items flagged for human review.
-- Any drafted replies to human reviewers the loop printed under "Human Reviewer Replies to Post" — these are not posted automatically; surface them so the user can review and post.
+- ReviewHog gaps logged this run (count and the `reviewhog-gaps.md` path), or that ReviewHog was skipped/timed out
+- Any drafted replies to human reviewers awaiting approval — these are never posted automatically
 
-If any step exited non-zero, tell the user which one and where the logs are (`.notes/` for Claude, `~/.local/state/copilot-review-loop/` for Copilot).
+If any step failed, tell the user which one and what's needed to finish it; the state file keeps it as the resume point for the next `/go`.
 
 The state file now records the full pipeline at HEAD, so re-running `/go` reports all-done and stops — until new commits or edits land, which mark the affected steps stale again.


### PR DESCRIPTION
- `/go` now tracks pipeline progress in `.notes/go-state.md` with sha-stamped step entries. Re-running reports where the pipeline stands and resumes at the first incomplete or stale step. On a branch `/go` never drove, it infers position from the session, tree, commits, and PR state, judges whether the implementation looks finished, moves work off the default branch if needed, and backfills tests when the adopted diff has none.
- The review phase replaces the Copilot loop with ReviewHog: push, add the `reviewhog` label (PostHog org repos only), run `review-code --fix` while the round is in flight, then `wait-for-pr-reviews` chains `address-pr-reviews` around the wait. One label add buys one round at one head (ReviewHog removes the label after each round and pushes never retrigger it), so resumed runs re-request on new commits. Legit `review-code` findings ReviewHog missed, plus ReviewHog comments dismissed as false positives, get logged to `reviewhog-gaps.md` to feed ReviewHog improvements later. The run ends with `ci-monitor` watching checks to green and `explain-open` walking through the items that need a human call.
- The `go` skill and the `implementation-planner`, `unit-test-writer`, and `bug-root-cause-analyzer` agents inherit the session model instead of pinning sonnet or opus.

## Test plan

- Run `/go` twice on a branch with committed work: the second run prints the position checklist and stops at all-done instead of redoing steps.
- Run `/go` with no arguments in a session that implemented something without `/go`: it adopts the work, then simplifies, commits, and opens a PR.
- Run `/go` on a non-PostHog repo: it skips ReviewHog but still runs `review-code`, a single `address-pr-reviews` pass, `ci-monitor`, and `explain-open`.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*