### PR TITLE
Add receipt-based re-adoption to ssh-agent-sync

### DIFF
--- a/bin/lib/test-ssh-agent-sync.sh
+++ b/bin/lib/test-ssh-agent-sync.sh
@@ -40,6 +40,15 @@ link_sock() {
   ln -s "$1" "$SOCK"
 }
 
+RECEIPT="$FAKE_HOME/.ssh/agent.fwd"
+STAMP="$FAKE_HOME/.ssh/agent.fwd.stalled"
+
+# Points the adoption receipt at the given target. Call after link_sock,
+# which wipes the fake ~/.ssh (receipt and stamp included) on every reset.
+set_receipt() {
+  ln -sf "$1" "$RECEIPT"
+}
+
 # ── Test: live forwarded socket ─────────────────────────────────────────────
 
 mkdir -p "$(dirname "$SECRETIVE")"
@@ -177,6 +186,173 @@ link_sock "$EMPTY"
 out=$(run_bin)
 assert "no arg with live empty forwarded sock stays forwarded" test "$out" = "forwarded"
 assert "live empty forwarded sock is left in place" test "$SOCK" -ef "$EMPTY"
+
+# ── Test: adoption records a receipt; a rejected loop doesn't ───────────────
+# The receipt is what lets no-arg callers find their way back to a forwarded
+# agent later, so it must be written on every genuine adoption and never for
+# a loop (re-adopting a loop would recreate the out-of-body failure).
+
+link_sock "$SECRETIVE"
+
+out=$(run_bin "$LOOPED")
+assert "a rejected loop leaves no receipt" test ! -e "$RECEIPT"
+
+echo 99 > "$STAMP"
+out=$(run_bin "$GENUINE")
+assert "adoption prints forwarded" test "$out" = "forwarded"
+assert "adoption records the receipt" test "$RECEIPT" -ef "$GENUINE"
+assert "adoption clears a leftover stall stamp" test ! -e "$STAMP"
+
+# ── Test: a newer push overwrites the receipt ────────────────────────────────
+# With two concurrent forwarded sessions, the most recent interactive login
+# wins: the receipt tracks exactly one socket, the last one a human chose.
+
+out=$(run_bin "$EMPTY")
+assert "a newer push repoints the sock" test "$SOCK" -ef "$EMPTY"
+assert "a newer push overwrites the receipt" test "$RECEIPT" -ef "$EMPTY"
+
+# ── Test: no arg, sock on Secretive, receipt names a live agent ─────────────
+# The motivating case: the sock healed to local (client slept, probe timed
+# out) and the client is back. No-arg callers — tmux panes, launchd, git's
+# signing path — must be able to re-adopt from the receipt alone.
+
+link_sock "$SECRETIVE"
+set_receipt "$GENUINE"
+
+out=$(run_bin)
+assert "re-adopt from a live receipt prints forwarded" test "$out" = "forwarded"
+assert "sock links directly at the receipt's target" test "$(readlink "$SOCK")" = "$GENUINE"
+assert "receipt survives re-adoption" test "$RECEIPT" -ef "$GENUINE"
+
+# ── Test: receipt whose socket refuses the connection is deleted ────────────
+# Connection-refused means the sshd session is gone for good; a fresh session
+# mints a fresh socket name and pushes it, so the receipt has nothing left to
+# offer and must not be re-probed forever.
+
+REFUSED="$FAKE_HOME/refused.sock"
+mksock "$REFUSED"
+link_sock "$SECRETIVE"
+set_receipt "$REFUSED"
+
+out=$(run_bin)
+assert "refused receipt stays local" test "$out" = "local"
+assert "conclusively dead receipt is deleted" test ! -e "$RECEIPT"
+assert "no stall stamp for a refused receipt" test ! -e "$STAMP"
+
+# ── Test: dangling receipt is deleted ────────────────────────────────────────
+
+link_sock "$SECRETIVE"
+set_receipt "$FAKE_HOME/never-was.sock"
+
+out=$(run_bin)
+assert "dangling receipt stays local" test "$out" = "local"
+assert "dangling receipt is deleted" test ! -e "$RECEIPT"
+
+# ── Test: receipt that loops back to the local agent is cleared ─────────────
+# The loop check applies to re-adoption exactly as it does to a push: a
+# receipt offering Secretive's own key list must resolve local and be
+# dropped, not adopted.
+
+link_sock "$SECRETIVE"
+set_receipt "$LOOPED"
+
+out=$(run_bin)
+assert "looped receipt resolves local" test "$out" = "local"
+assert "looped receipt is cleared, not adopted" test ! -e "$RECEIPT"
+assert "looped receipt leaves the sock on Secretive" test "$SOCK" -ef "$SECRETIVE"
+
+# ── Test: sleeping receipt is kept, then re-adopted once it answers ─────────
+# A receipt target that accepts but never answers is a sleeping client, not a
+# dead one. The probe must stay bounded, the receipt must survive, and the
+# stall stamp must defer the next probe until the minute-long retry window
+# passes (forced here by backdating the stamp) — then the revived socket
+# (same path, as after a lid-close/lid-open) is re-adopted.
+
+ASLEEP="$FAKE_HOME/asleep.sock"
+asleep_pid=$(mkblackhole_sock "$ASLEEP")
+agent_pids+=("$asleep_pid")
+link_sock "$SECRETIVE"
+set_receipt "$ASLEEP"
+
+rc=0
+out=$(run_bin) || rc=$?
+assert "sleeping receipt stays local" test "$out" = "local"
+assert "the receipt probe is bounded, not hung" test "$rc" -ne 124
+assert "sleeping receipt is kept" test -L "$RECEIPT"
+assert "a stall stamp is written" test -e "$STAMP"
+
+kill "$asleep_pid" 2>/dev/null || true
+rm -f "$ASLEEP"
+agent_pids+=("$(start_agent "$ASLEEP")")
+SSH_AUTH_SOCK="$ASLEEP" ssh-add "$FAKE_HOME/remote_key" >/dev/null 2>&1
+
+out=$(run_bin)
+assert "a fresh stall stamp defers the next probe" test "$out" = "local"
+
+echo 1 > "$STAMP"
+out=$(run_bin)
+assert "expired backoff re-adopts the revived socket" test "$out" = "forwarded"
+assert "sock points at the revived socket" test "$SOCK" -ef "$ASLEEP"
+assert "re-adoption clears the stall stamp" test ! -e "$STAMP"
+
+# ── Test: stalled sock and receipt naming the same target probe once ─────────
+# When the adopted sock times out and the receipt points at the same socket,
+# the verdict is shared instead of probing the same blackhole twice: one 2s
+# stall, not two, paid by whichever prompt or commit ran the sync.
+
+ASLEEP2="$FAKE_HOME/asleep2.sock"
+agent_pids+=("$(mkblackhole_sock "$ASLEEP2")")
+link_sock "$ASLEEP2"
+set_receipt "$ASLEEP2"
+
+start=$SECONDS
+rc=0
+out=$(run_bin) || rc=$?
+assert "stalled sock with matching receipt heals local" test "$out" = "local"
+assert "the shared verdict stays bounded" test "$rc" -ne 124
+assert "the shared verdict avoids a second probe" test $((SECONDS - start)) -lt 4
+assert "receipt is kept after the shared verdict" test -L "$RECEIPT"
+assert "the shared verdict writes the stall stamp" test -e "$STAMP"
+
+# ── Test: --local clears the receipt and pins Secretive ─────────────────────
+# The escape hatch for a forgotten-but-live remote session that keeps winning
+# re-adoption: pin local, drop the receipt, and print the resolved mode.
+
+link_sock "$GENUINE"
+set_receipt "$GENUINE"
+echo 99 > "$STAMP"
+
+out=$(run_bin --local)
+assert "--local prints local" test "$out" = "local"
+assert "--local pins the sock to Secretive" test "$SOCK" -ef "$SECRETIVE"
+assert "--local clears the receipt" test ! -e "$RECEIPT"
+assert "--local clears the stall stamp" test ! -e "$STAMP"
+
+rm -rf "$FAKE_HOME/.ssh" "$FAKE_HOME/Library"
+
+rc=0
+out=$(run_bin --local) || rc=$?
+assert "--local with nothing present prints none" test "$out" = "none"
+assert "--local with nothing present exits zero" test "$rc" -eq 0
+
+# ── Test: adoption prunes old dead sshd-minted leftovers ────────────────────
+# sshd doesn't always get to clean up its per-session sockets. A push removes
+# conclusively dead (connection-refused) s.*.sshd.* files over an hour old —
+# and nothing else: s.*.agent.* belongs to local ssh-agent instances that may
+# be live, and fresh sshd sockets may belong to a session still coming up.
+
+AGENT_DIR="$FAKE_HOME/.ssh/agent"
+mkdir -p "$AGENT_DIR"
+mksock "$AGENT_DIR/s.aaaa.sshd.1111"
+mksock "$AGENT_DIR/s.bbbb.agent.2222"
+mksock "$AGENT_DIR/s.cccc.sshd.3333"
+touch -t 202601010000 "$AGENT_DIR/s.aaaa.sshd.1111" "$AGENT_DIR/s.bbbb.agent.2222"
+
+out=$(run_bin "$GENUINE")
+assert "push with leftovers still adopts" test "$out" = "forwarded"
+assert "an old dead sshd-minted socket is pruned" test ! -e "$AGENT_DIR/s.aaaa.sshd.1111"
+assert "ssh-agent's own sockets are never pruned" test -e "$AGENT_DIR/s.bbbb.agent.2222"
+assert "fresh sshd sockets are left alone" test -e "$AGENT_DIR/s.cccc.sshd.3333"
 
 # ── Results ──────────────────────────────────────────────────────────────────
 

