### PR TITLE
Extract derive_org_repo as the single owner of origin parsing

### DIFF
--- a/ai/helpers/repo-context.sh
+++ b/ai/helpers/repo-context.sh
@@ -12,10 +12,14 @@
 # shellcheck disable=SC2034  # REPO_ORG/REPO_REPO are consumed by callers.
 derive_org_repo() {
     local remote_url
+    REPO_ORG=""
+    REPO_REPO=""
     remote_url=$(git remote get-url origin 2>/dev/null) || return 1
-    if [[ "$remote_url" =~ github\.com(-[^:/]+)?[:/]([^/]+)/([^/]+)$ ]]; then
-        REPO_ORG="${BASH_REMATCH[2]}"
-        REPO_REPO="${BASH_REMATCH[3]%.git}"
+    # The (^|[/@]) boundary keeps lookalike hosts (mygithub.com, foo.github.com)
+    # from matching while accepting scp, ssh://, and https:// URL shapes.
+    if [[ "$remote_url" =~ (^|[/@])github\.com(-[^:/]+)?[:/]([^/]+)/([^/]+)$ ]]; then
+        REPO_ORG="${BASH_REMATCH[3]}"
+        REPO_REPO="${BASH_REMATCH[4]%.git}"
         return 0
     fi
     return 1

--- a/ai/helpers/repo-context.sh
+++ b/ai/helpers/repo-context.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Derive the GitHub org/repo of the current directory's origin remote.
+#
+# Usage: source repo-context.sh, then: derive_org_repo || <no-github fallback>
+#
+# Sets REPO_ORG and REPO_REPO on success (return 0); returns 1 when there is no
+# repo, no origin, or the URL isn't GitHub-shaped. Handles SSH host aliases
+# (git@github.com-work:Org/repo.git) and repo names containing dots
+# (PostHog/posthog.com); a trailing .git is stripped. Hosts that merely start
+# with github.com (github.company.com) do not match.
+
+# shellcheck disable=SC2034  # REPO_ORG/REPO_REPO are consumed by callers.
+derive_org_repo() {
+    local remote_url
+    remote_url=$(git remote get-url origin 2>/dev/null) || return 1
+    if [[ "$remote_url" =~ github\.com(-[^:/]+)?[:/]([^/]+)/([^/]+)$ ]]; then
+        REPO_ORG="${BASH_REMATCH[2]}"
+        REPO_REPO="${BASH_REMATCH[3]%.git}"
+        return 0
+    fi
+    return 1
+}

--- a/ai/helpers/tests/test-repo-context.sh
+++ b/ai/helpers/tests/test-repo-context.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Tests for derive_org_repo across origin URL shapes.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/../repo-context.sh"
+
+passes=0
+failures=0
+
+check() { # desc actual expected
+    if [[ "$2" == "$3" ]]; then
+        passes=$((passes + 1))
+    else
+        echo "FAIL: $1"
+        echo "  expected [$3], got [$2]"
+        failures=$((failures + 1))
+    fi
+}
+
+try_url() { # url -> prints "org/repo" or "none"
+    local d
+    d=$(mktemp -d)
+    git -C "$d" init -q
+    git -C "$d" remote add origin "$1"
+    (cd "$d" && if derive_org_repo; then printf '%s/%s\n' "$REPO_ORG" "$REPO_REPO"; else echo none; fi)
+    rm -rf "$d"
+}
+
+check "ssh url" "$(try_url 'git@github.com:PostHog/posthog.git')" "PostHog/posthog"
+check "https with .git" "$(try_url 'https://github.com/haacked/dotfiles.git')" "haacked/dotfiles"
+check "https bare" "$(try_url 'https://github.com/haacked/dotfiles')" "haacked/dotfiles"
+check "ssh host alias" "$(try_url 'git@github.com-work:PostHog/posthog.git')" "PostHog/posthog"
+check "dotted repo name" "$(try_url 'git@github.com:PostHog/posthog.com.git')" "PostHog/posthog.com"
+check "non-github origin" "$(try_url 'git@gitlab.com:org/repo.git')" "none"
+check "github-prefixed host rejected" "$(try_url 'git@github.company.com:org/repo.git')" "none"
+check "outside a repo" "$( (cd "$(mktemp -d)" && if derive_org_repo; then echo yes; else echo none; fi) )" "none"
+
+echo ""
+echo "Passed: ${passes}, Failed: ${failures}"
+[[ "${failures}" -eq 0 ]]

--- a/ai/helpers/tests/test-repo-context.sh
+++ b/ai/helpers/tests/test-repo-context.sh
@@ -22,10 +22,10 @@ check() { # desc actual expected
 try_url() { # url -> prints "org/repo" or "none"
     local d
     d=$(mktemp -d)
+    trap 'rm -rf "$d"' RETURN
     git -C "$d" init -q
     git -C "$d" remote add origin "$1"
     (cd "$d" && if derive_org_repo; then printf '%s/%s\n' "$REPO_ORG" "$REPO_REPO"; else echo none; fi)
-    rm -rf "$d"
 }
 
 check "ssh url" "$(try_url 'git@github.com:PostHog/posthog.git')" "PostHog/posthog"
@@ -35,6 +35,9 @@ check "ssh host alias" "$(try_url 'git@github.com-work:PostHog/posthog.git')" "P
 check "dotted repo name" "$(try_url 'git@github.com:PostHog/posthog.com.git')" "PostHog/posthog.com"
 check "non-github origin" "$(try_url 'git@gitlab.com:org/repo.git')" "none"
 check "github-prefixed host rejected" "$(try_url 'git@github.company.com:org/repo.git')" "none"
+check "github-suffixed host rejected" "$(try_url 'https://mygithub.com/org/repo')" "none"
+check "github subdomain rejected" "$(try_url 'https://foo.github.com/org/repo')" "none"
+check "ssh:// url accepted" "$(try_url 'ssh://git@github.com/PostHog/posthog.git')" "PostHog/posthog"
 check "outside a repo" "$( (cd "$(mktemp -d)" && if derive_org_repo; then echo yes; else echo none; fi) )" "none"
 
 echo ""

--- a/ai/skills/followup/scripts/followup-add.sh
+++ b/ai/skills/followup/scripts/followup-add.sh
@@ -18,19 +18,19 @@ fi
 
 text="$*"
 
+# shellcheck source=/dev/null
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)/../../../helpers/repo-context.sh"
+
 # Derive the [org/repo · branch] context; record [no-repo] when there is no parseable GitHub origin.
 context="no-repo"
 repo=""
-if git rev-parse --git-dir > /dev/null 2>&1; then
-    remote_url=$(git remote get-url origin 2>/dev/null || echo "")
-    if [[ "$remote_url" =~ github\.com[:/]([^/]+)/([^/.]+)(\.git)?$ ]]; then
-        repo="${BASH_REMATCH[1]}/${BASH_REMATCH[2]}"
-        branch=$(git branch --show-current 2>/dev/null || echo "")
-        if [[ -n "$branch" ]]; then
-            context="${repo} · ${branch}"
-        else
-            context="$repo"
-        fi
+if derive_org_repo; then
+    repo="${REPO_ORG}/${REPO_REPO}"
+    branch=$(git branch --show-current 2>/dev/null || echo "")
+    if [[ -n "$branch" ]]; then
+        context="${repo} · ${branch}"
+    else
+        context="$repo"
     fi
 fi
 

--- a/ai/skills/followup/scripts/followup-detect.sh
+++ b/ai/skills/followup/scripts/followup-detect.sh
@@ -12,11 +12,14 @@ STALE_DAYS=14
 open_helper="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)/followup-open.sh"
 [[ -x "$open_helper" ]] || exit 0
 
+repo_context="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd -P)/../../../helpers/repo-context.sh"
+[[ -f "$repo_context" ]] || exit 0
+# shellcheck source=/dev/null
+source "$repo_context"
+
 # Only surface inside a git repo with a parseable GitHub origin.
-# `git remote get-url` also fails outside a repo, so it doubles as the repo guard.
-remote_url=$(git remote get-url origin 2>/dev/null) || exit 0
-[[ "$remote_url" =~ github\.com[:/]([^/]+)/([^/.]+)(\.git)?$ ]] || exit 0
-repo="${BASH_REMATCH[1]}/${BASH_REMATCH[2]}"
+derive_org_repo || exit 0
+repo="${REPO_ORG}/${REPO_REPO}"
 
 open_lines=$("$open_helper" 2>/dev/null) || exit 0
 [[ -n "$open_lines" ]] || exit 0

--- a/ai/skills/handoff/scripts/handoff-path.sh
+++ b/ai/skills/handoff/scripts/handoff-path.sh
@@ -12,12 +12,14 @@
 
 set -euo pipefail
 
+# shellcheck source=/dev/null
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)/../../../helpers/repo-context.sh"
+
 if git_root=$(git rev-parse --show-toplevel 2>/dev/null); then
     path="${git_root}/.notes/handoff.md"
 
