### PR TITLE
Add vault consolidate mode and duplicate page detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Skills live in [`ai/skills/`](ai/skills) and are installed into `~/.claude/skill
 | [`support`](ai/skills/support) | Support hero workflow: start ticket investigations, find prior notes, generate weekly highlights. |
 | [`test-plan`](ai/skills/test-plan) | Generate a manual test plan checklist focused on scenarios uncovered by existing tests. |
 | [`triage-issues`](ai/skills/triage-issues) | Identify unlabeled GitHub issues that may belong to a specific team. |
+| [`vault`](ai/skills/vault) | Operate the notes vault knowledge loop: ingest raw sources into interlinked wiki pages, lint vault health, consolidate duplicate pages, show the backlog. |
 
 The `squash` command lives at [`ai/commands/squash.md`](ai/commands/squash.md): squash developer commits on the current branch into one while preserving CI snapshot commits.
 

--- a/ai/skills/vault/SKILL.md
+++ b/ai/skills/vault/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: vault
-description: Operate the notes vault knowledge loop — ingest raw sources (standups, ops reports, meeting transcripts, URLs) into interlinked wiki pages, lint vault health, or show the ingest backlog. Use when the user runs /vault, asks to turn meeting notes or reports into knowledge, or wants a vault health check.
-argument-hint: "[ingest [path|url|--tranche N] | lint [area] | status]"
+description: Operate the notes vault knowledge loop — ingest raw sources (standups, ops reports, meeting transcripts, URLs) into interlinked wiki pages, lint vault health, consolidate duplicate wiki pages, or show the ingest backlog. Use when the user runs /vault, asks to turn meeting notes or reports into knowledge, wants duplicate notes merged, or wants a vault health check.
+argument-hint: "[ingest [path|url|--tranche N] | lint [area] | consolidate [area|pages] | status]"
 model: sonnet
 ---
 
@@ -17,6 +17,7 @@ Parse the first argument from user input.
 | --- | --- |
 | `ingest [path\|url\|--tranche N]` | **ingest** — distill raw sources into wiki pages |
 | `lint [area]` | **lint** — vault health check |
+| `consolidate [area\|pages]` | **consolidate** — merge duplicate or overlapping wiki pages |
 | `status` | **status** — backlog and recent activity |
 
 ## Ingest mode
@@ -56,11 +57,30 @@ cd ~/dev/haacked/notes && markdownlint-cli2 "PostHog/**/*.md"
 ~/.claude/skills/vault/scripts/vault-lint-links.sh
 ```
 
-The links helper reports dead `[[wikilinks]]` and orphan wiki pages (no inbound links). Also check for loose files in vault roots and empty directories (convention violations per the schema).
+The links helper reports dead `[[wikilinks]]`, orphan wiki pages (no inbound links), and duplicate wiki page names (consolidation candidates — route to `/vault consolidate`, not lint fixes). Also check for loose files in vault roots and empty directories (convention violations per the schema).
 
-2. Judgment checks over the scoped area only: contradictions between wiki pages, stale claims (dated assertions that no longer hold), missing cross-links between obviously related pages.
-3. Fix mechanical issues after a y/n confirmation. Report judgment issues as a checklist; offer to capture deferred ones as `/followup` items.
+2. Judgment checks over the scoped area only: contradictions between wiki pages, stale claims (dated assertions that no longer hold), missing cross-links between obviously related pages, duplicate or overlapping pages (same topic under different names — route to `/vault consolidate`).
+3. Fix mechanical issues after a y/n confirmation — except dead links from raw sources to consolidated-away pages, which are permanent by design: report, don't fix. Report judgment issues as a checklist; offer to capture deferred ones as `/followup` items.
 4. Append a `lint |` entry to `PostHog/log.md` summarizing what was checked and fixed.
