### PR TITLE
Detect requested bot reviewers via GraphQL

### DIFF
--- a/ai/skills/wait-for-pr-reviews/scripts/check-pending-reviews.sh
+++ b/ai/skills/wait-for-pr-reviews/scripts/check-pending-reviews.sh
@@ -8,10 +8,12 @@
 #     HTML markers on its review and status comment, and the label can linger
 #     after the round completes, so "pending" means: label present AND no marked
 #     completion since it was last applied (per the issue timeline).
-#   - Requested bot reviewers (Copilot, Greptile, …): GitHub clears a *user*
-#     entry from requested_reviewers when its review is submitted, so any bot
-#     still listed is mid-review. Team entries linger until a human member
-#     reviews, which a bot never satisfies, so teams are excluded.
+#   - Requested bot reviewers (Copilot, Greptile, …): GitHub clears the entry
+#     when the review is submitted, so any bot still requested is mid-review.
+#     The list comes from GraphQL `reviewRequests`, which returns App reviewers
+#     as Bot nodes; REST `requested_reviewers` omits them entirely. Team entries
+#     linger until a human member reviews, which a bot never satisfies, so teams
+#     are excluded.
 #
 # READ-ONLY: never requests a review, comments, or labels anything.
 # The verdict is a pure function (helpers/pending-reviews.jq); this wrapper only
@@ -44,6 +46,8 @@ fi
 
 REPO="$1"
 PR_NUMBER="$2"