--- a/bin/lib/test-ssh-agent-sync.sh
+++ b/bin/lib/test-ssh-agent-sync.sh
@@ -207,9 +207,28 @@ assert "adoption clears a leftover stall stamp" test ! -e "$STAMP"
 # With two concurrent forwarded sessions, the most recent interactive login
 # wins: the receipt tracks exactly one socket, the last one a human chose.
 
+link_sock "$GENUINE"
+set_receipt "$GENUINE"
+
 out=$(run_bin "$EMPTY")
 assert "a newer push repoints the sock" test "$SOCK" -ef "$EMPTY"
 assert "a newer push overwrites the receipt" test "$RECEIPT" -ef "$EMPTY"
+
+# ── Test: an already-adopted push repairs a drifted receipt ──────────────────
+# An adoption can predate the receipt file itself (first run after upgrading
+# to this version), leaving the sock forwarded with no matching receipt. The
+# push must repair the receipt without touching the sock, or the next heal
+# would have nothing to re-adopt from.
+
+link_sock "$GENUINE"
+set_receipt "$EMPTY"
+echo 99 > "$STAMP"
+
+out=$(run_bin "$GENUINE")
+assert "already-adopted push stays forwarded" test "$out" = "forwarded"
+assert "already-adopted push leaves the sock alone" test "$SOCK" -ef "$GENUINE"
+assert "already-adopted push repairs the drifted receipt" test "$RECEIPT" -ef "$GENUINE"
+assert "receipt repair clears a leftover stall stamp" test ! -e "$STAMP"
 
 # ── Test: no arg, sock on Secretive, receipt names a live agent ─────────────
 # The motivating case: the sock healed to local (client slept, probe timed