-    remote_url=$(git remote get-url origin 2>/dev/null || echo "")
-    if [[ "$remote_url" =~ github\.com[:/]([^/]+)/([^/.]+)(\.git)?$ ]]; then
-        scope="repo:${BASH_REMATCH[1]}/${BASH_REMATCH[2]}"
+    if derive_org_repo; then
+        scope="repo:${REPO_ORG}/${REPO_REPO}"
     else
         scope="repo:$(basename "$git_root")"
     fi

--- a/ai/skills/note/scripts/note-find-or-create.sh
+++ b/ai/skills/note/scripts/note-find-or-create.sh
@@ -31,7 +31,7 @@ fi
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)/../../../helpers/repo-context.sh"
 
 if ! derive_org_repo; then
-    echo "Error: could not determine GitHub org/repo from the origin remote" >&2
+    echo "Error: could not determine GitHub org/repo (not a git repo, no origin remote, or origin is not GitHub)" >&2
     exit 1
 fi
 org="$REPO_ORG"

--- a/ai/skills/note/scripts/note-find-or-create.sh
+++ b/ai/skills/note/scripts/note-find-or-create.sh
@@ -27,29 +27,15 @@ if ! [[ "$slug" =~ ^[a-z0-9]+(-[a-z0-9]+)*$ ]]; then
     exit 1
 fi
 
