### PR TITLE
Harden the scheduled link check and follow the raw/ vault layout

### DIFF
--- a/ai/skills/vault/SKILL.md
+++ b/ai/skills/vault/SKILL.md
@@ -63,7 +63,7 @@ The links helper reports dead `[[wikilinks]]`, orphan wiki pages (no inbound lin
 3. Fix mechanical issues after a y/n confirmation — except dead links sourced from raw files, which are permanent (raw is never edited; consolidated-away targets are the common case): report, don't fix. Report judgment issues as a checklist; offer to capture deferred ones as `/followup` items.
 4. Append a `lint |` entry to `PostHog/log.md` summarizing what was checked and fixed.
 
-The daily ingest drip (`bin/vault-ingest-run`) already runs the links helper with `--skip-raw-sources` and files a `lint |` entry when a wiki page's link breaks, reporting each distinct finding set once. Orphans, duplicates, markdownlint, and every judgment check belong to this mode.
+The daily ingest drip (`bin/vault-ingest-run`) already runs the links helper with `--skip-raw-sources` and files a `lint |` entry when a wiki page's link breaks, staying silent while the findings match the last report and listing at most ten. Orphans, duplicates, markdownlint, and every judgment check belong to this mode.
 
 ## Consolidate mode
 

--- a/ai/skills/vault/SKILL.md
+++ b/ai/skills/vault/SKILL.md
@@ -63,7 +63,7 @@ The links helper reports dead `[[wikilinks]]`, orphan wiki pages (no inbound lin
 3. Fix mechanical issues after a y/n confirmation — except dead links sourced from raw files, which are permanent (raw is never edited; consolidated-away targets are the common case): report, don't fix. Report judgment issues as a checklist; offer to capture deferred ones as `/followup` items.
 4. Append a `lint |` entry to `PostHog/log.md` summarizing what was checked and fixed.
 
-The daily ingest drip (`bin/vault-ingest-run`) already runs the links helper with `--skip-raw-sources` and files a `lint |` entry when a wiki page's link breaks, staying silent while the findings match the last report and listing at most ten. Orphans, duplicates, markdownlint, and every judgment check belong to this mode.
+The daily ingest drip (`bin/vault-ingest-run`) already runs the links helper with `--skip-raw-sources` and files a `lint |` entry when a wiki page's link breaks, staying silent while the findings match the last report. Orphans, duplicates, markdownlint, and every judgment check belong to this mode.
 
 ## Consolidate mode
 

--- a/ai/skills/vault/scripts/tests/test-vault.sh
+++ b/ai/skills/vault/scripts/tests/test-vault.sh
@@ -24,34 +24,42 @@ V=$(mktemp -d)
 trap 'rm -rf "$V"' EXIT
 
 # --- vault-next-source.sh: ledger matching ---
-mkdir -p "$V/standup" "$V/daily"
-printf 'x\n' > "$V/standup/2026-08-10.md"
-printf 'y\n' > "$V/standup/2026-08-10-part2.md"
-printf 'z\n' > "$V/daily/2026-08-11.md"
-printf 'n\n' > "$V/standup/2026-08-12.md"
-printf 'l\n' > "$V/standup/2026-08-13.md"
+# Raw sources live under raw/, per the schema. Fixtures that put them at the
+# vault root would pass while the real vault reported an empty backlog.
+mkdir -p "$V/raw/standup" "$V/raw/daily"
+printf 'x\n' > "$V/raw/standup/2026-08-10.md"
+printf 'y\n' > "$V/raw/standup/2026-08-10-part2.md"
+printf 'z\n' > "$V/raw/daily/2026-08-11.md"
+printf 'n\n' > "$V/raw/standup/2026-08-12.md"
+printf 'l\n' > "$V/raw/standup/2026-08-13.md"
+printf 'p\n' > "$V/raw/standup/2026-08-14.md"
 cat > "$V/log.md" <<'EOF'
 # Operations Log
 
-Preamble mentioning `standup/2026-08-13.md` before any entry heading.
+Preamble mentioning `raw/standup/2026-08-13.md` before any entry heading.
 
 ## [2026-08-11] ingest | recap
 
-Source: `standup/2026-08-10-part2.md`. Updated: [[a]].
+Source: `raw/standup/2026-08-10-part2.md`. Updated: [[a]].
 
 ## [2026-08-12] note | restructure
 
-Moved things around; the new raw file is `standup/2026-08-12.md`.
+Moved things around; the new raw file is `raw/standup/2026-08-12.md`.
 
 ## [2026-08-13] lint | health check
 
-Checked everything, including `standup/2026-08-10.md`.
+Checked everything, including `raw/standup/2026-08-10.md`.
+
+## [2026-08-14] ingest | pre-move entry
+
+Source: `standup/2026-08-14.md`, named the way entries did before the raw/ move.
 EOF
 
-check "prefix sibling stays in backlog" "$(VAULT="$V" "$NEXT" all 2>/dev/null | grep -cF 'standup/2026-08-10.md')" "1"
-check "ingested source marked processed" "$(VAULT="$V" "$NEXT" all 2>/dev/null | grep -cF 'standup/2026-08-10-part2.md' || true)" "0"
-check "path named in a note entry stays in backlog" "$(VAULT="$V" "$NEXT" all 2>/dev/null | grep -cF 'standup/2026-08-12.md')" "1"
-check "path named in the preamble stays in backlog" "$(VAULT="$V" "$NEXT" all 2>/dev/null | grep -cF 'standup/2026-08-13.md')" "1"
+check "prefix sibling stays in backlog" "$(VAULT="$V" "$NEXT" all 2>/dev/null | grep -cF 'raw/standup/2026-08-10.md')" "1"
+check "ingested source marked processed" "$(VAULT="$V" "$NEXT" all 2>/dev/null | grep -cF 'raw/standup/2026-08-10-part2.md' || true)" "0"
+check "pre-move ledger path marks a source processed" "$(VAULT="$V" "$NEXT" all 2>/dev/null | grep -cF 'raw/standup/2026-08-14.md' || true)" "0"
+check "path named in a note entry stays in backlog" "$(VAULT="$V" "$NEXT" all 2>/dev/null | grep -cF 'raw/standup/2026-08-12.md')" "1"
+check "path named in the preamble stays in backlog" "$(VAULT="$V" "$NEXT" all 2>/dev/null | grep -cF 'raw/standup/2026-08-13.md')" "1"
 check "backlog count" "$(VAULT="$V" "$NEXT" all 2>/dev/null | grep -c .)" "4"
 check "bad count rejected" "$(VAULT="$V" "$NEXT" banana 2>&1 | grep -c 'Error' || true)" "1"
 
@@ -76,13 +84,13 @@ printf 'back to [[page-a]]\n' > "$V/reference/page-b.md"
 # variant, and dups in raw/working-doc areas that must not be reported.
 # Created after the vault-next-source checks so the raw fixtures don't
 # perturb the backlog counts above.
-mkdir -p "$V/sdks" "$V/repositories/posthog" "$V/ops-reports/2026-08-01" "$V/ops-reports/2026-08-02" "$V/repositories/a/plans" "$V/repositories/b/plans" "$V/sprint-planning" "$V/quarterly-planning"
+mkdir -p "$V/sdks" "$V/repositories/posthog" "$V/raw/ops-reports/2026-08-01" "$V/raw/ops-reports/2026-08-02" "$V/repositories/a/plans" "$V/repositories/b/plans" "$V/sprint-planning" "$V/quarterly-planning"
 printf 'topic\n' > "$V/reference/dup-topic.md"
 printf 'topic again\n' > "$V/sdks/dup-topic.md"
 printf 'cache notes\n' > "$V/reference/Widget Cache.md"
 printf 'cache notes again\n' > "$V/repositories/posthog/widget-cache.md"
-printf 'report\n' > "$V/ops-reports/2026-08-01/svc.md"
-printf 'report\n' > "$V/ops-reports/2026-08-02/svc.md"
+printf 'report\n' > "$V/raw/ops-reports/2026-08-01/svc.md"
+printf 'report\n' > "$V/raw/ops-reports/2026-08-02/svc.md"
 printf 'plan\n' > "$V/repositories/a/plans/plan.md"
 printf 'plan\n' > "$V/repositories/b/plans/plan.md"
 printf 'sp\n' > "$V/sprint-planning/cadence.md"
@@ -102,7 +110,7 @@ check "reports the real dead link" "$(grep -c 'ghost-page' <<< "$out")" "1"
 check "backtick-fenced [[ ]] excluded" "$(grep -c '\-n' <<< "$out" || true)" "0"
 check "tilde-fenced [[ ]] excluded" "$(grep -c 'tilde-fenced' <<< "$out" || true)" "0"
 check "inline-code [[ ]] excluded" "$(grep -c 'not-a-link' <<< "$out" || true)" "0"
-check "raw-area file not an orphan" "$(grep -c 'standup/2026-08-10' <<< "$out" || true)" "0"
+check "raw-area file not an orphan" "$(grep -c 'raw/standup/2026-08-10' <<< "$out" || true)" "0"
 check "exact dup reported" "$(grep -c 'dup-topic.md' <<< "$dup_section")" "2"
 check "name-variant dup reported" "$(grep -c 'Widget Cache.md\|widget-cache.md' <<< "$dup_section")" "2"
 check "raw-area dups excluded" "$(grep -c 'ops-reports' <<< "$dup_section" || true)" "0"
@@ -117,7 +125,7 @@ check "ledger-only page is an orphan" "$(grep -c 'ledger-only' <<< "$out")" "1"
 # A dead link in a raw source can only be fixed by restoring its target, since
 # raw files are never edited. The default report keeps those visible; the
 # scheduled check (bin/vault-ingest-run) skips them to stay quiet by default.
-printf 'points at [[vanished-page]]\n' >> "$V/standup/2026-08-13.md"
+printf 'points at [[vanished-page]]\n' >> "$V/raw/standup/2026-08-13.md"
 
 raw_out=$("$LINT" "$V")
 skip_out=$("$LINT" --skip-raw-sources "$V")
@@ -131,8 +139,7 @@ check "mistyped flag exits 64" "$("$LINT" --skip-raw-source "$V" >/dev/null 2>&1
 # The scheduled check in bin/vault-ingest-run parses this section by header and
 # line shape, so both are part of the interface, not incidental formatting.
 check "dead-link section header is stable" "$(grep -c '^== Dead wikilinks ==' <<< "$skip_out")" "1"
-dead_lines=$(awk '/^== Dead wikilinks ==/ { inside = 1; next } /^== / { inside = 0 } inside && NF && $0 != "(none)"' <<< "$skip_out")
-check "dead-link lines are 'path -> [[target]]'" "$(grep -cv '^.* -> \[\[.*\]\]$' <<< "$dead_lines" || true)" "0"
+check "dead-link lines are 'path -> [[target]]'" "$(grep ' -> ' <<< "$skip_out" | grep -cv '^.* -> \[\[.*\]\]$' || true)" "0"
 
 echo ""
 echo "Passed: ${passes}, Failed: ${failures}"

--- a/ai/skills/vault/scripts/tests/test-vault.sh
+++ b/ai/skills/vault/scripts/tests/test-vault.sh
@@ -125,6 +125,14 @@ check "raw dead link reported by default" "$(grep -c 'vanished-page' <<< "$raw_o
 check "raw dead link skipped with flag" "$(grep -c 'vanished-page' <<< "$skip_out" || true)" "0"
 check "wiki dead link survives the flag" "$(grep -c 'ghost-page' <<< "$skip_out")" "1"
 check "flag keeps the orphan check intact" "$(grep -c 'ledger-only' <<< "$skip_out")" "1"
+check "mistyped flag is rejected" "$("$LINT" --skip-raw-source "$V" 2>&1 >/dev/null | grep -c 'Unknown option')" "1"
+check "mistyped flag exits 64" "$("$LINT" --skip-raw-source "$V" >/dev/null 2>&1; echo $?)" "64"
+
+# The scheduled check in bin/vault-ingest-run parses this section by header and
+# line shape, so both are part of the interface, not incidental formatting.
+check "dead-link section header is stable" "$(grep -c '^== Dead wikilinks ==' <<< "$skip_out")" "1"
+dead_lines=$(awk '/^== Dead wikilinks ==/ { inside = 1; next } /^== / { inside = 0 } inside && NF && $0 != "(none)"' <<< "$skip_out")
+check "dead-link lines are 'path -> [[target]]'" "$(grep -cv '^.* -> \[\[.*\]\]$' <<< "$dead_lines" || true)" "0"
 
 echo ""
 echo "Passed: ${passes}, Failed: ${failures}"

--- a/ai/skills/vault/scripts/vault-lint-links.sh
+++ b/ai/skills/vault/scripts/vault-lint-links.sh
@@ -39,12 +39,9 @@ for arg in "$@"; do
 done
 cd "$VAULT" || exit 1
 
-# The raw layer, in sync with vault-next-source.sh's find list.
+# The raw layer is one directory, per the schema in the vault's CLAUDE.md.
 is_raw_source() {
-    case "$1" in
-        standup/*|ops-reports/*|daily/*|support/*|2[0-9][0-9][0-9]/*) return 0 ;;
-    esac
-    return 1
+    [[ "$1" == raw/* ]]
 }
 
 tmpdir=$(mktemp -d)

--- a/ai/skills/vault/scripts/vault-lint-links.sh
+++ b/ai/skills/vault/scripts/vault-lint-links.sh
@@ -30,6 +30,10 @@ VAULT="$HOME/dev/haacked/notes/PostHog"
 for arg in "$@"; do
     case "$arg" in
         --skip-raw-sources) SKIP_RAW_SOURCES=1 ;;
+        # A mistyped flag must not pass for a vault path: the scheduled check
+        # reads this script's stdout, where a silently-ignored filter looks like
+        # a real finding and a silently-ignored path looks like a clean vault.
+        -*) echo "Unknown option: $arg" >&2; exit 64 ;;
         *) VAULT="$arg" ;;
     esac
 done
@@ -72,11 +76,11 @@ while IFS=$'\t' read -r f target; do
 done < "$tmpdir/links"
 [[ "$dead" -eq 0 ]] && echo "(none)"
 
-# Wiki-layer pages only, per the layer schema in the vault's CLAUDE.md (raw
-# areas stay in sync with vault-next-source.sh's find list).
+# Wiki-layer pages only, per the layer schema in the vault's CLAUDE.md.
 while IFS= read -r f; do
+    is_raw_source "$f" && continue
     case "$f" in
-        standup/*|ops-reports/*|daily/*|support/*|2[0-9][0-9][0-9]/*|*/plans/*|*/archive/*|sprint-planning/*|quarterly-planning/*|Followups.md|log.md|CLAUDE.md|Home.md) continue ;;
+        */plans/*|*/archive/*|sprint-planning/*|quarterly-planning/*|Followups.md|log.md|CLAUDE.md|Home.md) continue ;;
     esac
     printf '%s\n' "$f"
 done < "$tmpdir/files" > "$tmpdir/wiki"

--- a/ai/skills/vault/scripts/vault-next-source.sh
+++ b/ai/skills/vault/scripts/vault-next-source.sh
@@ -30,10 +30,9 @@ fi
 
 cd "$VAULT"
 
-# Raw areas per the schema in CLAUDE.md; year dirs (Granola exports) match the
-# 2[0-9][0-9][0-9] glob. Keep in sync with the case pattern in vault-lint-links.sh.
+# The raw layer is one directory, per the schema in CLAUDE.md.
 # BSD stat: this setup is macOS-only.
-raw_list=$(find standup ops-reports daily support 2[0-9][0-9][0-9] -type f -name '*.md' -print0 2>/dev/null | xargs -0 stat -f '%m|%N' 2>/dev/null | sort -n | cut -d'|' -f2- || true)
+raw_list=$(find raw -type f -name '*.md' -print0 2>/dev/null | xargs -0 stat -f '%m|%N' 2>/dev/null | sort -n | cut -d'|' -f2- || true)
 
 if [[ -z "$raw_list" ]]; then
     echo "No raw sources found under $VAULT" >&2
@@ -52,8 +51,15 @@ ingest_entries=$(awk '
 
 # One grep fork per raw file (~1s at 260 files, fork-bound not size-bound);
 # an awk lookup-set join only pays off once the backlog reaches the thousands.
+# Entries dated before the 2026-08-18 raw/ move name paths without the prefix,
+# and the schema requires tooling to accept both forms; matching only the
+# current form would re-ingest every source processed before the move.
 pending=$(printf '%s\n' "$raw_list" | while IFS= read -r f; do
-    grep -qF "\`${f}\`" <<< "$ingest_entries" || printf '%s\n' "$f"
+    if grep -qF "\`${f}\`" <<< "$ingest_entries" ||
+        grep -qF "\`${f#raw/}\`" <<< "$ingest_entries"; then
+        continue
+    fi
+    printf '%s\n' "$f"
 done)
 
 if [[ -z "$pending" ]]; then

--- a/bin/vault-ingest-run
+++ b/bin/vault-ingest-run
@@ -61,10 +61,25 @@ echo "$SESSION_ID" > "$LAST_SESSION_FILE"
 lint_dead_links() {
   local log_file="${WORKING_DIR}/PostHog/log.md"
   local fingerprint_file="${STATE_DIR}/last-dead-links"
-  local dead count fingerprint
-  dead=$("${HOME}/.claude/skills/vault/scripts/vault-lint-links.sh" --skip-raw-sources \
-    "${WORKING_DIR}/PostHog" 2>/dev/null |
-    awk '/^== Dead wikilinks ==/ { inside = 1; next } /^== / { inside = 0 } inside && NF && $0 != "(none)"' || true)
+  local report dead count fingerprint status=0
+
+  # Never let a broken check read as a clean vault. Discarding stderr and
+  # forcing success here would turn a missing skills symlink or a renamed flag
+  # into a silent daily all-clear, so failures are loud and leave the
+  # fingerprint alone: recovery then reports the set rather than assuming the
+  # last run logged it.
+  report=$("${HOME}/.claude/skills/vault/scripts/vault-lint-links.sh" --skip-raw-sources \
+    "${WORKING_DIR}/PostHog") || status=$?
+  if [[ "$status" -ne 0 ]]; then
+    log_error "Link check: lint exited $status; skipping this run"
+    return 0
+  fi
+  if ! grep -q '^== Dead wikilinks ==' <<< "$report"; then
+    log_error "Link check: report is missing its dead-wikilinks section; skipping this run"
+    return 0
+  fi
+
+  dead=$(awk '/^== Dead wikilinks ==/ { inside = 1; next } /^== / { inside = 0 } inside && NF && $0 != "(none)"' <<< "$report")
 
   if [[ -z "$dead" ]]; then
     log_info "Link check: no dead wikilinks"
@@ -87,11 +102,18 @@ lint_dead_links() {
 
   # Paths are backtick-wrapped per the log convention. Naming them is safe: the
   # ingest ledger only counts paths inside "ingest |" entries.
+  # The fingerprint prefix keeps the heading unique: two same-day runs reporting
+  # the same number of links would otherwise collide, and MD024 is scoped to
+  # siblings where every log.md heading is one. Past entries are never edited,
+  # so a collision would be a permanent lint error.
   {
-    printf '\n## [%s] lint | %s dead wikilink(s)\n\n' "$(date +%F)" "$count"
+    printf '\n## [%s] lint | %s dead wikilink(s) (%s)\n\n' "$(date +%F)" "$count" "${fingerprint:0:7}"
     printf 'Scheduled link check (vault-ingest). Wiki pages pointing at pages that no longer resolve:\n\n'
+    # head reads from a here-string rather than a pipe: closing the pipe on a
+    # long report would raise SIGPIPE in printf, which pipefail turns into a
+    # failed status and errexit turns into an aborted run.
     # shellcheck disable=SC2016  # backticks in the sed pattern are literal, not expansions
-    printf '%s\n' "$dead" | head -10 | sed 's|^\(.*\) -> \(\[\[.*\]\]\)$|- `\1` -> \2|'
+    head -10 <<< "$dead" | sed 's|^\(.*\) -> \(\[\[.*\]\]\)$|- `\1` -> \2|'
     if [[ "$count" -gt 10 ]]; then
       printf -- '- (+%s more)\n' "$((count - 10))"
     fi

--- a/bin/vault-ingest-run
+++ b/bin/vault-ingest-run
@@ -24,12 +24,10 @@ if ! [[ "$TRANCHE" =~ ^[0-9]+$ ]]; then
   exit 64
 fi
 
-# Pinned rather than inherited: an unattended run that writes wiki pages should
-# not change model tier when the CLI default moves, and the budget below is
-# calibrated to one tier's costs. Opus for the judgment the schema asks for
-# (deciding what is durable, catching a stale claim), since pages are rewritten
-# in place and a thin distillation looks fine on the page. Set
-# VAULT_INGEST_MODEL to try another tier against the pages Opus already wrote.
+# Pinned rather than inherited: an unattended run that rewrites wiki pages in
+# place should not change tier when the CLI default moves, and the budget below
+# is calibrated to one tier's costs. Opus for the judgment the schema asks for:
+# deciding what is durable, catching a stale claim.
 MODEL="${VAULT_INGEST_MODEL:-claude-opus-5}"
 
 # A runaway guard, not a spend limit: on a subscription plan the real constraint
@@ -61,19 +59,16 @@ echo "$SESSION_ID" > "$LAST_SESSION_FILE"
 lint_dead_links() {
   local log_file="${WORKING_DIR}/PostHog/log.md"
   local fingerprint_file="${STATE_DIR}/last-dead-links"
-  local report dead count fingerprint status=0
+  local report dead count fingerprint
 
-  # Never let a broken check read as a clean vault. Discarding stderr and
-  # forcing success here would turn a missing skills symlink or a renamed flag
-  # into a silent daily all-clear, so failures are loud and leave the
-  # fingerprint alone: recovery then reports the set rather than assuming the
-  # last run logged it.
+  # A broken check must not read as a clean vault: failures are loud and leave
+  # the fingerprint alone, so recovery reports the whole set instead of assuming
+  # the last run logged it.
   report=$("${HOME}/.claude/skills/vault/scripts/vault-lint-links.sh" --skip-raw-sources \
-    "${WORKING_DIR}/PostHog") || status=$?
-  if [[ "$status" -ne 0 ]]; then
-    log_error "Link check: lint exited $status; skipping this run"
+    "${WORKING_DIR}/PostHog") || {
+    log_error "Link check: lint exited $?; skipping this run"
     return 0
-  fi
+  }
   if ! grep -q '^== Dead wikilinks ==' <<< "$report"; then
     log_error "Link check: report is missing its dead-wikilinks section; skipping this run"
     return 0
@@ -87,12 +82,11 @@ lint_dead_links() {
     return 0
   fi
 
-  count=$(printf '%s\n' "$dead" | grep -c . || true)
+  count=$(grep -c . <<< "$dead")
 
   # The ledger is append-only, so an unfixed link must not earn a fresh entry
-  # every morning. Report each distinct set of findings once; clearing the
-  # fingerprint above means a link that breaks again is reported again.
-  fingerprint=$(printf '%s\n' "$dead" | shasum | cut -d' ' -f1)
+  # every morning: report each distinct set of findings once.
+  fingerprint=$(shasum <<< "$dead" | cut -d' ' -f1)
   if [[ -f "$fingerprint_file" && "$(<"$fingerprint_file")" == "$fingerprint" ]]; then
     log_info "Link check: $count dead wikilink(s), unchanged since the last report"
     return 0
@@ -100,20 +94,17 @@ lint_dead_links() {
 
   log_warn "Link check: $count dead wikilink(s); appending a lint entry to log.md"
 
-  # Paths are backtick-wrapped per the log convention. Naming them is safe: the
-  # ingest ledger only counts paths inside "ingest |" entries.
-  # The fingerprint prefix keeps the heading unique: two same-day runs reporting
-  # the same number of links would otherwise collide, and MD024 is scoped to
-  # siblings where every log.md heading is one. Past entries are never edited,
-  # so a collision would be a permanent lint error.
+  # Paths stay plain: per the ledger rule only "ingest |" entries backtick-wrap
+  # paths, since a backticked raw path marks that source ingested. The time
+  # keeps the heading unique, and MD024 is scoped to siblings where every
+  # log.md heading is one, so a collision would be permanent.
   {
-    printf '\n## [%s] lint | %s dead wikilink(s) (%s)\n\n' "$(date +%F)" "$count" "${fingerprint:0:7}"
+    printf '\n## [%s] lint | %s dead wikilink(s) (%s)\n\n' "$(date +%F)" "$count" "$(date +%H:%M)"
     printf 'Scheduled link check (vault-ingest). Wiki pages pointing at pages that no longer resolve:\n\n'
     # head reads from a here-string rather than a pipe: closing the pipe on a
     # long report would raise SIGPIPE in printf, which pipefail turns into a
     # failed status and errexit turns into an aborted run.
-    # shellcheck disable=SC2016  # backticks in the sed pattern are literal, not expansions
-    head -10 <<< "$dead" | sed 's|^\(.*\) -> \(\[\[.*\]\]\)$|- `\1` -> \2|'
+    head -10 <<< "$dead" | sed 's|^|- |'
     if [[ "$count" -gt 10 ]]; then
       printf -- '- (+%s more)\n' "$((count - 10))"
     fi


### PR DESCRIPTION
Three commits on top of the merged scheduled link check (#184):

Harden the scheduled dead-link check: lint failures are loud (a broken check must not read as a clean vault), unknown flags exit 64, lint entries to log.md use plain paths per the ledger convention (a backticked raw path would mark that source ingested), and the daily heading carries a time so repeated same-day checks can't collide on MD024.

Follow the vault's raw/ layout: the raw folders now live under raw/ in the PostHog vault, so vault-next-source.sh finds sources there, vault-lint-links.sh classifies raw sources by the raw/* prefix, and the backlog helper accepts both raw/-prefixed and pre-move legacy ledger paths (entries before 2026-08-18 name paths without the prefix; history is never rewritten).

Tidy the scheduled link check: SKILL.md reflects that an unchanged finding set stays silent, and test fixtures cover the raw/ layout, the pre-move ledger fallback, flag rejection, and the lint report's header and line shape (bin/vault-ingest-run parses them).

Related: #185 updates the standup and ops-report tooling paths for the same layout change.

Test plan: test-vault.sh passes 29/29 against the new fixtures; the live backlog and lint output against the migrated vault match the pre-move baselines.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*