@@ -295,6 +314,20 @@ assert "expired backoff re-adopts the revived socket" test "$out" = "forwarded"
 assert "sock points at the revived socket" test "$SOCK" -ef "$ASLEEP"
 assert "re-adoption clears the stall stamp" test ! -e "$STAMP"
 
+# ── Test: a garbage stamp is survived, not fatal ─────────────────────────────
+# A corrupted or half-written stamp must read as an expired backoff, not kill
+# the script: an unguarded non-numeric value in the arithmetic comparison
+# would abort the sync under set -e, failing git's signing path outright.
+
+link_sock "$SECRETIVE"
+set_receipt "$ASLEEP"
+echo not-a-number > "$STAMP"
+
+rc=0
+out=$(run_bin) || rc=$?
+assert "a garbage stamp doesn't abort the sync" test "$rc" -eq 0
+assert "a garbage stamp reads as an expired backoff" test "$out" = "forwarded"
+
 # ── Test: stalled sock and receipt naming the same target probe once ─────────
 # When the adopted sock times out and the receipt points at the same socket,
 # the verdict is shared instead of probing the same blackhole twice: one 2s
@@ -314,6 +347,21 @@ assert "the shared verdict avoids a second probe" test $((SECONDS - start)) -lt 
 assert "receipt is kept after the shared verdict" test -L "$RECEIPT"
 assert "the shared verdict writes the stall stamp" test -e "$STAMP"
 
+# ── Test: refused sock and receipt naming the same target share the verdict ──
+# The rc-2 side of verdict sharing: when the adopted sock and the receipt
+# both name a socket that refuses the connection, the receipt is deleted on
+# the sock probe's verdict alone, without a second probe.
+
+REFUSED2="$FAKE_HOME/refused2.sock"
+mksock "$REFUSED2"
+link_sock "$REFUSED2"
+set_receipt "$REFUSED2"
+
+out=$(run_bin)
+assert "shared refused verdict heals local" test "$out" = "local"
+assert "shared refused verdict drops the receipt" test ! -e "$RECEIPT"
+assert "shared refused verdict leaves no stall stamp" test ! -e "$STAMP"
+
 # ── Test: --local clears the receipt and pins Secretive ─────────────────────
 # The escape hatch for a forgotten-but-live remote session that keeps winning
 # re-adoption: pin local, drop the receipt, and print the resolved mode.
@@ -327,6 +375,13 @@ assert "--local prints local" test "$out" = "local"
 assert "--local pins the sock to Secretive" test "$SOCK" -ef "$SECRETIVE"
 assert "--local clears the receipt" test ! -e "$RECEIPT"
 assert "--local clears the stall stamp" test ! -e "$STAMP"
+
+# --local must stick: with the old target still alive and answering, a
+# later no-arg sync has no receipt to re-adopt from and stays local.
+
+out=$(run_bin)
+assert "--local sticks against a still-live old target" test "$out" = "local"
+assert "no-arg after --local stays pinned to Secretive" test "$SOCK" -ef "$SECRETIVE"
 
 rm -rf "$FAKE_HOME/.ssh" "$FAKE_HOME/Library"
 

