### PR TITLE
Point standup and ops-report tooling at the raw/ vault layout

### DIFF
--- a/ai/skills/ops-report/SKILL.md
+++ b/ai/skills/ops-report/SKILL.md
@@ -338,7 +338,7 @@ Group results by message pattern and identify the **top 5 most frequent** error 
 Determine today's date from the system. The report path is:
 
 ```text
-~/dev/haacked/notes/PostHog/ops-reports/{YYYY-MM-DD}/{service}-{window}.md
+~/dev/haacked/notes/PostHog/raw/ops-reports/{YYYY-MM-DD}/{service}-{window}.md
 ```
 
 For `day` window, the filename can omit the suffix (e.g., `feature-flags.md`). For `week` and `month`, include it (e.g., `feature-flags-week.md`).

--- a/ai/skills/standup/scripts/standup-dates.sh
+++ b/ai/skills/standup/scripts/standup-dates.sh
@@ -11,7 +11,7 @@
 
 set -euo pipefail
 
-STANDUP_DIR="$HOME/dev/haacked/notes/PostHog/standup"
+STANDUP_DIR="$HOME/dev/haacked/notes/PostHog/raw/standup"
 
 # Ensure directory exists
 mkdir -p "$STANDUP_DIR"

--- a/ai/skills/standup/scripts/standup-find.sh
+++ b/ai/skills/standup/scripts/standup-find.sh
@@ -14,7 +14,7 @@
 
 set -euo pipefail
 
-STANDUP_DIR="$HOME/dev/haacked/notes/PostHog/standup"
+STANDUP_DIR="$HOME/dev/haacked/notes/PostHog/raw/standup"
 
 # Ensure directory exists
 mkdir -p "$STANDUP_DIR"

--- a/ai/skills/vault/SKILL.md
+++ b/ai/skills/vault/SKILL.md
@@ -7,7 +7,7 @@ model: sonnet
 
 # Vault Operations
 
-The knowledge loop over the PostHog work vault at `~/dev/haacked/notes/PostHog` (paths below are relative to `~/dev/haacked/notes`). The schema (raw vs wiki vs working docs, the log rules) lives in `PostHog/CLAUDE.md` — read it before any operation. The operations log `PostHog/log.md` is both history and the ingest ledger: a backtick-wrapped vault-relative path anywhere in the log marks that raw source as ingested, so only ingest entries may backtick-wrap paths — every other entry type writes paths plain or as `[[wikilinks]]`.
+The knowledge loop over the PostHog work vault at `~/dev/haacked/notes/PostHog` (paths below are relative to `~/dev/haacked/notes`). The schema (raw vs wiki vs working docs, the log rules) lives in `PostHog/CLAUDE.md` — read it before any operation. The operations log `PostHog/log.md` is both history and the ingest ledger: a backtick-wrapped vault-relative path anywhere in the log marks that raw source as ingested, so only ingest entries may backtick-wrap paths — every other entry type writes paths plain or as `[[wikilinks]]`. Ledger entries dated before 2026-08-18 name raw paths without the `raw/` prefix (pre-move layout); the backlog helper accepts both.
 
 ## Modes
 
@@ -39,7 +39,7 @@ It prints the oldest raw file not yet named by an `ingest |` log entry (stderr s
 ```markdown
 ## [YYYY-MM-DD] ingest | <short title>
 
-Source: `2026/07/Feature Flags - Growth Review.md`. Updated: [[page-one]], [[page-two]]. New: [[page-three]].
+Source: `raw/2026/07/Feature Flags - Growth Review.md`. Updated: [[page-one]], [[page-two]]. New: [[page-three]].
 ```
 
 5. Report: source, pages updated/created, anything deliberately skipped.

--- a/ai/skills/vault/SKILL.md
+++ b/ai/skills/vault/SKILL.md
@@ -7,7 +7,7 @@ model: sonnet
 
 # Vault Operations
 
-The knowledge loop over the PostHog work vault at `~/dev/haacked/notes/PostHog` (paths below are relative to `~/dev/haacked/notes`). The schema (raw vs wiki vs working docs, the log rules) lives in `PostHog/CLAUDE.md` — read it before any operation. The operations log `PostHog/log.md` is both history and the ingest ledger: a backtick-wrapped vault-relative path anywhere in the log marks that raw source as ingested, so only ingest entries may backtick-wrap paths — every other entry type writes paths plain or as `[[wikilinks]]`. Ledger entries dated before 2026-08-18 name raw paths without the `raw/` prefix (pre-move layout); the backlog helper accepts both.
+The knowledge loop over the PostHog work vault at `~/dev/haacked/notes/PostHog` (paths below are relative to `~/dev/haacked/notes`). The schema (raw vs wiki vs working docs, the log rules) lives in `PostHog/CLAUDE.md` — read it before any operation. The operations log `PostHog/log.md` is both history and the ingest ledger: a backtick-wrapped vault-relative path anywhere in the log marks that raw source as ingested, so only ingest entries may backtick-wrap paths — every other entry type writes paths plain or as `[[wikilinks]]`. Ledger entries dated before 2026-08-18 name raw paths without the `raw/` prefix (pre-move layout); both forms mark a source ingested.
 
 ## Modes
 

--- a/bin/standup-run
+++ b/bin/standup-run
@@ -41,7 +41,7 @@ Do these steps in order.
 
 1. Invoke the /standup skill: "/standup". Follow its steps to query GitHub PR
    activity, compose the notes, and WRITE THE ARCHIVE FILE (the plain-text
-   file under ~/dev/haacked/notes/PostHog/standup/) — the next run's
+   file under ~/dev/haacked/notes/PostHog/raw/standup/) — the next run's
    carry-over logic depends on that file existing. Do NOT run the clipboard
    step (the swift copy-html-to-clipboard helper): nobody is at the keyboard,
    and the DM in step 2 replaces it.


### PR DESCRIPTION
The PostHog notes vault moved its raw areas (standup, ops-reports, daily, support, and the year folders) under a single top-level raw/ directory. This updates the tooling that writes to those paths: STANDUP_DIR in the standup helper scripts, the archive path in the standup-run worker prompt, and the ops-report skill's report path template.

The vault skill's ledger docs now show raw/-prefixed source paths and note that entries dated before 2026-08-18 use the pre-move form, which the backlog helper accepts. The vault scripts' own raw/ adaptation (find root, ledger fallback, lint patterns, tests) lands separately.

Test plan: with the migrated vault in place, standup-find.sh resolves the latest standup at raw/standup/2026-08-17.md and standup-dates.sh computes new paths under raw/standup/; the vault test suite passes against the separately landing script changes.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*