### PR TITLE
Add a scheduled dead-link check to the vault ingest drip

### DIFF
--- a/ai/skills/vault/SKILL.md
+++ b/ai/skills/vault/SKILL.md
@@ -63,6 +63,8 @@ The links helper reports dead `[[wikilinks]]`, orphan wiki pages (no inbound lin
 3. Fix mechanical issues after a y/n confirmation — except dead links sourced from raw files, which are permanent (raw is never edited; consolidated-away targets are the common case): report, don't fix. Report judgment issues as a checklist; offer to capture deferred ones as `/followup` items.
 4. Append a `lint |` entry to `PostHog/log.md` summarizing what was checked and fixed.
 
+The daily ingest drip (`bin/vault-ingest-run`) already runs the links helper with `--skip-raw-sources` and files a `lint |` entry when a wiki page's link breaks, reporting each distinct finding set once. Orphans, duplicates, markdownlint, and every judgment check belong to this mode.
+
 ## Consolidate mode
 
 Merge duplicate or overlapping wiki pages — one survivor absorbs the rest. Wiki layer only: never raw sources, `plans/`, `archive/`, or structural files (`Home.md`, `log.md`, `CLAUDE.md`, `Followups.md`). Interactive only — per-merge confirmation is the point; never run unattended.

--- a/ai/skills/vault/scripts/tests/test-vault.sh
+++ b/ai/skills/vault/scripts/tests/test-vault.sh
@@ -113,6 +113,19 @@ check "unique page not a dup" "$(grep -c 'page-b' <<< "$dup_section" || true)" "
 check "log.md links are not dead-link sources" "$(grep -c '\[\[a\]\]' <<< "$out" || true)" "0"
 check "ledger-only page is an orphan" "$(grep -c 'ledger-only' <<< "$out")" "1"
 
+# --- vault-lint-links.sh: --skip-raw-sources ---
+# A dead link in a raw source can only be fixed by restoring its target, since
+# raw files are never edited. The default report keeps those visible; the
+# scheduled check (bin/vault-ingest-run) skips them to stay quiet by default.
+printf 'points at [[vanished-page]]\n' >> "$V/standup/2026-08-13.md"
+
+raw_out=$("$LINT" "$V")
+skip_out=$("$LINT" --skip-raw-sources "$V")
+check "raw dead link reported by default" "$(grep -c 'vanished-page' <<< "$raw_out")" "1"
+check "raw dead link skipped with flag" "$(grep -c 'vanished-page' <<< "$skip_out" || true)" "0"
+check "wiki dead link survives the flag" "$(grep -c 'ghost-page' <<< "$skip_out")" "1"
+check "flag keeps the orphan check intact" "$(grep -c 'ledger-only' <<< "$skip_out")" "1"
+
 echo ""
 echo "Passed: ${passes}, Failed: ${failures}"
 [[ "${failures}" -eq 0 ]]

--- a/ai/skills/vault/scripts/vault-lint-links.sh
+++ b/ai/skills/vault/scripts/vault-lint-links.sh
@@ -2,7 +2,11 @@
 # Report dead [[wikilinks]], orphan wiki pages (no inbound wikilinks), and
 # duplicate wiki page names (consolidation candidates).
 #
-# Usage: vault-lint-links.sh [vault-dir]
+# Usage: vault-lint-links.sh [--skip-raw-sources] [vault-dir]
+#
+# --skip-raw-sources drops dead links whose source is a raw file. They are only
+# fixable by restoring the target, so the scheduled check in
+# bin/vault-ingest-run skips them to stay quiet unless a wiki page breaks.
 #
 # Report-only; exits 0 except when the vault dir can't be entered (no -e: a
 # file with zero wikilinks makes the extraction pipeline "fail", which must
@@ -21,8 +25,23 @@
 
 set -uo pipefail
 
-VAULT="${1:-$HOME/dev/haacked/notes/PostHog}"
+SKIP_RAW_SOURCES=0
+VAULT="$HOME/dev/haacked/notes/PostHog"
+for arg in "$@"; do
+    case "$arg" in
+        --skip-raw-sources) SKIP_RAW_SOURCES=1 ;;
+        *) VAULT="$arg" ;;
+    esac
+done
 cd "$VAULT" || exit 1