--- a/bin/lib/test-ssh-agent-sync.sh
+++ b/bin/lib/test-ssh-agent-sync.sh
@@ -402,12 +402,29 @@ mksock "$AGENT_DIR/s.aaaa.sshd.1111"
 mksock "$AGENT_DIR/s.bbbb.agent.2222"
 mksock "$AGENT_DIR/s.cccc.sshd.3333"
 touch -t 202601010000 "$AGENT_DIR/s.aaaa.sshd.1111" "$AGENT_DIR/s.bbbb.agent.2222"
+# An old leftover that accepts but never answers may be a sleeping client's
+# socket — possibly the very one the receipt would re-adopt — so only
+# connection-refused leftovers are conclusively dead enough to remove.
+BH_LEFT="$AGENT_DIR/s.dddd.sshd.4444"
+agent_pids+=("$(mkblackhole_sock "$BH_LEFT")")
+touch -t 202601010000 "$BH_LEFT"
 
 out=$(run_bin "$GENUINE")
 assert "push with leftovers still adopts" test "$out" = "forwarded"
 assert "an old dead sshd-minted socket is pruned" test ! -e "$AGENT_DIR/s.aaaa.sshd.1111"
 assert "ssh-agent's own sockets are never pruned" test -e "$AGENT_DIR/s.bbbb.agent.2222"
 assert "fresh sshd sockets are left alone" test -e "$AGENT_DIR/s.cccc.sshd.3333"
+assert "a stalled old leftover is never pruned" test -e "$BH_LEFT"
+
+# ── Test: an unknown flag is rejected, not run as maintenance ────────────────
+# A typo'd --local must not silently run a normal sync and print a mode the
+# caller then trusts: it exits 2 with no mode word and touches nothing.
+
+rc=0
+out=$(run_bin --lcoal) || rc=$?
+assert "an unknown flag exits 2" test "$rc" -eq 2
+assert "an unknown flag prints no mode word" test -z "$out"
+assert "an unknown flag leaves the sock alone" test "$SOCK" -ef "$GENUINE"
 
 # ── Results ──────────────────────────────────────────────────────────────────
 

--- a/bin/ssh-agent-sync
+++ b/bin/ssh-agent-sync
@@ -57,6 +57,14 @@ receipt="$HOME/.ssh/agent.fwd"
 stamp="$HOME/.ssh/agent.fwd.stalled"
 forwarded="${1:-}"
 
+# Reject unknown flags rather than silently running maintenance: a typo'd
+# --local would otherwise print a mode and leave the caller believing the
+# pin took.
+if [[ "$forwarded" == --* && "$forwarded" != "--local" ]]; then
+  echo "ssh-agent-sync: unknown option: $forwarded" >&2
+  exit 2
+fi
+
 # Lists the keys an agent socket offers and returns the probe's verdict (0
 # keys listed, 1 reachable but empty, 2 unreachable, 124 never answered), so
 # one bounded round trip yields both. Requiring a key-type prefix filters
@@ -93,7 +101,9 @@ drop_receipt() {
   rm -f "$receipt" "$stamp"
 }
 