+REPO_OWNER="${REPO%%/*}"
+REPO_NAME="${REPO#*/}"
 
 die() {
   log_error "$1"
@@ -89,8 +93,27 @@ comments=$(gh api --paginate --slurp \
               updated_at: (.updated_at // null) } ]') \
   || die "could not fetch comments for ${REPO}#${PR_NUMBER}"
 
-requested_users=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/requested_reviewers" \
-  --jq '[.users[]? | {login: (.login // ""), type: (.type // "")}]' 2>/dev/null) \
+# GraphQL, not REST: `pulls/:n/requested_reviewers` returns only `.users`, and a
+# GitHub App reviewer (Copilot, Greptile) is a Bot node that never appears there,
+# so the REST list reads empty while the bot is mid-review. `__typename` doubles
+# as the `type` the verdict filters on. Team and Mannequin nodes are dropped here,
+# which is what excludes teams: a team request lingers until a human member
+# reviews, which a bot's review never satisfies.
+# shellcheck disable=SC2016  # $owner/$name/$pr are GraphQL variables, not shell
+requested_users=$(gh api graphql \
+  -f query='query($owner: String!, $name: String!, $pr: Int!) {
+      repository(owner: $owner, name: $name) {
+        pullRequest(number: $pr) {
+          reviewRequests(first: 100) {
+            nodes { requestedReviewer { __typename ... on User { login } ... on Bot { login } } }
+          }
+        }
+      }
+    }' \
+  -f owner="${REPO_OWNER}" -f name="${REPO_NAME}" -F pr="${PR_NUMBER}" \
+  --jq '[.data.repository.pullRequest.reviewRequests.nodes[]?.requestedReviewer
+         | select(. != null and (.__typename == "User" or .__typename == "Bot"))
+         | {login: (.login // ""), type: .__typename}]' 2>/dev/null) \
   || die "could not fetch requested reviewers for ${REPO}#${PR_NUMBER}"
 
 jq -n \

--- a/ai/skills/wait-for-pr-reviews/scripts/helpers/pending-reviews.jq
+++ b/ai/skills/wait-for-pr-reviews/scripts/helpers/pending-reviews.jq
@@ -34,7 +34,7 @@
 #     timeline: [{event: "labeled"|"review_requested", label, reviewer, created_at}],
 #     reviews: [{login, type, body, submitted_at}],
 #     comments: [{login, type, body, created_at, updated_at}],
-#     requested_users: [{login, type}] }
+#     requested_users: [{login, type}] }   # type: GraphQL __typename
 # Output: { pending: [{reviewer, signal: "label"|"requested_reviewer", since}],
 #           warnings: [<string>] }
 #   since: when the label was applied (label) or the review was requested
@@ -50,6 +50,13 @@ def REVIEWHOG_POSTING_LOGIN: "posthog[bot]";
 def is_copilot_login:
   ascii_downcase
   | . == "copilot" or . == "copilot-pull-request-reviewer" or . == "copilot-pull-request-reviewer[bot]";
+
+# GitHub records Copilot's `review_requested` timeline event under the login
+# "Copilot" while the reviewRequests node carries "copilot-pull-request-reviewer",
+# so dating the request needs an alias-aware match, not string equality.
+def same_reviewer($a; $b):
+  (($a // "") | ascii_downcase) == (($b // "") | ascii_downcase)
+  or (($a // "") | is_copilot_login) and (($b // "") | is_copilot_login);
 
 def is_reviewhog_login: ascii_downcase | test("review-?hog");
 def is_reviewhog_actor:
@@ -77,14 +84,15 @@ def is_reviewhog_actor:
 | (if $label_present and $label_time == null then
      ["reviewhog label present but no labeled timeline event dates it; not treating it as pending"]
    else [] end) as $warnings
-# .type is the REST user-object field; this mirrors copilot.sh's is_bot check,
-# which reads GraphQL's __typename for the same "Bot, or Copilot's odd login" test.
+# .type carries GraphQL's __typename ("Bot"/"User"), matching copilot.sh's is_bot
+# check for the same "Bot, or Copilot's odd login" test.
 | (($in.requested_users // [])
    | map(select(.type == "Bot" or ((.login // "") | is_copilot_login)))
    | map(. as $bot
      | { reviewer: $bot.login,
          signal: "requested_reviewer",
          since: ([ $in.timeline[]?
-                   | select(.event == "review_requested" and .reviewer == $bot.login)
+                   | select(.event == "review_requested"
+                            and same_reviewer(.reviewer; $bot.login))
                    | .created_at ] | max) })) as $requested_pending
 | {pending: ($reviewhog_pending + $requested_pending), warnings: $warnings}

--- a/ai/skills/wait-for-pr-reviews/scripts/helpers/pending-reviews.jq
+++ b/ai/skills/wait-for-pr-reviews/scripts/helpers/pending-reviews.jq
@@ -55,8 +55,8 @@ def is_copilot_login:
 # "Copilot" while the reviewRequests node carries "copilot-pull-request-reviewer",
 # so dating the request needs an alias-aware match, not string equality.
 def same_reviewer($a; $b):
-  (($a // "") | ascii_downcase) == (($b // "") | ascii_downcase)
-  or (($a // "") | is_copilot_login) and (($b // "") | is_copilot_login);
+  ((($a // "") | ascii_downcase) == (($b // "") | ascii_downcase))
+  or ((($a // "") | is_copilot_login) and (($b // "") | is_copilot_login));
 
 def is_reviewhog_login: ascii_downcase | test("review-?hog");
 def is_reviewhog_actor:

--- a/ai/skills/wait-for-pr-reviews/scripts/tests/test-pending-reviews.sh
+++ b/ai/skills/wait-for-pr-reviews/scripts/tests/test-pending-reviews.sh
@@ -257,6 +257,20 @@ assert "requested reviewer with no matching event -> since is null" \
         '{requested_users: [$u]}')" \
     '.pending[0].since' "null"
 
+# GitHub logs Copilot's request under "Copilot" but returns the reviewer node as
+# "copilot-pull-request-reviewer"; the join treats the aliases as one reviewer.
+assert "copilot requested under an alias login -> since equals the timeline event" \
+    "$(jq -n --argjson u "$(jq -c -n '{login: "copilot-pull-request-reviewer", type: "Bot"}')" \
+        --argjson e "$(review_requested_event "Copilot" "${T1}")" \
+        '{requested_users: [$u], timeline: [$e]}')" \
+    '.pending[0].since' "${T1}"
+
+assert "unrelated bot does not borrow another reviewer's request event -> since is null" \
+    "$(jq -n --argjson u "$(jq -c -n '{login: "greptile-apps[bot]", type: "Bot"}')" \
+        --argjson e "$(review_requested_event "Copilot" "${T1}")" \
+        '{requested_users: [$u], timeline: [$e]}')" \
+    '.pending[0].since' "null"
+
 # ── Case-insensitivity ───────────────────────────────────────────────────────
 
 assert "case-insensitive label and event name -> still detected as pending" \


### PR DESCRIPTION
## What

`check-pending-reviews.sh` read requested reviewers from REST `pulls/:n/requested_reviewers`, which only returns `.users`. A GitHub App reviewer like Copilot or Greptile is a Bot node and never appears there, so the check reported nothing pending while the bot was still mid-review. It now queries GraphQL `reviewRequests`, which returns Bot nodes, and uses `__typename` as the `type` the verdict already filters on.

GitHub logs Copilot's `review_requested` timeline event under the login `Copilot` but names the reviewer node `copilot-pull-request-reviewer`. Dating the request needs an alias-aware match, so `same_reviewer` in `pending-reviews.jq` joins the two forms instead of comparing strings.

Team and Mannequin nodes are dropped in the GraphQL jq filter, which keeps the existing behavior of excluding teams: a team request lingers until a human member reviews, which a bot's review never satisfies.

## Test plan

- [x] `ai/skills/wait-for-pr-reviews/scripts/tests/test-pending-reviews.sh` covers the alias join (Copilot requested as `copilot-pull-request-reviewer` dates from the `Copilot` event) and the negative case (an unrelated bot does not borrow another reviewer's request event). 35 passed, 0 failed.
- [ ] Run the script against a live PR with Copilot requested and confirm it reports pending.