-# Get org/repo from git remote
-if ! git rev-parse --git-dir > /dev/null 2>&1; then
-    echo "Error: not in a git repository" >&2
-    exit 1
-fi
+# shellcheck source=/dev/null
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)/../../../helpers/repo-context.sh"
 
-remote_url=$(git remote get-url origin 2>/dev/null || echo "")
-if [[ -z "$remote_url" ]]; then
-    echo "Error: no origin remote found" >&2
+if ! derive_org_repo; then
+    echo "Error: could not determine GitHub org/repo from the origin remote" >&2
     exit 1
 fi
-
-# Parse org/repo from various git URL formats:
-# - git@github.com:org/repo.git
-# - https://github.com/org/repo.git
-# - https://github.com/org/repo
-if [[ "$remote_url" =~ github\.com[:/]([^/]+)/([^/.]+)(\.git)?$ ]]; then
-    org="${BASH_REMATCH[1]}"
-    repo="${BASH_REMATCH[2]}"
-else
-    echo "Error: could not parse org/repo from remote URL: $remote_url" >&2
-    exit 1
-fi
+org="$REPO_ORG"
+repo="$REPO_REPO"
 
 # Use different notes location for PostHog repos
 org_lower=$(echo "$org" | tr '[:upper:]' '[:lower:]')

--- a/ai/skills/note/scripts/note-find.sh
+++ b/ai/skills/note/scripts/note-find.sh
@@ -30,7 +30,7 @@ fi
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)/../../../helpers/repo-context.sh"
 
 if ! derive_org_repo; then
-    echo "Error: could not determine GitHub org/repo from the origin remote" >&2
+    echo "Error: could not determine GitHub org/repo (not a git repo, no origin remote, or origin is not GitHub)" >&2
     exit 1
 fi
 org="$REPO_ORG"

--- a/ai/skills/note/scripts/note-find.sh
+++ b/ai/skills/note/scripts/note-find.sh
@@ -26,29 +26,15 @@ if ! [[ "$slug" =~ ^[a-z0-9]+(-[a-z0-9]+)*$ ]]; then
     exit 1
 fi
 
-# Get org/repo from git remote
-if ! git rev-parse --git-dir > /dev/null 2>&1; then
-    echo "Error: not in a git repository" >&2
-    exit 1
-fi
+# shellcheck source=/dev/null
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)/../../../helpers/repo-context.sh"
 