+
+# The raw layer, in sync with vault-next-source.sh's find list.
+is_raw_source() {
+    case "$1" in
+        standup/*|ops-reports/*|daily/*|support/*|2[0-9][0-9][0-9]/*) return 0 ;;
+    esac
+    return 1
+}
 
 tmpdir=$(mktemp -d)
 trap 'rm -rf "$tmpdir"' EXIT
@@ -44,6 +63,7 @@ done < "$tmpdir/files"
 echo "== Dead wikilinks =="
 dead=0
 while IFS=$'\t' read -r f target; do
+    [[ "$SKIP_RAW_SOURCES" -eq 1 ]] && is_raw_source "$f" && continue
     base="${target##*/}"
     if ! grep -qxF -- "${target}.md" "$tmpdir/files" && ! grep -qxF -- "${base}.md" "$tmpdir/files" && ! grep -qF -- "/${base}.md" "$tmpdir/files"; then
         printf '%s -> [[%s]]\n' "$f" "$target"

--- a/bin/vault-ingest-run
+++ b/bin/vault-ingest-run
@@ -24,7 +24,19 @@ if ! [[ "$TRANCHE" =~ ^[0-9]+$ ]]; then
   exit 64
 fi
 
-MAX_BUDGET_USD="${VAULT_INGEST_MAX_BUDGET_USD:-10}"
+# Pinned rather than inherited: an unattended run that writes wiki pages should
+# not change model tier when the CLI default moves, and the budget below is
+# calibrated to one tier's costs. Opus for the judgment the schema asks for
+# (deciding what is durable, catching a stale claim), since pages are rewritten
+# in place and a thin distillation looks fine on the page. Set
+# VAULT_INGEST_MODEL to try another tier against the pages Opus already wrote.
+MODEL="${VAULT_INGEST_MODEL:-claude-opus-5}"
+
+# A runaway guard, not a spend limit: on a subscription plan the real constraint
+# is quota, which is why the agent fires outside working hours. Measured tranches
+# of 5 land near $8 at list rates, so this leaves room for a heavy one to finish
+# rather than being cut off mid-tranche. Raise it alongside the tranche size.
+MAX_BUDGET_USD="${VAULT_INGEST_MAX_BUDGET_USD:-25}"
 RUN_TIMEOUT_SECONDS="${VAULT_INGEST_TIMEOUT_SECONDS:-1800}"   # 30 min
 RUN_KILL_AFTER_SECONDS="${VAULT_INGEST_KILL_AFTER_SECONDS:-60}"
 
@@ -39,6 +51,57 @@ LAST_SESSION_FILE="${STATE_DIR}/last-session-id"
 SESSION_ID=$(uuidgen | tr '[:upper:]' '[:lower:]')
 echo "$SESSION_ID" > "$LAST_SESSION_FILE"
 