+
+## Consolidate mode
+
+Merge duplicate or overlapping wiki pages — one survivor absorbs the rest. Wiki layer only: never raw sources, `plans/`, `archive/`, or structural files (`Home.md`, `log.md`, `CLAUDE.md`, `Followups.md`). Interactive only — per-merge confirmation is the point; never run unattended.
+
+1. Gather candidates: explicit pages in the argument form one cluster; otherwise run the links helper (above) and take its "Duplicate wiki page names" clusters, filtered to `[area]` when given; when an area is given, add overlaps noticed while reading it via `Home.md`. Cap a run at ~5 merges — stay bounded, stay involved.
+2. Read every page in a cluster fully. Same name but genuinely different topics is a rename, not a merge — offer to rename the less canonical page and update its inbound links instead.
+3. Pick the survivor: most inbound links, then the name that fits conventions (kebab-case in `repositories/`, Title Case elsewhere), then the most complete content.
+4. Propose the merge and wait for y/n before writing anything: survivor, pages to absorb, count of inbound links to rewrite, and any links from raw sources that will keep pointing at the old name (raw sources are never edited).
+5. On yes: rewrite the survivor as one distilled page — every durable fact from all pages, union of outbound `[[wikilinks]]`, no concatenated sections. Rewrite each inbound link to the survivor — grep for the old basename inside `[[ ]]` to catch `[[name]]`, `[[name|alias]]`, `[[name#heading]]`, and `[[dir/name]]` forms; preserve aliases, and re-anchor or drop `#heading` fragments that don't exist on the survivor. Update links in wiki pages, `Home.md`, and `Followups.md`; never edit `log.md` or raw sources. Re-grep the old basename before deleting — remaining `[[ ]]` hits must be only raw sources or `log.md`. Then delete the absorbed pages with `rm` — the notes auto-backup agent owns git; never commit or push.
+6. Append one `consolidate |` entry to `PostHog/log.md` for the run — survivor as a `[[wikilink]]`, absorbed pages as plain paths. Never backtick-wrap any path in the entry — the ingest ledger greps all of `log.md`, so a backticked raw path would mark that source processed:
+
+```markdown
+## [YYYY-MM-DD] consolidate | <short title>
+
+Merged reference/Feature Flags.md into [[feature-flags]]; rewrote 6 inbound links. Scope: reference.
+```
+
+7. Report: merges done, merges skipped and why, any raw-source links left pointing at deleted names.
 
 ## Status mode
 
@@ -75,5 +95,5 @@ Report, using one Bash call where possible:
 
 | `/vault` | `/note` | `/followup` |
 | --- | --- | --- |
-| In-vault operations loop (ingest, lint) | Capture from a code-repo session into the vault | Capture a "do this later" item |
+| In-vault operations loop (ingest, lint, consolidate) | Capture from a code-repo session into the vault | Capture a "do this later" item |
 | Works the raw → wiki pipeline | Writes one topic note | Writes one checklist line |

--- a/ai/skills/vault/SKILL.md
+++ b/ai/skills/vault/SKILL.md
@@ -7,7 +7,7 @@ model: sonnet
 
 # Vault Operations
 
-The knowledge loop over the PostHog work vault at `~/dev/haacked/notes/PostHog` (paths below are relative to `~/dev/haacked/notes`). The schema (raw vs wiki vs working docs, the log rules) lives in `PostHog/CLAUDE.md` — read it before any operation. The operations log `PostHog/log.md` is both history and the ingest ledger.
+The knowledge loop over the PostHog work vault at `~/dev/haacked/notes/PostHog` (paths below are relative to `~/dev/haacked/notes`). The schema (raw vs wiki vs working docs, the log rules) lives in `PostHog/CLAUDE.md` — read it before any operation. The operations log `PostHog/log.md` is both history and the ingest ledger: a backtick-wrapped vault-relative path anywhere in the log marks that raw source as ingested, so only ingest entries may backtick-wrap paths — every other entry type writes paths plain or as `[[wikilinks]]`.
 
 ## Modes
 