-defer_receipt() {
+# Records when a probe attempt happened; the backoff below reads it. Called
+# both before a probe (stampede control) and on a timed-out one (backoff).
+stamp_attempt() {
   date +%s > "$stamp"
 }
 
@@ -195,7 +205,7 @@ elif [[ -S "$secretive" ]]; then
         else
           # Stamp before probing: when a wake fans precmd out across every
           # pane at once, only the first pays the probe.
-          defer_receipt
+          stamp_attempt
           keys=$(agent_keys "$target") || rc=$?
         fi
         if (( rc <= 1 )); then
@@ -212,7 +222,7 @@ elif [[ -S "$secretive" ]]; then
         elif (( rc == 124 )); then
           # Accepts but never answers: likely a sleeping client. Keep the
           # receipt; the stamp defers the next attempt.
-          defer_receipt
+          stamp_attempt
         else
           drop_receipt
         fi

--- a/bin/ssh-agent-sync
+++ b/bin/ssh-agent-sync
@@ -149,7 +149,7 @@ elif [[ -S "$secretive" ]]; then
     fi
   fi
 
-  failed="" failed_rc=0
+  failed_target="" failed_rc=0
   if ! [[ "$sock" -ef "$secretive" ]]; then
     # An adopted forwarded socket can outlive its SSH session as a file that
     # still passes -S. ssh-add exits 2 when it cannot reach the agent at all
@@ -163,7 +163,7 @@ elif [[ -S "$secretive" ]]; then
       # Remember the verdict: when the receipt names this same socket, the
       # block below reuses it rather than probing the same blackhole twice
       # in one run (two 2s stalls, paid by a prompt or a commit).
-      failed=$(readlink "$sock" 2>/dev/null) || failed=""
+      failed_target=$(readlink "$sock" 2>/dev/null) || failed_target=""
       failed_rc=$rc
       relink "$secretive" "$sock"
     fi
@@ -180,13 +180,17 @@ elif [[ -S "$secretive" ]]; then
       drop_receipt
     else
       now=$(date +%s)
-      IFS= read -r last < "$stamp" 2>/dev/null || last=0
+      # The stderr redirect must precede the input redirect: they apply left
+      # to right, and the stamp legitimately doesn't exist until a probe has
+      # stalled, so a trailing 2>/dev/null would let the failed open print
+      # "No such file or directory" into git's output on every signed commit.
+      IFS= read -r last 2>/dev/null < "$stamp" || last=0
       [[ -z "$last" || "$last" == *[!0-9]* ]] && last=0
       if (( now - last >= 60 )); then
         target=$(readlink "$receipt" 2>/dev/null) || target=""
         rc=0
         keys=""
-        if [[ -n "$failed" && "$target" == "$failed" ]]; then
+        if [[ -n "$failed_target" && "$target" == "$failed_target" ]]; then
           rc=$failed_rc
         else
           # Stamp before probing: when a wake fans precmd out across every

--- a/bin/ssh-agent-sync
+++ b/bin/ssh-agent-sync
@@ -4,19 +4,43 @@
 # agent. A forwarded agent that offers exactly the local Secretive's keys
 # is a loop (an `ssh macbook` from the Mac to itself forwards the Mac's
 # own agent) and is treated as local: adopting it would route signing
-# approvals to a Touch ID prompt on a machine nobody is sitting at. Safe
-# to call repeatedly; only touches the symlink when it isn't already
-# pointing at the right target. The key-list comparison runs only while a
-# not-yet-adopted forwarded socket is offered; callers should stop passing
-# a socket once it resolves to "local" (zshrc's precmd hook does), since a
-# rejected or torn-down socket never becomes forwardable again. No-arg
-# calls re-verify a previously adopted forwarded socket is still reachable
-# and heal back to Secretive when it isn't: a torn-down session can leave a
-# socket file that still passes -S but no longer answers. Prints the
-# resolved mode ("local", "forwarded", or "none") so callers don't have to
-# re-derive it themselves.
+# approvals to a Touch ID prompt on a machine nobody is sitting at.
 #
-# Usage: ssh-agent-sync [forwarded-socket-path]
+# Every adoption is recorded in ~/.ssh/agent.fwd, the receipt. Only an
+# interactive SSH login ever passes a socket path in, so the receipt is
+# proof a human once chose that socket — which is what lets no-arg callers
+# (tmux panes, launchd, git's signing path; none of them ever see a
+# forwarded socket in their environment) find their way back to it. When
+# the symlink sits on Secretive and the receipt's target answers, a no-arg
+# call re-adopts it after re-running the loop check. A target that refuses
+# the connection is dead for good — sshd mints a fresh socket name per
+# session and the login shell pushes it — so the receipt is deleted. A
+# target that accepts but never answers is likely a sleeping client: the
+# receipt is kept and retried at most once a minute (the last attempt is
+# recorded as epoch seconds in ~/.ssh/agent.fwd.stalled) so prompts don't
+# stall two seconds per draw while the client is asleep.
+#
+# `ssh-agent-sync --local` clears the receipt and pins the symlink to
+# Secretive: the escape hatch when a forgotten-but-live remote session
+# keeps winning re-adoption. It sticks while that session sits attached to
+# tmux (its login shell is blocked inside `tmux attach` and can't
+# re-push); a detached session's precmd would push again within 30s.
+#
+# Adoption also prunes conclusively dead leftovers under ~/.ssh/agent/,
+# since sshd doesn't always get to clean up its own. Only sockets sshd
+# minted (s.*.sshd.*) that are over an hour old and refuse the connection
+# are removed: s.*.agent.* files belong to local ssh-agent instances that
+# may be live, and a socket that accepts-but-stalls may be a sleeping
+# client's, so both are left alone.
+#
+# Safe to call repeatedly; only touches the symlink when it isn't already
+# pointing at the right target. No-arg calls re-verify a previously
+# adopted forwarded socket is still reachable and heal back to Secretive
+# when it isn't: a torn-down session can leave a socket file that still
+# passes -S but no longer answers. Prints the resolved mode ("local",
+# "forwarded", or "none") so callers don't have to re-derive it.
+#
+# Usage: ssh-agent-sync [forwarded-socket-path | --local]
 
 set -euo pipefail
 
@@ -29,38 +53,167 @@ sock="$HOME/.ssh/agent.sock"
 # (IdentityAgent=...), for git's own SSH transport rather than signing.
 # Keep both in sync if Secretive ever changes its container/bundle id.
 secretive="$HOME/Library/Containers/com.maxgoedjen.Secretive.SecretAgent/Data/socket.ssh"
+receipt="$HOME/.ssh/agent.fwd"
+stamp="$HOME/.ssh/agent.fwd.stalled"
 forwarded="${1:-}"
 
-# Lists the keys an agent socket offers; empty when the agent is
-# unreachable, has none, or doesn't answer within the deadline. Requiring a
-# key-type prefix filters out ssh-add's "The agent has no identities."
-# sentence, which goes to stdout. A socket whose SSH transport stalled accepts
-# the connection but never replies, so this must not be left unbounded: it runs
-# from zsh's precmd and from git's signing path, and would hang both.
+# Lists the keys an agent socket offers and returns the probe's verdict (0
+# keys listed, 1 reachable but empty, 2 unreachable, 124 never answered), so
+# one bounded round trip yields both. Requiring a key-type prefix filters
+# out ssh-add's "The agent has no identities." sentence, which goes to
+# stdout. A socket whose SSH transport stalled accepts the connection but
+# never replies, so this must not be left unbounded: it runs from zsh's
+# precmd and from git's signing path, and would hang both.
 agent_keys() {
-  run_bounded 2 env SSH_AUTH_SOCK="$1" ssh-add -L | grep -E '^(ssh-|ecdsa-|sk-)' || true
+  local out rc=0
+  out=$(run_bounded 2 env SSH_AUTH_SOCK="$1" ssh-add -L) || rc=$?
+  printf '%s\n' "$out" | grep -E '^(ssh-|ecdsa-|sk-)' || true
+  return "$rc"
+}
+
+# Replaces a symlink via rename(2) so readers never observe the unlink
+# window `ln -sf` leaves: git-ssh-sign's -S test racing a relink would
+# otherwise silently skip pinning SSH_AUTH_SOCK for that signature.
+relink() {
+  local tmp="$2.$$.tmp"
+  rm -f "$tmp"
+  ln -s "$1" "$tmp"
+  mv -f "$tmp" "$2"
+}
+
+# The receipt and its stall stamp move together — the stamp must never
+# outlive the receipt, or a stale backoff clock would silently defer the
+# next receipt's first probe.
+record_receipt() {
+  relink "$1" "$receipt"
+  rm -f "$stamp"
+}
+
+drop_receipt() {
+  rm -f "$receipt" "$stamp"
+}
+
+defer_receipt() {
+  date +%s > "$stamp"
+}
+
+# Removes dead sshd-forwarding leftovers next to the socket just adopted.
+# Runs at login before tmux attaches, so it must stay cheap: at most three
+# probes, each bounded at one second, and only connection-refused sockets
+# (rc 2) are conclusively dead enough to unlink.
+prune_stale() {
+  local f rc probes=0
+  [[ -d "$HOME/.ssh/agent" ]] || return 0
+  while IFS= read -r f; do
+    [[ -S "$f" ]] || continue
+    # The just-adopted socket can itself be over an hour old (sessions
+    # outlive the age gate); it is the one candidate that must survive.
+    if [[ "$f" -ef "$sock" ]]; then continue; fi
+    if (( probes >= 3 )); then break; fi
+    probes=$((probes + 1))
+    rc=0
+    run_bounded 1 env SSH_AUTH_SOCK="$f" ssh-add -l >/dev/null || rc=$?
+    if (( rc == 2 )); then rm -f "$f"; fi
+  done < <(find "$HOME/.ssh/agent" -name 's.*.sshd.*' -mmin +60 2>/dev/null)
 }
 
 [[ -d "$HOME/.ssh" ]] || mkdir -p -m 700 "$HOME/.ssh"
 
-if [[ -n "$forwarded" && -S "$forwarded" ]] && ! [[ "$sock" -ef "$forwarded" ]]; then
-  forwarded_keys=$(agent_keys "$forwarded")
-  if [[ -S "$secretive" && -n "$forwarded_keys" && "$forwarded_keys" == "$(agent_keys "$secretive")" ]]; then
-    [[ "$sock" -ef "$secretive" ]] || ln -sf "$secretive" "$sock"
-  else
-    ln -sf "$forwarded" "$sock"
+if [[ "$forwarded" == "--local" ]]; then
+  drop_receipt
+  if [[ -S "$secretive" ]] && ! [[ "$sock" -ef "$secretive" ]]; then
+    relink "$secretive" "$sock"
   fi
-elif [[ -S "$secretive" ]] && ! [[ "$sock" -ef "$secretive" ]]; then
-  # An adopted forwarded socket can outlive its SSH session as a file that
-  # still passes -S. ssh-add exits 2 when it cannot reach the agent at all
-  # (a stale, missing, or dangling sock alike); 1 means reachable-but-empty,
-  # which stays adopted (matching the empty-forwarded adoption above). A socket
-  # that connects but never answers times out to 124, which lands in the same
-  # ">= 2" bucket: unusable, so heal back to Secretive.
-  rc=0
-  run_bounded 2 env SSH_AUTH_SOCK="$sock" ssh-add -l >/dev/null || rc=$?
-  if (( rc >= 2 )); then
-    ln -sf "$secretive" "$sock"
+elif [[ -n "$forwarded" && -S "$forwarded" ]] && ! [[ "$sock" -ef "$forwarded" ]]; then
+  forwarded_keys=$(agent_keys "$forwarded") || true
+  if [[ -S "$secretive" && -n "$forwarded_keys" && "$forwarded_keys" == "$(agent_keys "$secretive")" ]]; then
+    # A loop leaves no receipt: nothing here is worth re-adopting later.
+    [[ "$sock" -ef "$secretive" ]] || relink "$secretive" "$sock"
+  else
+    relink "$forwarded" "$sock"
+    record_receipt "$forwarded"
+    prune_stale
+  fi
+elif [[ -S "$secretive" ]]; then
+  # A push that finds its socket already adopted still refreshes the
+  # receipt, so receipt and sock can't drift apart (an adoption can predate
+  # the receipt file itself). The string comparison against $sock screens
+  # out tmux panes, whose precmd passes the agent.sock path itself back in;
+  # matching the sock's target as a string rather than with -ef matters for
+  # the same reason — a receipt pointed at the sock would dangle the moment
+  # the sock moved.
+  if [[ -n "$forwarded" && "$forwarded" != "$sock" && -S "$forwarded" ]]; then
+    cur=$(readlink "$sock" 2>/dev/null) || cur=""
+    if [[ "$cur" == "$forwarded" ]] && ! [[ "$receipt" -ef "$forwarded" ]]; then
+      record_receipt "$forwarded"
+    fi
+  fi
+
+  failed="" failed_rc=0
+  if ! [[ "$sock" -ef "$secretive" ]]; then
+    # An adopted forwarded socket can outlive its SSH session as a file that
+    # still passes -S. ssh-add exits 2 when it cannot reach the agent at all
+    # (a stale, missing, or dangling sock alike); 1 means reachable-but-empty,
+    # which stays adopted (matching the empty-forwarded adoption above). A
+    # socket that connects but never answers times out to 124, which lands in
+    # the same ">= 2" bucket: unusable, so heal back to Secretive.
+    rc=0
+    run_bounded 2 env SSH_AUTH_SOCK="$sock" ssh-add -l >/dev/null || rc=$?
+    if (( rc >= 2 )); then
+      # Remember the verdict: when the receipt names this same socket, the
+      # block below reuses it rather than probing the same blackhole twice
+      # in one run (two 2s stalls, paid by a prompt or a commit).
+      failed=$(readlink "$sock" 2>/dev/null) || failed=""
+      failed_rc=$rc
+      relink "$secretive" "$sock"
+    fi
+  fi
+
+  # Re-adoption: the way back to a forwarded agent after a heal, without
+  # scanning or guessing. Runs only while the sock sits on Secretive —
+  # while a forwarded sock is adopted and answering, the sock itself is
+  # the source of truth and the receipt is left alone.
+  if [[ -L "$receipt" ]] && [[ "$sock" -ef "$secretive" ]]; then
+    if ! [[ -S "$receipt" ]]; then
+      # A dangling receipt is dead for good — fresh sessions mint fresh
+      # socket names and push them. This also clears pre-reboot receipts.
+      drop_receipt
+    else
+      now=$(date +%s)
+      IFS= read -r last < "$stamp" 2>/dev/null || last=0
+      [[ -z "$last" || "$last" == *[!0-9]* ]] && last=0
+      if (( now - last >= 60 )); then
+        target=$(readlink "$receipt" 2>/dev/null) || target=""
+        rc=0
+        keys=""
+        if [[ -n "$failed" && "$target" == "$failed" ]]; then
+          rc=$failed_rc
+        else
+          # Stamp before probing: when a wake fans precmd out across every
+          # pane at once, only the first pays the probe.
+          defer_receipt
+          keys=$(agent_keys "$target") || rc=$?
+        fi
+        if (( rc <= 1 )); then
+          if [[ -n "$keys" && "$keys" == "$(agent_keys "$secretive")" ]]; then
+            # Same loop check as the push path: this "forwarded" agent is
+            # the local one seen through an ssh-to-self hop.
+            drop_receipt
+          else
+            # Link the sock at the target, not at the receipt: a receipt
+            # deleted later must not dangle the sock.
+            relink "$target" "$sock"
+            rm -f "$stamp"
+          fi
+        elif (( rc == 124 )); then
+          # Accepts but never answers: likely a sleeping client. Keep the
+          # receipt; the stamp defers the next attempt.
+          defer_receipt
+        else
+          drop_receipt
+        fi
+      fi
+    fi
   fi
 fi
 

--- a/macos/LaunchAgents/com.haacked.secretive-ssh-auth.plist
+++ b/macos/LaunchAgents/com.haacked.secretive-ssh-auth.plist
@@ -9,13 +9,13 @@
     symlink (see zsh/zshrc.symlink and bin/ssh-agent-sync) rather than
     Secretive's socket directly, so processes that never source .zshrc
     (GUI apps, tools that spawn non-interactive shells) still pick up a
-    live agent. Runs ssh-agent-sync with no argument, since only an
-    interactive SSH shell knows about a live forwarded socket to hand
-    it; this job can only heal toward the local Secretive agent, which
-    is enough to seed the symlink before any shell has run. Signing
-    itself resolves the right key fresh at sign time via
-    gpg.ssh.defaultKeyCommand (bin/git-signing-key), so there's no key
-    file to seed here.
+    live agent. Runs ssh-agent-sync with no argument: it heals toward
+    the local Secretive agent and re-adopts the last receipted
+    forwarded socket if that still answers. At boot any receipt
+    predates the reboot, so this run also cleans it up while seeding
+    the symlink before any shell has run. Signing itself resolves the
+    right key fresh at sign time via gpg.ssh.defaultKeyCommand
+    (bin/git-signing-key), so there's no key file to seed here.
     -->
     <key>ProgramArguments</key>
     <array>

--- a/zsh/zshrc.symlink
+++ b/zsh/zshrc.symlink
@@ -7,11 +7,6 @@ prompt_context(){}
 
 # --- SSH ---
 
-# Auto-attach tmux for SSH sessions
-if [ -f "$HOME/.dotfiles/zsh/ssh-tmux.zsh" ]; then
-  . "$HOME/.dotfiles/zsh/ssh-tmux.zsh"
-fi
-
 # SSH agent: every shell exports the same stable symlink, whether it's an SSH
 # session, a tmux pane (see ssh-tmux.zsh), or a host-native one like a
 # Supacode tab viewed through Jump Desktop's screen share. A live forwarded
@@ -60,6 +55,18 @@ _ssh_agent_sync() {
 _ssh_agent_sync
 autoload -Uz add-zsh-hook
 add-zsh-hook precmd _ssh_agent_sync
+
+# Auto-attach tmux for SSH sessions. Sourced after the agent sync above,
+# because an SSH login shell blocks inside `tmux attach` until the session
+# ends: the freshly minted forwarded socket has to be captured and pushed
+# first, or every reconnect lands in tmux with its new socket unadopted.
+# Panes inside tmux then inherit the symlink path as SSH_AUTH_SOCK (tmux
+# refreshes it from the attaching client), which the sync treats as a
+# self-reference no-op; after a heal, re-adoption comes from
+# ssh-agent-sync's receipt, not from the panes.
+if [ -f "$HOME/.dotfiles/zsh/ssh-tmux.zsh" ]; then
+  . "$HOME/.dotfiles/zsh/ssh-tmux.zsh"
+fi
 
 # --- Secrets (never committed) ---
 if [ -f "$HOME/.secrets" ]; then


### PR DESCRIPTION
- `ssh-agent-sync` now records each adopted forwarded socket as a receipt (`~/.ssh/agent.fwd`). When the agent symlink has healed back to local Secretive, no-arg callers (tmux panes, launchd, git's signing path) re-adopt the receipt's socket once it answers again, after the same loop check pushes get. A refused socket deletes the receipt; one that accepts but never answers keeps it with a once-a-minute retry, so a sleeping client costs at most one bounded 2s probe per minute. `ssh-agent-sync --local` clears the receipt and pins local for the case where a forgotten live session keeps winning.
- The zshrc agent block now runs before the tmux auto-attach. The login shell used to block inside `tmux attach` before ever capturing the forwarded socket, so each reconnect's freshly minted socket went unadopted. Now every SSH (re)connect pushes it first.
- Pushes prune conclusively dead sshd socket leftovers under `~/.ssh/agent/` (refused connection, over an hour old, `s.*.sshd.*` only; `ssh-agent`'s own `s.*.agent.*` sockets are never touched).

This fixes remote commit signing silently reverting to the unattended machine after the client laptop sleeps: the bounded probe times out, the symlink heals to local, and before this change nothing inside tmux could ever find its way back to the forwarded agent.

**Test plan:** `bash bin/lib/test-ssh-agent-sync.sh` (65 assertions, including re-adopt, refused/stalled/looped/dangling receipts, backoff, `--local`, and pruning), plus `test-git-signing-key.sh` and `test-git-signing-integration.sh` unchanged and green. Live verification after merge: SSH in from the client, confirm a pane prints `forwarded`, sleep and wake the client, confirm re-adoption within a minute.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*