+# Check links before the backlog test, so the check outlives the drip: once the
+# backlog drains this script exits early every day, and a lint step below that
+# would silently stop running. Reports the vault as it stands, so a link the
+# previous run broke surfaces on this one.
+#
+# Dead links only. Orphans are a standing backlog to triage in a /vault lint
+# session, not a daily alarm; add them here once that baseline is clean.
+lint_dead_links() {
+  local log_file="${WORKING_DIR}/PostHog/log.md"
+  local fingerprint_file="${STATE_DIR}/last-dead-links"
+  local dead count fingerprint
+  dead=$("${HOME}/.claude/skills/vault/scripts/vault-lint-links.sh" --skip-raw-sources \
+    "${WORKING_DIR}/PostHog" 2>/dev/null |
+    awk '/^== Dead wikilinks ==/ { inside = 1; next } /^== / { inside = 0 } inside && NF && $0 != "(none)"' || true)
+
+  if [[ -z "$dead" ]]; then
+    log_info "Link check: no dead wikilinks"
+    rm -f "$fingerprint_file"
+    return 0
+  fi
+
+  count=$(printf '%s\n' "$dead" | grep -c . || true)
+
+  # The ledger is append-only, so an unfixed link must not earn a fresh entry
+  # every morning. Report each distinct set of findings once; clearing the
+  # fingerprint above means a link that breaks again is reported again.
+  fingerprint=$(printf '%s\n' "$dead" | shasum | cut -d' ' -f1)
+  if [[ -f "$fingerprint_file" && "$(<"$fingerprint_file")" == "$fingerprint" ]]; then
+    log_info "Link check: $count dead wikilink(s), unchanged since the last report"
+    return 0
+  fi
+
+  log_warn "Link check: $count dead wikilink(s); appending a lint entry to log.md"
+
+  # Paths are backtick-wrapped per the log convention. Naming them is safe: the
+  # ingest ledger only counts paths inside "ingest |" entries.
+  {
+    printf '\n## [%s] lint | %s dead wikilink(s)\n\n' "$(date +%F)" "$count"
+    printf 'Scheduled link check (vault-ingest). Wiki pages pointing at pages that no longer resolve:\n\n'
+    # shellcheck disable=SC2016  # backticks in the sed pattern are literal, not expansions
+    printf '%s\n' "$dead" | head -10 | sed 's|^\(.*\) -> \(\[\[.*\]\]\)$|- `\1` -> \2|'
+    if [[ "$count" -gt 10 ]]; then
+      printf -- '- (+%s more)\n' "$((count - 10))"
+    fi
+  } >> "$log_file"
+
+  printf '%s\n' "$fingerprint" > "$fingerprint_file"
+}
+
+lint_dead_links
+
 # Skip early when the backlog is empty: no reason to spend a claude session.
 BACKLOG=$("${HOME}/.claude/skills/vault/scripts/vault-next-source.sh" all 2>/dev/null | grep -c . || true)
 if [[ "$BACKLOG" -eq 0 ]]; then
@@ -49,6 +112,7 @@ fi
 log_section "vault-ingest"
 log_info "Session ID:  $SESSION_ID"
 log_info "Tranche:     $TRANCHE (backlog: $BACKLOG)"
+log_info "Model:       $MODEL"
 log_info "Budget cap:  \$${MAX_BUDGET_USD}"
 log_info "Working dir: $WORKING_DIR"
 
@@ -93,6 +157,7 @@ caffeinate -i timeout --kill-after="$RUN_KILL_AFTER_SECONDS" \
   "$RUN_TIMEOUT_SECONDS" \
   claude --print \
     --session-id "$SESSION_ID" \
+    --model "$MODEL" \
     --permission-mode bypassPermissions \
     --max-budget-usd "$MAX_BUDGET_USD" \
     --output-format text \


### PR DESCRIPTION
The daily vault-ingest drip now runs `vault-lint-links.sh --skip-raw-sources` before the backlog early-exit and files a `lint |` entry to `log.md` when a wiki page's link breaks. A fingerprint in the state dir reports each distinct finding set once, so an unfixed link doesn't earn a fresh ledger entry every morning.

Dead links in raw sources are unfixable by policy (raw is never edited), so the new `--skip-raw-sources` flag drops them for the scheduled check while the default report keeps them visible for `/vault lint`.

Also pins the ingest model rather than inheriting the CLI default, and raises the runaway budget cap to $25 so a heavy tranche finishes instead of being cut off.

Test coverage: four new cases in `test-vault.sh` covering the flag's skip/keep behavior (24/24 passing).

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*