@@ -60,19 +60,19 @@ cd ~/dev/haacked/notes && markdownlint-cli2 "PostHog/**/*.md"
 The links helper reports dead `[[wikilinks]]`, orphan wiki pages (no inbound links), and duplicate wiki page names (consolidation candidates — route to `/vault consolidate`, not lint fixes). Also check for loose files in vault roots and empty directories (convention violations per the schema).
 
 2. Judgment checks over the scoped area only: contradictions between wiki pages, stale claims (dated assertions that no longer hold), missing cross-links between obviously related pages, duplicate or overlapping pages (same topic under different names — route to `/vault consolidate`).
-3. Fix mechanical issues after a y/n confirmation — except dead links from raw sources to consolidated-away pages, which are permanent by design: report, don't fix. Report judgment issues as a checklist; offer to capture deferred ones as `/followup` items.
+3. Fix mechanical issues after a y/n confirmation — except dead links sourced from raw files, which are permanent (raw is never edited; consolidated-away targets are the common case): report, don't fix. Report judgment issues as a checklist; offer to capture deferred ones as `/followup` items.
 4. Append a `lint |` entry to `PostHog/log.md` summarizing what was checked and fixed.
 
 ## Consolidate mode
 
 Merge duplicate or overlapping wiki pages — one survivor absorbs the rest. Wiki layer only: never raw sources, `plans/`, `archive/`, or structural files (`Home.md`, `log.md`, `CLAUDE.md`, `Followups.md`). Interactive only — per-merge confirmation is the point; never run unattended.
 
-1. Gather candidates: explicit pages in the argument form one cluster; otherwise run the links helper (above) and take its "Duplicate wiki page names" clusters, filtered to `[area]` when given; when an area is given, add overlaps noticed while reading it via `Home.md`. Cap a run at ~5 merges — stay bounded, stay involved.
+1. Gather candidates: explicit pages in the argument form one cluster (a single page means: find and merge that page's duplicates); otherwise run the links helper (above) and take its "Duplicate wiki page names" clusters. When `[area]` is given, keep the clusters that touch it (clusters span directories by nature — never drop a cluster's out-of-area members) and add overlaps noticed while reading the area via `Home.md`. Cap a run at ~5 merges — stay bounded, stay involved.
 2. Read every page in a cluster fully. Same name but genuinely different topics is a rename, not a merge — offer to rename the less canonical page and update its inbound links instead.
 3. Pick the survivor: most inbound links, then the name that fits conventions (kebab-case in `repositories/`, Title Case elsewhere), then the most complete content.