-remote_url=$(git remote get-url origin 2>/dev/null || echo "")
-if [[ -z "$remote_url" ]]; then
-    echo "Error: no origin remote found" >&2
+if ! derive_org_repo; then
+    echo "Error: could not determine GitHub org/repo from the origin remote" >&2
     exit 1
 fi
-
-# Parse org/repo from various git URL formats:
-# - git@github.com:org/repo.git
-# - https://github.com/org/repo.git
-# - https://github.com/org/repo
-if [[ "$remote_url" =~ github\.com[:/]([^/]+)/([^/.]+)(\.git)?$ ]]; then
-    org="${BASH_REMATCH[1]}"
-    repo="${BASH_REMATCH[2]}"
-else
-    echo "Error: could not parse org/repo from remote URL: $remote_url" >&2
-    exit 1
-fi
+org="$REPO_ORG"
+repo="$REPO_REPO"
 
 # Use different notes location for PostHog repos
 org_lower=$(echo "$org" | tr '[:upper:]' '[:lower:]')

--- a/ai/skills/note/scripts/note-list.sh
+++ b/ai/skills/note/scripts/note-list.sh
@@ -15,7 +15,7 @@ set -euo pipefail
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)/../../../helpers/repo-context.sh"
 
 if ! derive_org_repo; then
-    echo "Error: could not determine GitHub org/repo from the origin remote" >&2
+    echo "Error: could not determine GitHub org/repo (not a git repo, no origin remote, or origin is not GitHub)" >&2
     exit 1
 fi
 org="$REPO_ORG"

--- a/ai/skills/note/scripts/note-list.sh
+++ b/ai/skills/note/scripts/note-list.sh
@@ -11,29 +11,15 @@
 
 set -euo pipefail
 
-# Get org/repo from git remote
-if ! git rev-parse --git-dir > /dev/null 2>&1; then
-    echo "Error: not in a git repository" >&2
-    exit 1
-fi
+# shellcheck source=/dev/null
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)/../../../helpers/repo-context.sh"
 
-remote_url=$(git remote get-url origin 2>/dev/null || echo "")
-if [[ -z "$remote_url" ]]; then
-    echo "Error: no origin remote found" >&2
+if ! derive_org_repo; then
+    echo "Error: could not determine GitHub org/repo from the origin remote" >&2
     exit 1
 fi
-
-# Parse org/repo from various git URL formats:
-# - git@github.com:org/repo.git
-# - https://github.com/org/repo.git
-# - https://github.com/org/repo
-if [[ "$remote_url" =~ github\.com[:/]([^/]+)/([^/.]+)(\.git)?$ ]]; then
-    org="${BASH_REMATCH[1]}"
-    repo="${BASH_REMATCH[2]}"
-else
-    echo "Error: could not parse org/repo from remote URL: $remote_url" >&2
-    exit 1
-fi
+org="$REPO_ORG"
+repo="$REPO_REPO"
 
 # Use different notes location for PostHog repos
 org_lower=$(echo "$org" | tr '[:upper:]' '[:lower:]')


### PR DESCRIPTION
Stacked on #174 (it migrates the followup scripts that live there). The org/repo-from-origin regex had grown to six copies across three skills; this PR moves it into ai/helpers/repo-context.sh and points every call site at it.

The pattern also gets the two capability fixes from the review backlog: SSH host aliases like git@github.com-work:Org/repo.git now parse (multi-account SSH configs), and repo names containing dots (PostHog/posthog.com) no longer truncate or fall back to [no-repo]. Hosts that merely start with github.com (github.company.com) are rejected, which the old immediate-delimiter pattern also did. Scripts locate the helper via their physical path (pwd -P), so the same relative reference works from a repo checkout and through the ~/.claude skill symlinks.

## Test plan

- New ai/helpers/tests/test-repo-context.sh: 8 checks over URL shapes (ssh, https with and without .git, host alias, dotted repo, gitlab rejected, github-prefixed host rejected, no repo).
- Followup suite still passes (12 checks) and note-find-or-create/note-list/handoff-path round-trips behave identically on unchanged URL shapes.
- shellcheck clean across the helper and all six migrated scripts.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*