### PR TITLE
Give the org/repo → vault-path mapping one owner

### DIFF
--- a/ai/skills/go/SKILL.md
+++ b/ai/skills/go/SKILL.md
@@ -52,11 +52,11 @@ First, check whether a plan already exists for this work. Compute the plan direc
 ```bash
 repo=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null || echo "")
 branch=$(git branch --show-current)
-case "$repo" in
-  PostHog/*) plan_dir="$HOME/dev/haacked/notes/PostHog/repositories/${repo#PostHog/}/plans" ;;
-  */*)       plan_dir="$HOME/dev/haacked/notes/Dev/repositories/$repo/plans" ;;
-  *)         plan_dir="" ;;
-esac
+if [[ "$repo" == */* ]]; then
+  plan_dir=$(~/.claude/skills/note/scripts/notes-path.sh "$repo" plans)
+else
+  plan_dir=""
+fi
 ```
 
 If `$plan_dir` is set, look for an existing plan in this preference order:

--- a/ai/skills/note/SKILL.md
+++ b/ai/skills/note/SKILL.md
@@ -83,7 +83,7 @@ status=$(echo "$result" | cut -f1)
 note_path=$(echo "$result" | cut -f2)
 ```
 
-Never construct paths manually — the script derives org/repo from the current git repository, builds the path (`~/dev/haacked/notes/PostHog/repositories/{repo}/{slug}.md` for PostHog repos, `~/dev/haacked/notes/Dev/repositories/{org}/{repo}/{slug}.md` otherwise), and validates the slug format.
+Never construct paths manually — the script derives org/repo from the current git repository, builds the path (`~/dev/haacked/notes/PostHog/repositories/{repo}/{slug}.md` for PostHog repos, `~/dev/haacked/notes/Dev/repositories/{org}/{repo}/{slug}.md` otherwise), and validates the slug format. The org/repo → path mapping itself has one owner, `scripts/notes-path.sh`, which `/go` also uses for plan directories.
 
 If `status` is `found`: tell the user the existing note path and that you're updating it, then read the current content and add new discoveries while preserving existing knowledge.
 

--- a/ai/skills/note/scripts/note-find-or-create.sh
+++ b/ai/skills/note/scripts/note-find-or-create.sh
@@ -51,15 +51,9 @@ else
     exit 1
 fi
 
-# Use different notes location for PostHog repos
-org_lower=$(echo "$org" | tr '[:upper:]' '[:lower:]')
-if [[ "$org_lower" == "posthog" ]]; then
-    notes_base="$HOME/dev/haacked/notes/PostHog/repositories"
-    note_path="${notes_base}/${repo}/${slug}.md"
-else
-    notes_base="$HOME/dev/haacked/notes/Dev/repositories"
-    note_path="${notes_base}/${org}/${repo}/${slug}.md"
-fi
+# notes-path.sh owns the org/repo → vault-path mapping.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+note_path="$("$SCRIPT_DIR/notes-path.sh" "${org}/${repo}")/${slug}.md"
 
 if [[ -f "$note_path" ]]; then
     echo -e "found\t${note_path}"

--- a/ai/skills/note/scripts/note-find.sh
+++ b/ai/skills/note/scripts/note-find.sh
@@ -50,15 +50,9 @@ else
     exit 1
 fi
 
-# Use different notes location for PostHog repos
-org_lower=$(echo "$org" | tr '[:upper:]' '[:lower:]')
-if [[ "$org_lower" == "posthog" ]]; then
-    notes_base="$HOME/dev/haacked/notes/PostHog/repositories"
-    note_path="${notes_base}/${repo}/${slug}.md"
-else
-    notes_base="$HOME/dev/haacked/notes/Dev/repositories"
-    note_path="${notes_base}/${org}/${repo}/${slug}.md"
-fi
+# notes-path.sh owns the org/repo → vault-path mapping.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+note_path="$("$SCRIPT_DIR/notes-path.sh" "${org}/${repo}")/${slug}.md"
 
 if [[ -f "$note_path" ]]; then
     echo -e "found\t${note_path}"

--- a/ai/skills/note/scripts/note-list.sh
+++ b/ai/skills/note/scripts/note-list.sh
@@ -35,13 +35,9 @@ else
     exit 1
 fi
 
-# Use different notes location for PostHog repos
-org_lower=$(echo "$org" | tr '[:upper:]' '[:lower:]')
-if [[ "$org_lower" == "posthog" ]]; then
-    notes_dir="$HOME/dev/haacked/notes/PostHog/repositories/${repo}"
-else
-    notes_dir="$HOME/dev/haacked/notes/Dev/repositories/${org}/${repo}"
-fi
+# notes-path.sh owns the org/repo → vault-path mapping.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+notes_dir="$("$SCRIPT_DIR/notes-path.sh" "${org}/${repo}")"
 
 # Check if notes directory exists
 if [[ ! -d "$notes_dir" ]]; then

--- a/ai/skills/note/scripts/notes-path.sh
+++ b/ai/skills/note/scripts/notes-path.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Resolve where notes and plans live for a repo — the single owner of the
+# org/repo → vault-path mapping. PostHog repos are single-org and flat;
+# everything else nests under Dev/repositories/{org}/{repo}.
+#
+# Usage: notes-path.sh <org/repo> [notes|plans]
+# Prints the directory path: the repo's topic-note dir, or its plans dir.
+
+set -euo pipefail
+
+if [[ $# -lt 1 || "$1" != */* ]]; then
+    echo "Usage: notes-path.sh <org/repo> [notes|plans]" >&2
+    exit 1
+fi
+
+org="${1%%/*}"
+repo="${1#*/}"
+kind="${2:-notes}"
+
+org_lower=$(echo "$org" | tr '[:upper:]' '[:lower:]')
+if [[ "$org_lower" == "posthog" ]]; then
+    base="$HOME/dev/haacked/notes/PostHog/repositories/${repo}"
+else
+    base="$HOME/dev/haacked/notes/Dev/repositories/${org}/${repo}"
+fi
+
+case "$kind" in
+    notes) printf '%s\n' "$base" ;;
+    plans) printf '%s\n' "$base/plans" ;;
+    *) echo "Error: kind must be notes or plans" >&2; exit 1 ;;
+esac

--- a/ai/skills/note/scripts/notes-path.sh
+++ b/ai/skills/note/scripts/notes-path.sh
@@ -8,7 +8,9 @@
 
 set -euo pipefail
 
-if [[ $# -lt 1 || "$1" != */* ]]; then
+# Exactly one slash with non-empty sides — org/, /repo, and org/repo/extra
+# would otherwise route notes into malformed directories.
+if [[ $# -lt 1 ]] || ! [[ "$1" =~ ^[^/]+/[^/]+$ ]]; then
     echo "Usage: notes-path.sh <org/repo> [notes|plans]" >&2
     exit 1
 fi

--- a/ai/skills/note/scripts/tests/test-notes-path.sh
+++ b/ai/skills/note/scripts/tests/test-notes-path.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Tests for notes-path.sh, the single owner of the org/repo → vault-path mapping.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+NP="${SCRIPT_DIR}/../notes-path.sh"
+
+passes=0
+failures=0
+
+check() { # desc actual expected
+    if [[ "$2" == "$3" ]]; then
+        passes=$((passes + 1))
+    else
+        echo "FAIL: $1"
+        echo "  expected [$3], got [$2]"
+        failures=$((failures + 1))
+    fi
+}
+
+check "posthog notes" "$("$NP" PostHog/posthog)" "$HOME/dev/haacked/notes/PostHog/repositories/posthog"
+check "posthog org is case-insensitive" "$("$NP" posthog/posthog-js)" "$HOME/dev/haacked/notes/PostHog/repositories/posthog-js"
+check "dev notes" "$("$NP" haacked/dotfiles)" "$HOME/dev/haacked/notes/Dev/repositories/haacked/dotfiles"
+check "dev plans" "$("$NP" haacked/dotfiles plans)" "$HOME/dev/haacked/notes/Dev/repositories/haacked/dotfiles/plans"
+check "posthog plans" "$("$NP" PostHog/posthog plans)" "$HOME/dev/haacked/notes/PostHog/repositories/posthog/plans"
+check "bad kind rejected" "$("$NP" a/b nope 2>&1 | grep -c 'Error' || true)" "1"
+check "missing slash rejected" "$("$NP" nope 2>&1 | grep -c 'Usage' || true)" "1"
+
+echo ""
+echo "Passed: ${passes}, Failed: ${failures}"
+[[ "${failures}" -eq 0 ]]

--- a/ai/skills/note/scripts/tests/test-notes-path.sh
+++ b/ai/skills/note/scripts/tests/test-notes-path.sh
@@ -25,6 +25,9 @@ check "dev plans" "$("$NP" haacked/dotfiles plans)" "$HOME/dev/haacked/notes/Dev
 check "posthog plans" "$("$NP" PostHog/posthog plans)" "$HOME/dev/haacked/notes/PostHog/repositories/posthog/plans"
 check "bad kind rejected" "$("$NP" a/b nope 2>&1 | grep -c 'Error' || true)" "1"
 check "missing slash rejected" "$("$NP" nope 2>&1 | grep -c 'Usage' || true)" "1"
+check "empty repo rejected" "$("$NP" org/ 2>&1 | grep -c 'Usage' || true)" "1"
+check "empty org rejected" "$("$NP" /repo 2>&1 | grep -c 'Usage' || true)" "1"
+check "extra segment rejected" "$("$NP" org/repo/extra 2>&1 | grep -c 'Usage' || true)" "1"
 
 echo ""
 echo "Passed: ${passes}, Failed: ${failures}"


### PR DESCRIPTION
Stacked on #175 (it rewrites the mapping lines that PR moved to the vault). The where-do-notes-and-plans-live mapping was restated in the three note scripts and inlined as a bash case statement in go/SKILL.md; a path change meant editing four places and hoping none got missed, which the #175 review demonstrated is a real failure mode.

notes-path.sh is now the single owner: `notes-path.sh <org/repo> [notes|plans]` prints the directory, the note scripts build file paths from it, and /go's plan_dir snippet delegates to it the same way note/SKILL.md already delegates path construction. A side effect worth knowing: /go previously matched `PostHog/*` case-sensitively while the note scripts lowercased the org; both now share the case-insensitive behavior.

## Test plan

- New ai/skills/note/scripts/tests/test-notes-path.sh: 7 checks (PostHog flat mapping, case-insensitive org, Dev nested mapping, plans kind for both, bad kind and missing-slash rejection).
- note-find-or-create.sh round-trip still finds the migrated note at the vault path; note-list.sh lists both dotfiles notes.
- shellcheck clean across the note scripts and tests.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*