-4. Propose the merge and wait for y/n before writing anything: survivor, pages to absorb, count of inbound links to rewrite, and any links from raw sources that will keep pointing at the old name (raw sources are never edited).
-5. On yes: rewrite the survivor as one distilled page — every durable fact from all pages, union of outbound `[[wikilinks]]`, no concatenated sections. Rewrite each inbound link to the survivor — grep for the old basename inside `[[ ]]` to catch `[[name]]`, `[[name|alias]]`, `[[name#heading]]`, and `[[dir/name]]` forms; preserve aliases, and re-anchor or drop `#heading` fragments that don't exist on the survivor. Update links in wiki pages, `Home.md`, and `Followups.md`; never edit `log.md` or raw sources. Re-grep the old basename before deleting — remaining `[[ ]]` hits must be only raw sources or `log.md`. Then delete the absorbed pages with `rm` — the notes auto-backup agent owns git; never commit or push.
-6. Append one `consolidate |` entry to `PostHog/log.md` for the run — survivor as a `[[wikilink]]`, absorbed pages as plain paths. Never backtick-wrap any path in the entry — the ingest ledger greps all of `log.md`, so a backticked raw path would mark that source processed:
+4. Propose the merge and wait for y/n before writing anything: survivor, pages to absorb, count of inbound links to rewrite, and any links from raw sources that will keep pointing at the old name.
+5. On yes: rewrite the survivor as one distilled page — every durable fact from all pages, union of outbound `[[wikilinks]]` minus links between the merged pages (they'd become self-links), no concatenated sections. Rewrite each inbound link to the survivor — grep for the old basename inside `[[ ]]` to catch `[[name]]`, `[[name|alias]]`, `[[name#heading]]`, and `[[dir/name]]` forms; preserve aliases, and re-anchor or drop `#heading` fragments that don't exist on the survivor. Update links in every editable file — wiki pages, `Home.md`, `Followups.md`, and working docs under `plans/` or `archive/` — but never `log.md` or raw sources. Re-grep the old basename before deleting: remaining `[[ ]]` hits must be only raw sources, `log.md`, or quoted examples inside code fences. Then delete the absorbed pages with `rm` — the notes auto-backup agent owns git; never commit or push.
+6. Append one `consolidate |` entry to `PostHog/log.md` for the run — survivor as a `[[wikilink]]`, absorbed pages as plain paths, renames from step 2 logged the same way (old path → `[[new-name]]`). Never backtick-wrap a path here — per the ledger rule above, that would mark a raw source ingested:
 
 ```markdown
 ## [YYYY-MM-DD] consolidate | <short title>

--- a/ai/skills/vault/scripts/tests/test-vault.sh
+++ b/ai/skills/vault/scripts/tests/test-vault.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# Tests for vault-next-source.sh (ledger matching) and vault-lint-links.sh (link extraction).
+# Tests for vault-next-source.sh (ledger matching) and vault-lint-links.sh
+# (link extraction, orphan/duplicate detection, ledger-link exclusion).
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -61,7 +62,7 @@ printf 'back to [[page-a]]\n' > "$V/reference/page-b.md"
 # variant, and dups in raw/working-doc areas that must not be reported.
 # Created after the vault-next-source checks so the raw fixtures don't
 # perturb the backlog counts above.
-mkdir -p "$V/sdks" "$V/repositories/posthog" "$V/ops-reports/2026-08-01" "$V/ops-reports/2026-08-02" "$V/repositories/a/plans" "$V/repositories/b/plans"
+mkdir -p "$V/sdks" "$V/repositories/posthog" "$V/ops-reports/2026-08-01" "$V/ops-reports/2026-08-02" "$V/repositories/a/plans" "$V/repositories/b/plans" "$V/sprint-planning" "$V/quarterly-planning"
 printf 'topic\n' > "$V/reference/dup-topic.md"
 printf 'topic again\n' > "$V/sdks/dup-topic.md"
 printf 'cache notes\n' > "$V/reference/Widget Cache.md"
@@ -70,6 +71,12 @@ printf 'report\n' > "$V/ops-reports/2026-08-01/svc.md"
 printf 'report\n' > "$V/ops-reports/2026-08-02/svc.md"
 printf 'plan\n' > "$V/repositories/a/plans/plan.md"
 printf 'plan\n' > "$V/repositories/b/plans/plan.md"
+printf 'sp\n' > "$V/sprint-planning/cadence.md"
+printf 'qp\n' > "$V/quarterly-planning/cadence.md"
+# Names made only of separators normalize to an empty key and must not
+# cluster (or collide with the grouping awk's empty prev sentinel).
+printf 'dash\n' > "$V/reference/-.md"
+printf 'underscore\n' > "$V/sdks/_.md"
 # A page whose only mention is a ledger entry: log.md links must not count
 # as inbound links (or as dead-link sources — see [[a]] in the ledger above).
 printf 'only the ledger names me\n' > "$V/reference/ledger-only.md"
@@ -82,13 +89,15 @@ check "backtick-fenced [[ ]] excluded" "$(grep -c '\-n' <<< "$out" || true)" "0"
 check "tilde-fenced [[ ]] excluded" "$(grep -c 'tilde-fenced' <<< "$out" || true)" "0"
 check "inline-code [[ ]] excluded" "$(grep -c 'not-a-link' <<< "$out" || true)" "0"
 check "raw-area file not an orphan" "$(grep -c 'standup/2026-08-10' <<< "$out" || true)" "0"
-check "exact dup reported" "$(grep -c 'dup-topic.md' <<< "$dup_section" || true)" "2"
-check "name-variant dup reported" "$(grep -c 'Widget Cache.md\|widget-cache.md' <<< "$dup_section" || true)" "2"
+check "exact dup reported" "$(grep -c 'dup-topic.md' <<< "$dup_section")" "2"
+check "name-variant dup reported" "$(grep -c 'Widget Cache.md\|widget-cache.md' <<< "$dup_section")" "2"
 check "raw-area dups excluded" "$(grep -c 'ops-reports' <<< "$dup_section" || true)" "0"
 check "plans dups excluded" "$(grep -c '/plans/' <<< "$dup_section" || true)" "0"
+check "planning cadence dirs excluded" "$(grep -c 'sprint-planning\|quarterly-planning' <<< "$out" || true)" "0"
+check "empty-key names don't cluster" "$(grep -c -- '-\.md' <<< "$dup_section" || true)" "0"
 check "unique page not a dup" "$(grep -c 'page-b' <<< "$dup_section" || true)" "0"
 check "log.md links are not dead-link sources" "$(grep -c '\[\[a\]\]' <<< "$out" || true)" "0"
-check "ledger-only page is an orphan" "$(grep -c 'ledger-only' <<< "$out" || true)" "1"
+check "ledger-only page is an orphan" "$(grep -c 'ledger-only' <<< "$out")" "1"
 
 echo ""
 echo "Passed: ${passes}, Failed: ${failures}"

--- a/ai/skills/vault/scripts/tests/test-vault.sh
+++ b/ai/skills/vault/scripts/tests/test-vault.sh
@@ -57,12 +57,38 @@ Inline `[[not-a-link]]` here.
 EOF
 printf 'back to [[page-a]]\n' > "$V/reference/page-b.md"
 
+# Duplicate-name fixtures: exact dup across wiki dirs, a case/space vs kebab
+# variant, and dups in raw/working-doc areas that must not be reported.
+# Created after the vault-next-source checks so the raw fixtures don't
+# perturb the backlog counts above.
+mkdir -p "$V/sdks" "$V/repositories/posthog" "$V/ops-reports/2026-08-01" "$V/ops-reports/2026-08-02" "$V/repositories/a/plans" "$V/repositories/b/plans"
+printf 'topic\n' > "$V/reference/dup-topic.md"
+printf 'topic again\n' > "$V/sdks/dup-topic.md"
+printf 'cache notes\n' > "$V/reference/Widget Cache.md"
+printf 'cache notes again\n' > "$V/repositories/posthog/widget-cache.md"
+printf 'report\n' > "$V/ops-reports/2026-08-01/svc.md"
+printf 'report\n' > "$V/ops-reports/2026-08-02/svc.md"
+printf 'plan\n' > "$V/repositories/a/plans/plan.md"
+printf 'plan\n' > "$V/repositories/b/plans/plan.md"
+# A page whose only mention is a ledger entry: log.md links must not count
+# as inbound links (or as dead-link sources — see [[a]] in the ledger above).
+printf 'only the ledger names me\n' > "$V/reference/ledger-only.md"
+printf 'Pages: [[ledger-only]]\n' >> "$V/log.md"
+
 out=$("$LINT" "$V")
+dup_section=$(sed -n '/== Duplicate wiki page names ==/,$p' <<< "$out")
 check "reports the real dead link" "$(grep -c 'ghost-page' <<< "$out")" "1"
 check "backtick-fenced [[ ]] excluded" "$(grep -c '\-n' <<< "$out" || true)" "0"
 check "tilde-fenced [[ ]] excluded" "$(grep -c 'tilde-fenced' <<< "$out" || true)" "0"
 check "inline-code [[ ]] excluded" "$(grep -c 'not-a-link' <<< "$out" || true)" "0"
 check "raw-area file not an orphan" "$(grep -c 'standup/2026-08-10' <<< "$out" || true)" "0"
+check "exact dup reported" "$(grep -c 'dup-topic.md' <<< "$dup_section" || true)" "2"
+check "name-variant dup reported" "$(grep -c 'Widget Cache.md\|widget-cache.md' <<< "$dup_section" || true)" "2"
+check "raw-area dups excluded" "$(grep -c 'ops-reports' <<< "$dup_section" || true)" "0"
+check "plans dups excluded" "$(grep -c '/plans/' <<< "$dup_section" || true)" "0"
+check "unique page not a dup" "$(grep -c 'page-b' <<< "$dup_section" || true)" "0"
+check "log.md links are not dead-link sources" "$(grep -c '\[\[a\]\]' <<< "$out" || true)" "0"
+check "ledger-only page is an orphan" "$(grep -c 'ledger-only' <<< "$out" || true)" "1"
 
 echo ""
 echo "Passed: ${passes}, Failed: ${failures}"

--- a/ai/skills/vault/scripts/vault-lint-links.sh
+++ b/ai/skills/vault/scripts/vault-lint-links.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# Report dead [[wikilinks]] and orphan wiki pages (no inbound wikilinks).
+# Report dead [[wikilinks]], orphan wiki pages (no inbound wikilinks), and
+# duplicate wiki page names (consolidation candidates).
 #
 # Usage: vault-lint-links.sh [vault-dir]
 #
@@ -8,8 +9,14 @@
 # not kill the report). Obsidian
 # resolves [[Name]] by basename anywhere in the vault and [[dir/Name]] by
 # path, so a link is dead only when neither resolves. Raw areas, plans, and
-# structural files are excluded from the orphan check (they aren't expected
-# to have inbound links).
+# structural files are excluded from the orphan and duplicate checks (they
+# aren't expected to have inbound links, and dated duplicates there are by
+# design). log.md is excluded as a link source: ledger mentions are
+# point-in-time history, not navigation — they must not rescue a page from
+# orphan status, and past entries are never edited, so a deleted page would
+# otherwise be a dead link forever. Raw sources stay link sources on purpose:
+# their links to consolidated-away pages surface as dead links, keeping those
+# permanent stragglers visible.
 
 set -uo pipefail
 
@@ -26,6 +33,7 @@ find . -type f -name '*.md' -not -path './.obsidian/*' | sed 's|^\./||' > "$tmpd
 # code samples are not wikilinks.
 : > "$tmpdir/links"
 while IFS= read -r f; do
+    [[ "$f" == "log.md" ]] && continue
     # shellcheck disable=SC2016  # backticks in the sed pattern are literal, not expansions
     awk '/^[[:space:]]*(```|~~~)/ { infence = !infence; next } !infence { print }' "$f" 2>/dev/null | sed 's/`[^`]*`//g' | grep -o '\[\[[^]]*\]\]' | sed -e 's/^\[\[//' -e 's/\]\]$//' -e 's/|.*//' -e 's/#.*//' | while IFS= read -r target; do
         [[ -n "$target" ]] && printf '%s\t%s\n' "$f" "$target" >> "$tmpdir/links"
@@ -43,15 +51,20 @@ while IFS=$'\t' read -r f target; do
 done < "$tmpdir/links"
 [[ "$dead" -eq 0 ]] && echo "(none)"
 
+# Wiki-layer pages only, per the layer schema in the vault's CLAUDE.md: raw
+# areas (keep in sync with vault-next-source.sh's find list), working docs,
+# and structural files are excluded.
+while IFS= read -r f; do
+    case "$f" in
+        standup/*|ops-reports/*|daily/*|support/*|2[0-9][0-9][0-9]/*|*/plans/*|*/archive/*|Followups.md|log.md|CLAUDE.md|Home.md) continue ;;
+    esac
+    printf '%s\n' "$f"
+done < "$tmpdir/files" > "$tmpdir/wiki"
+
 echo ""
 echo "== Orphan wiki pages (no inbound wikilinks) =="
 orphans=0
 while IFS= read -r f; do
-    # Raw areas (keep in sync with vault-next-source.sh's find list) plus
-    # working docs and structural files not expected to have inbound links.
-    case "$f" in
-        standup/*|ops-reports/*|daily/*|support/*|2[0-9][0-9][0-9]/*|*/plans/*|*/archive/*|Followups.md|log.md|CLAUDE.md|Home.md) continue ;;
-    esac
     base="${f##*/}"
     base="${base%.md}"
     # Pure string suffix check — a regex here would let metacharacters in page
@@ -60,9 +73,22 @@ while IFS= read -r f; do
         orphans=$((orphans + 1))
         [[ "$orphans" -le 20 ]] && printf '%s\n' "$f"
     fi
-done < "$tmpdir/files"
+done < "$tmpdir/wiki"
 if [[ "$orphans" -eq 0 ]]; then
     echo "(none)"
 elif [[ "$orphans" -gt 20 ]]; then
     echo "(+$((orphans - 20)) more — ${orphans} orphans total)"
 fi
+
+echo ""
+echo "== Duplicate wiki page names =="
+# Same-basename wiki pages resolve [[Name]] ambiguously; case/space/hyphen/
+# underscore variants usually mean one topic split across pages. Both are
+# consolidation candidates (/vault consolidate). Clusters print one path per
+# line, blank-line separated.
+awk -F/ '{ base = $NF; sub(/\.md$/, "", base); key = tolower(base); gsub(/[ _-]/, "", key); printf "%s\t%s\n", key, $0 }' "$tmpdir/wiki" | sort > "$tmpdir/names"
+awk -F'\t' '
+    NR == FNR { n[$1]++; next }
+    n[$1] > 1 { if ($1 != prev) { if (found++) print ""; prev = $1 } print "  " $2 }
+    END { if (!found) print "(none)" }
+' "$tmpdir/names" "$tmpdir/names"

--- a/ai/skills/vault/scripts/vault-lint-links.sh
+++ b/ai/skills/vault/scripts/vault-lint-links.sh
@@ -8,10 +8,11 @@
 # file with zero wikilinks makes the extraction pipeline "fail", which must
 # not kill the report). Obsidian
 # resolves [[Name]] by basename anywhere in the vault and [[dir/Name]] by
-# path, so a link is dead only when neither resolves. Raw areas, plans, and
-# structural files are excluded from the orphan and duplicate checks (they
-# aren't expected to have inbound links, and dated duplicates there are by
-# design). log.md is excluded as a link source: ledger mentions are
+# path, so a link is dead only when neither resolves. Raw areas, plans, dated
+# planning dirs, and structural files are excluded from the orphan and
+# duplicate checks (they aren't expected to have inbound links, and dated
+# duplicates there are by design). log.md is excluded as a link source: ledger
+# mentions are
 # point-in-time history, not navigation — they must not rescue a page from
 # orphan status, and past entries are never edited, so a deleted page would
 # otherwise be a dead link forever. Raw sources stay link sources on purpose:
@@ -44,19 +45,18 @@ echo "== Dead wikilinks =="
 dead=0
 while IFS=$'\t' read -r f target; do
     base="${target##*/}"
-    if ! grep -qxF "${target}.md" "$tmpdir/files" && ! grep -qxF "${base}.md" "$tmpdir/files" && ! grep -qF "/${base}.md" "$tmpdir/files"; then
+    if ! grep -qxF -- "${target}.md" "$tmpdir/files" && ! grep -qxF -- "${base}.md" "$tmpdir/files" && ! grep -qF -- "/${base}.md" "$tmpdir/files"; then
         printf '%s -> [[%s]]\n' "$f" "$target"
         dead=$((dead + 1))
     fi
 done < "$tmpdir/links"
 [[ "$dead" -eq 0 ]] && echo "(none)"
 
-# Wiki-layer pages only, per the layer schema in the vault's CLAUDE.md: raw
-# areas (keep in sync with vault-next-source.sh's find list), working docs,
-# and structural files are excluded.
+# Wiki-layer pages only, per the layer schema in the vault's CLAUDE.md (raw
+# areas stay in sync with vault-next-source.sh's find list).
 while IFS= read -r f; do
     case "$f" in
-        standup/*|ops-reports/*|daily/*|support/*|2[0-9][0-9][0-9]/*|*/plans/*|*/archive/*|Followups.md|log.md|CLAUDE.md|Home.md) continue ;;
+        standup/*|ops-reports/*|daily/*|support/*|2[0-9][0-9][0-9]/*|*/plans/*|*/archive/*|sprint-planning/*|quarterly-planning/*|Followups.md|log.md|CLAUDE.md|Home.md) continue ;;
     esac
     printf '%s\n' "$f"
 done < "$tmpdir/files" > "$tmpdir/wiki"
@@ -85,8 +85,9 @@ echo "== Duplicate wiki page names =="
 # Same-basename wiki pages resolve [[Name]] ambiguously; case/space/hyphen/
 # underscore variants usually mean one topic split across pages. Both are
 # consolidation candidates (/vault consolidate). Clusters print one path per
-# line, blank-line separated.
-awk -F/ '{ base = $NF; sub(/\.md$/, "", base); key = tolower(base); gsub(/[ _-]/, "", key); printf "%s\t%s\n", key, $0 }' "$tmpdir/wiki" | sort > "$tmpdir/names"
+# line, blank-line separated. Names that normalize to nothing are skipped, and
+# LC_ALL=C keeps equal keys adjacent regardless of locale.
+awk -F/ '{ base = $NF; sub(/\.md$/, "", base); key = tolower(base); gsub(/[ _-]/, "", key); if (key != "") printf "%s\t%s\n", key, $0 }' "$tmpdir/wiki" | LC_ALL=C sort > "$tmpdir/names"
 awk -F'\t' '
     NR == FNR { n[$1]++; next }
     n[$1] > 1 { if ($1 != prev) { if (found++) print ""; prev = $1 } print "  " $2 }


### PR DESCRIPTION
- `/vault` gains a consolidate mode: merge duplicate or overlapping wiki pages into one survivor, rewrite inbound wikilinks, then delete the absorbed pages, capped at ~5 merges per run with a y/n confirmation before each. Wiki layer only: never raw sources, `plans/`, `archive/`, or structural files. Interactive only, so the unattended ingest drip is unchanged.
- The links helper reports a third section, "Duplicate wiki page names": wiki pages whose basenames match after lowercasing and stripping spaces, hyphens, and underscores, so `Widget Cache.md` and `widget-cache.md` cluster. Raw areas, working docs, and the dated planning dirs (`sprint-planning/`, `quarterly-planning/`) are excluded because dated duplicates there are by design. Lint routes these clusters to `/vault consolidate` rather than fixing them in place.
- Behavior change in the links helper: `log.md` no longer counts as a wikilink source. Ledger mentions are history, not navigation. Without this, a consolidated-away page would be reported as a dead link forever (past log entries are never edited), and a page named only in the ledger could never surface as an orphan.
- The skill hoists the ledger rule to the top: only ingest entries may backtick-wrap paths, since the ingest ledger treats a backticked path anywhere in `log.md` as a processed source. Lint's fix step now treats any dead link sourced from a raw file as permanent (report, don't fix).
- README gains the missing `vault` row in the skills table.

## Test plan

- `bash ai/skills/vault/scripts/tests/test-vault.sh`: 18 checks covering duplicate clustering, name-variant matching, empty-key names, raw-area, working-doc, and planning-dir exclusions, and the ledger-link semantics.
- `shellcheck ai/skills/vault/scripts/vault-lint-links.sh` is clean.
- Ran the updated helper against the real vault and diffed against the old script: the duplicate section prints `(none)`, and the only orphan-list changes are the intended ones (dated planning files drop out; pages whose only mention is a ledger entry can now appear).

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*