### PR TITLE
Detect a pending Copilot review via GraphQL

### DIFF
--- a/ai/skills/wait-for-pr-reviews/scripts/check-pending-reviews.sh
+++ b/ai/skills/wait-for-pr-reviews/scripts/check-pending-reviews.sh
@@ -36,6 +36,8 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DOTFILES_DIR="${DOTFILES_DIR:-$HOME/.dotfiles}"
 source "${DOTFILES_DIR}/bin/lib/logging.sh"
+# shellcheck source=bin/lib/github.sh
+source "${DOTFILES_DIR}/bin/lib/github.sh"
 
 PENDING_JQ="${SCRIPT_DIR}/helpers/pending-reviews.jq"
 
@@ -46,8 +48,6 @@ fi
 
 REPO="$1"
 PR_NUMBER="$2"
-REPO_OWNER="${REPO%%/*}"
-REPO_NAME="${REPO#*/}"
 
 die() {
   log_error "$1"
@@ -93,27 +93,7 @@ comments=$(gh api --paginate --slurp \
               updated_at: (.updated_at // null) } ]') \
   || die "could not fetch comments for ${REPO}#${PR_NUMBER}"
 
-# GraphQL, not REST: `pulls/:n/requested_reviewers` returns only `.users`, and a
-# GitHub App reviewer (Copilot, Greptile) is a Bot node that never appears there,
-# so the REST list reads empty while the bot is mid-review. `__typename` doubles
-# as the `type` the verdict filters on. Team and Mannequin nodes are dropped here,
-# which is what excludes teams: a team request lingers until a human member
-# reviews, which a bot's review never satisfies.
-# shellcheck disable=SC2016  # $owner/$name/$pr are GraphQL variables, not shell
-requested_users=$(gh api graphql \
-  -f query='query($owner: String!, $name: String!, $pr: Int!) {
-      repository(owner: $owner, name: $name) {
-        pullRequest(number: $pr) {
-          reviewRequests(first: 100) {
-            nodes { requestedReviewer { __typename ... on User { login } ... on Bot { login } } }
-          }
-        }
-      }
-    }' \
-  -f owner="${REPO_OWNER}" -f name="${REPO_NAME}" -F pr="${PR_NUMBER}" \
-  --jq '[.data.repository.pullRequest.reviewRequests.nodes[]?.requestedReviewer
-         | select(. != null and (.__typename == "User" or .__typename == "Bot"))
-         | {login: (.login // ""), type: .__typename}]' 2>/dev/null) \
+requested_users=$(get_requested_reviewers "$REPO" "$PR_NUMBER" 2>/dev/null) \
   || die "could not fetch requested reviewers for ${REPO}#${PR_NUMBER}"
 
 jq -n \

--- a/bin/lib/copilot.sh
+++ b/bin/lib/copilot.sh
@@ -162,12 +162,20 @@ get_latest_copilot_review() {
 # still there means a review is in flight.
 #
 # An API failure reads as "not pending" so callers request a review rather than
-# wait on one that may not exist. The reviewer list is captured before it is
-# counted, not piped straight into jq: a piped jq exits 0 on the empty output of
-# a failed fetch, which would report "not pending" as if it were an answer.
+# wait on one that may not exist, but it says so: read silently, a transient 502
+# or rate limit reaches get_copilot_review_for_head as "nothing is pending" and
+# is reported to the user as "Copilot is not enabled for this repo". The warning
+# goes to stderr because that caller prints the review ID to stdout.
+#
+# The reviewer list is captured before it is counted, not piped straight into jq:
+# a piped jq exits 0 on the empty output of a failed fetch, which would report
+# "not pending" as if it were an answer.
 is_copilot_review_pending() {
   local reviewers requested
-  reviewers=$(get_requested_reviewers "$REPO" "$PR_NUMBER" 2>/dev/null) || return 1
+  reviewers=$(get_requested_reviewers "$REPO" "$PR_NUMBER" 2>/dev/null) || {
+    log_warn "Could not check for a pending Copilot review on ${REPO}#${PR_NUMBER}; assuming none" >&2
+    return 1
+  }
 
   requested=$(echo "$reviewers" | jq "[.[] | select(.login | $COPILOT_LOGIN_JQ)] | length")
   [[ "$requested" -gt 0 ]]

--- a/bin/lib/copilot.sh
+++ b/bin/lib/copilot.sh
@@ -161,20 +161,25 @@ get_latest_copilot_review() {
 # GitHub clears the request when the review lands, so a Copilot entry that is
 # still there means a review is in flight.
 #
-# An API failure reads as "not pending" so callers request a review rather than
-# wait on one that may not exist, but it says so: read silently, a transient 502
-# or rate limit reaches get_copilot_review_for_head as "nothing is pending" and
-# is reported to the user as "Copilot is not enabled for this repo". The warning
-# goes to stderr because that caller prints the review ID to stdout.
+# Returns 0 when a review is pending, 1 when none is, and 2 when the reviewer
+# list could not be read. A caller deciding only whether to request a review can
+# treat both non-zero codes alike, but one that would otherwise report "Copilot
+# does not appear to be enabled" must not draw that conclusion from 2: a
+# transient 502 or rate limit would send the user to change repository settings
+# that were already correct.
+#
+# gh's own diagnostic is left on stderr so the warning says which failure it was.
+# The warning goes there too, because get_copilot_review_for_head prints the
+# review ID to stdout.
 #
 # The reviewer list is captured before it is counted, not piped straight into jq:
 # a piped jq exits 0 on the empty output of a failed fetch, which would report
 # "not pending" as if it were an answer.
 is_copilot_review_pending() {
   local reviewers requested
-  reviewers=$(get_requested_reviewers "$REPO" "$PR_NUMBER" 2>/dev/null) || {
-    log_warn "Could not check for a pending Copilot review on ${REPO}#${PR_NUMBER}; assuming none" >&2
-    return 1
+  reviewers=$(get_requested_reviewers "$REPO" "$PR_NUMBER") || {
+    log_warn "Could not check for a pending Copilot review on ${REPO}#${PR_NUMBER}" >&2
+    return 2
   }
 
   requested=$(echo "$reviewers" | jq "[.[] | select(.login | $COPILOT_LOGIN_JQ)] | length")
@@ -232,10 +237,17 @@ get_copilot_review_for_head() {
       fi
     fi
 
-    if [[ "$latest_id" == "0" ]] && ! is_copilot_review_pending; then
-      log_error "Copilot does not appear to be enabled for ${REPO}." >&2
-      log_error "Enable Copilot code review in the repository settings first." >&2
-      return 2
+    # Only a definite "nothing is pending" means Copilot is off for this repo.
+    # The request above just succeeded, so a reviewer list that cannot be read
+    # says nothing about whether Copilot is enabled.
+    if [[ "$latest_id" == "0" ]]; then
+      local pending_rc=0
+      is_copilot_review_pending || pending_rc=$?
+      if [[ "$pending_rc" -eq 1 ]]; then
+        log_error "Copilot does not appear to be enabled for ${REPO}." >&2
+        log_error "Enable Copilot code review in the repository settings first." >&2
+        return 2
+      fi
     fi
   fi
 

--- a/bin/lib/copilot.sh
+++ b/bin/lib/copilot.sh
@@ -154,10 +154,41 @@ get_latest_copilot_review() {
 }
 
 # Check if a Copilot review is already pending (requested but not yet submitted).
+# GitHub clears the request when the review lands, so a Copilot entry that is
+# still there means a review is in flight.
+#
+# GraphQL, not REST: `pulls/:n/requested_reviewers` returns only `.users`, and
+# Copilot is a GitHub App whose reviewer entry is a Bot node that never appears
+# there, so the REST list reads empty for the whole time Copilot is mid-review.
+# Same query as ai/skills/wait-for-pr-reviews/scripts/check-pending-reviews.sh;
+# `__typename` doubles as the reviewer type, and Team entries drop out with it.
+#
+# An API failure reads as "not pending" so callers request a review rather than
+# wait on one that may not exist. The fallback sits outside the command
+# substitution because `gh api` writes HTTP error bodies to stdout: inside, it
+# would append "0" to the error body instead of replacing it.
 is_copilot_review_pending() {
+  local owner="${REPO%%/*}"
+  local repo_name="${REPO##*/}"
   local requested
-  requested=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/requested_reviewers" \
-    --jq "[.users[]? | select(.login | $COPILOT_LOGIN_JQ)] | length" 2>/dev/null || echo "0")
+
+  # shellcheck disable=SC2016  # $owner/$name/$pr are GraphQL variables, not shell
+  requested=$(gh api graphql \
+    -f query='query($owner: String!, $name: String!, $pr: Int!) {
+        repository(owner: $owner, name: $name) {
+          pullRequest(number: $pr) {
+            reviewRequests(first: 100) {
+              nodes { requestedReviewer { __typename ... on User { login } ... on Bot { login } } }
+            }
+          }
+        }
+      }' \
+    -f owner="$owner" -f name="$repo_name" -F pr="${PR_NUMBER}" \
+    --jq '[.data.repository.pullRequest.reviewRequests.nodes[]?.requestedReviewer
+           | select(. != null and (.__typename == "User" or .__typename == "Bot"))
+           | select((.login // "") | '"$COPILOT_LOGIN_JQ"')] | length' 2>/dev/null) \
+    || requested="0"
+
   [[ "$requested" -gt 0 ]]
 }
 

--- a/bin/lib/copilot.sh
+++ b/bin/lib/copilot.sh
@@ -26,6 +26,10 @@
 #   fetch_unresolved_review_comments - Fetch unresolved inline comments from any reviewer
 #   minimize_copilot_reviews  - Collapse previous Copilot review top-level comments
 
+_copilot_lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=bin/lib/github.sh
+source "$_copilot_lib_dir/github.sh"
+
 # The short name "copilot" silently no-ops on the requested_reviewers endpoint.
 # The full bot login is required to actually trigger a review.
 COPILOT_REVIEWER="copilot-pull-request-reviewer[bot]"
@@ -157,38 +161,15 @@ get_latest_copilot_review() {
 # GitHub clears the request when the review lands, so a Copilot entry that is
 # still there means a review is in flight.
 #
-# GraphQL, not REST: `pulls/:n/requested_reviewers` returns only `.users`, and
-# Copilot is a GitHub App whose reviewer entry is a Bot node that never appears
-# there, so the REST list reads empty for the whole time Copilot is mid-review.
-# Same query as ai/skills/wait-for-pr-reviews/scripts/check-pending-reviews.sh;
-# `__typename` doubles as the reviewer type, and Team entries drop out with it.
-#
 # An API failure reads as "not pending" so callers request a review rather than
-# wait on one that may not exist. The fallback sits outside the command
-# substitution because `gh api` writes HTTP error bodies to stdout: inside, it
-# would append "0" to the error body instead of replacing it.
+# wait on one that may not exist. The reviewer list is captured before it is
+# counted, not piped straight into jq: a piped jq exits 0 on the empty output of
+# a failed fetch, which would report "not pending" as if it were an answer.
 is_copilot_review_pending() {
-  local owner="${REPO%%/*}"
-  local repo_name="${REPO##*/}"
-  local requested
+  local reviewers requested
+  reviewers=$(get_requested_reviewers "$REPO" "$PR_NUMBER" 2>/dev/null) || return 1
 
-  # shellcheck disable=SC2016  # $owner/$name/$pr are GraphQL variables, not shell
-  requested=$(gh api graphql \
-    -f query='query($owner: String!, $name: String!, $pr: Int!) {
-        repository(owner: $owner, name: $name) {
-          pullRequest(number: $pr) {
-            reviewRequests(first: 100) {
-              nodes { requestedReviewer { __typename ... on User { login } ... on Bot { login } } }
-            }
-          }
-        }
-      }' \
-    -f owner="$owner" -f name="$repo_name" -F pr="${PR_NUMBER}" \
-    --jq '[.data.repository.pullRequest.reviewRequests.nodes[]?.requestedReviewer
-           | select(. != null and (.__typename == "User" or .__typename == "Bot"))
-           | select((.login // "") | '"$COPILOT_LOGIN_JQ"')] | length' 2>/dev/null) \
-    || requested="0"
-
+  requested=$(echo "$reviewers" | jq "[.[] | select(.login | $COPILOT_LOGIN_JQ)] | length")
   [[ "$requested" -gt 0 ]]
 }
 
@@ -243,7 +224,7 @@ get_copilot_review_for_head() {
       fi
     fi
 
-    if ! is_copilot_review_pending && [[ "$latest_id" == "0" ]]; then
+    if [[ "$latest_id" == "0" ]] && ! is_copilot_review_pending; then
       log_error "Copilot does not appear to be enabled for ${REPO}." >&2
       log_error "Enable Copilot code review in the repository settings first." >&2
       return 2

--- a/bin/lib/github.sh
+++ b/bin/lib/github.sh
@@ -9,6 +9,7 @@
 #   parse_pr_url      - Parse a GitHub PR URL into OWNER, REPO_NAME, REPO, PR_NUMBER
 #   get_current_repo  - Get the current repo as owner/name
 #   resolve_pr_target - Resolve a PR argument (URL, number, or branch) into OWNER, REPO_NAME, REPO, PR_NUMBER
+#   get_requested_reviewers - Requested reviewers on a PR as [{login, type}]
 
 get_github_user() {
   gh api user --jq '.login' 2>/dev/null || {
@@ -75,4 +76,39 @@ resolve_pr_target() {
     log_error "Expected a PR number or URL (https://github.com/owner/repo/pull/123)."
     return 1
   fi
+}
+
+# Requested reviewers on a PR, as [{login, type}] where type is GraphQL's
+# __typename ("User" or "Bot"). GitHub clears a request when that reviewer
+# submits, so anything still listed is mid-review.
+#
+# GraphQL, not REST: `pulls/:n/requested_reviewers` returns only `.users`, and a
+# GitHub App reviewer (Copilot, Greptile) is a Bot node that never appears there,
+# so the REST list reads empty while the app is mid-review. Team and Mannequin
+# nodes drop out here, which is what excludes teams: a team request lingers until
+# a human member reviews, which a bot's review never satisfies.
+#
+# Usage: get_requested_reviewers <owner/repo> <pr_number>
+get_requested_reviewers() {
+  local slug="$1" pr="$2"
+
+  # shellcheck disable=SC2016  # $owner/$name/$pr are GraphQL variables, not shell
+  local query='query($owner: String!, $name: String!, $pr: Int!) {
+      repository(owner: $owner, name: $name) {
+        pullRequest(number: $pr) {
+          reviewRequests(first: 100) {
+            nodes { requestedReviewer { __typename ... on User { login } ... on Bot { login } } }
+          }
+        }
+      }
+    }'
+
+  gh api graphql \
+    -f query="$query" \
+    -f owner="${slug%%/*}" \
+    -f name="${slug##*/}" \
+    -F pr="$pr" \
+    --jq '[.data.repository.pullRequest.reviewRequests.nodes[]?.requestedReviewer
+           | select(. != null and (.__typename == "User" or .__typename == "Bot"))
+           | {login: (.login // ""), type: .__typename}]'
 }

--- a/bin/lib/test-copilot-pending.sh
+++ b/bin/lib/test-copilot-pending.sh
@@ -1,0 +1,181 @@
+#!/bin/bash
+# Tests for is_copilot_review_pending in copilot.sh and the branch it drives in
+# get_copilot_review_for_head, its only caller.
+#
+# The function reads the PR's review requests over GraphQL because REST's
+# requested_reviewers returns only `.users`: Copilot is a GitHub App, its entry
+# is a Bot node, and the REST list reads empty for the whole time Copilot is
+# mid-review. These tests pin the Bot case, the login aliases the match accepts,
+# the entries it must reject, the "not pending" reading of an API failure, and
+# the two outcomes the caller draws from the answer.
+#
+# Usage: test-copilot-pending.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# shellcheck source=bin/lib/test-helpers.sh
+source "$SCRIPT_DIR/test-helpers.sh"
+# shellcheck source=bin/lib/logging.sh
+source "$SCRIPT_DIR/logging.sh"
+# shellcheck source=bin/lib/copilot.sh
+source "$SCRIPT_DIR/copilot.sh"
+
+TESTTMP="$(mktemp -d)"
+trap 'rm -rf "$TESTTMP"' EXIT
+
+# ── Fixture globals the function reads ────────────────────────────────────
+
+REPO="acme/widgets"
+PR_NUMBER=123
+
+# ── gh stub ───────────────────────────────────────────────────────────────
+# Defined after sourcing so it wins. Nothing hits the network: the stub records
+# the call, then answers GH_RESPONSE through the function's own --jq filter with
+# real jq, so the tests exercise the production projection rather than a canned
+# count. GH_STATUS non-zero behaves like a failed `gh api`, which writes the HTTP
+# error body to stdout.
+#
+# The calls go to a file, not a variable: the function captures gh in a command
+# substitution, and that subshell's variables die with it.
+
+GH_CALLS_FILE="$TESTTMP/gh-calls"
+: > "$GH_CALLS_FILE"
+GH_RESPONSE=""
+GH_STATUS=0
+GH_ERROR_BODY='{"message":"Not Found","status":"404"}'
+
+gh() {
+  printf '%s\n' "$*" >> "$GH_CALLS_FILE"
+  if [[ "$GH_STATUS" -ne 0 ]]; then
+    printf '%s\n' "$GH_ERROR_BODY"
+    return "$GH_STATUS"
+  fi
+  local filter=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --jq)
+        filter="$2"
+        shift 2
+        ;;
+      *) shift ;;
+    esac
+  done
+  printf '%s' "$GH_RESPONSE" | jq -r "$filter"
+}
+
+# A reviewRequests response wrapping the given reviewer nodes.
+response_with() {
+  GH_RESPONSE=$(printf \
+    '{"data":{"repository":{"pullRequest":{"reviewRequests":{"nodes":[%s]}}}}}' "$1")
+}
+
+bot() { printf '{"requestedReviewer":{"__typename":"Bot","login":"%s"}}' "$1"; }
+user() { printf '{"requestedReviewer":{"__typename":"User","login":"%s"}}' "$1"; }
+
+gh_asked_graphql() {
+  local calls
+  calls=$(cat "$GH_CALLS_FILE")
+  [[ "$calls" == *graphql* && "$calls" == *reviewRequests* && "$calls" != *requested_reviewers* ]]
+}
+
+gh_passed_pr_coordinates() {
+  local calls
+  calls=$(cat "$GH_CALLS_FILE")
+  [[ "$calls" == *"owner=acme"* && "$calls" == *"name=widgets"* && "$calls" == *"pr=123"* ]]
+}
+
+# ── Test: a requested Copilot Bot node reads as pending ───────────────────
+# The bug this fix closes: REST reported {"users":[],"teams":[]} here.
+
+response_with "$(bot copilot-pull-request-reviewer)"
+assert "requested Copilot bot is pending" is_copilot_review_pending
+assert "asks GraphQL, not the REST requested_reviewers list" gh_asked_graphql
+assert "splits REPO into owner and name and passes the PR number" gh_passed_pr_coordinates
+
+# ── Test: the login aliases GitHub reports Copilot under ──────────────────
+
+response_with "$(bot Copilot)"
+assert "the Copilot alias is pending" is_copilot_review_pending
+
+response_with "$(bot 'copilot-pull-request-reviewer[bot]')"
+assert "the [bot]-suffixed login is pending" is_copilot_review_pending
+
+# ── Test: nothing requested ───────────────────────────────────────────────
+
+response_with ""
+assert_not "no requested reviewers is not pending" is_copilot_review_pending
+
+# ── Test: reviewers that are not Copilot ──────────────────────────────────
+
+response_with "$(user octocat)"
+assert_not "a requested human is not pending" is_copilot_review_pending
+
+response_with "$(user copilot-fan)"
+assert_not "a human handle containing copilot is not pending" is_copilot_review_pending
+
+response_with "$(bot greptile-apps)"
+assert_not "a different review bot is not pending" is_copilot_review_pending
+
+response_with '{"requestedReviewer":{"__typename":"Team","name":"Reviewers","slug":"reviewers"}}'
+assert_not "a requested team is not pending" is_copilot_review_pending
+
+response_with '{"requestedReviewer":null}'
+assert_not "a null reviewer node is not pending" is_copilot_review_pending
+
+# ── Test: Copilot alongside other reviewers ───────────────────────────────
+
+response_with "$(user octocat),$(bot copilot-pull-request-reviewer)"
+assert "Copilot among other reviewers is pending" is_copilot_review_pending
+
+# ── Test: an API failure reads as not pending, quietly ────────────────────
+# gh writes HTTP error bodies to stdout, so the "0" fallback has to replace the
+# captured body rather than be appended to it: the function's `-gt` test errors
+# out loudly on a captured body it cannot read as a number.
+
+stderr_file="$TESTTMP/stderr"
+GH_STATUS=22
+rc=0
+is_copilot_review_pending 2>"$stderr_file" || rc=$?
+assert "an API failure is not pending" test "$rc" -ne 0
+assert "an API failure stays quiet" test ! -s "$stderr_file"
+GH_STATUS=0
+
+# ── Caller: what get_copilot_review_for_head does with the answer ─────────
+# Reading "not pending" while Copilot was mid-review sent it down the request
+# branch, where a PR with no earlier Copilot review then failed the enabled
+# check and returned 2 — so copilot-review-loop.sh gave up on the very first
+# review of every PR. POLL_TIMEOUT=0 skips the polling loop, leaving only the
+# branch under test; a timeout there returns 1.
+
+POLL_TIMEOUT=0
+requested_count=0
+HEAD_SHA="abc1234"
+LATEST_REVIEW='{"id":null,"commit_id":null}'
+
+get_pr_head_sha() { echo "$HEAD_SHA"; }
+get_latest_copilot_review() { echo "$LATEST_REVIEW"; }
+request_copilot_review() {
+  requested_count=$((requested_count + 1))
+  return 0
+}
+
+# Copilot mid-review on a PR it has never reviewed before.
+response_with "$(bot copilot-pull-request-reviewer)"
+rc=0
+get_copilot_review_for_head >/dev/null 2>&1 || rc=$?
+assert "waits for a pending review instead of reporting Copilot disabled" test "$rc" -ne 2
+assert "does not re-request a review that is already pending" test "$requested_count" -eq 0
+
+# Nothing pending after a successful request: Copilot really is off for this repo.
+response_with ""
+requested_count=0
+rc=0
+get_copilot_review_for_head >/dev/null 2>&1 || rc=$?
+assert "requests a review when none is pending" test "$requested_count" -eq 1
+assert "still reports Copilot disabled when the request leaves nothing pending" test "$rc" -eq 2
+
+# ── Results ───────────────────────────────────────────────────────────────
+
+print_results

--- a/bin/lib/test-copilot-pending.sh
+++ b/bin/lib/test-copilot-pending.sh
@@ -106,6 +106,15 @@ assert_not_pending "a null reviewer node is not pending" '{"requestedReviewer":n
 assert_pending "Copilot among other reviewers is pending" \
   "$(user octocat),$(bot copilot-pull-request-reviewer)"
 
+# ── Test: the shape check-pending-reviews.sh feeds pending-reviews.jq ─────
+# Only .login is read here, but the other consumer selects on .type, so nothing
+# else in either suite would notice the projection dropping it.
+
+response_with "$(user octocat),$(bot greptile-apps)"
+assert "projects login and GraphQL __typename as type" \
+  test "$(get_requested_reviewers "$REPO" "$PR_NUMBER" | jq -c .)" \
+  = '[{"login":"octocat","type":"User"},{"login":"greptile-apps","type":"Bot"}]'
+
 # ── Test: an API failure reads as not pending, and says so ────────────────
 # gh writes HTTP error bodies to stdout, so a failed fetch must not be read as
 # an answer: the count runs on the captured list only after the fetch succeeds.
@@ -154,6 +163,20 @@ rc=0
 get_copilot_review_for_head >/dev/null 2>&1 || rc=$?
 assert "requests a review when none is pending" test "$requested_count" -eq 1
 assert "still reports Copilot disabled when the request leaves nothing pending" test "$rc" -eq 2
+
+# A reviewer list that cannot be read is not evidence Copilot is off: the
+# request above succeeded, so only the confirmation failed.
+response_with ""
+GH_STATUS=22
+requested_count=0
+rc=0
+get_copilot_review_for_head >/dev/null 2>"$stderr_file" || rc=$?
+assert "a fetch failure is not reported as Copilot being disabled" test "$rc" -ne 2
+assert "a fetch failure warns why" \
+  grep -q "Could not check for a pending Copilot review" "$stderr_file"
+assert_not "a fetch failure does not advise changing repository settings" \
+  grep -q "does not appear to be enabled" "$stderr_file"
+GH_STATUS=0
 
 # ── Results ───────────────────────────────────────────────────────────────
 

--- a/bin/lib/test-copilot-pending.sh
+++ b/bin/lib/test-copilot-pending.sh
@@ -2,13 +2,6 @@
 # Tests for is_copilot_review_pending in copilot.sh and the branch it drives in
 # get_copilot_review_for_head, its only caller.
 #
-# The function reads the PR's review requests over GraphQL because REST's
-# requested_reviewers returns only `.users`: Copilot is a GitHub App, its entry
-# is a Bot node, and the REST list reads empty for the whole time Copilot is
-# mid-review. These tests pin the Bot case, the login aliases the match accepts,
-# the entries it must reject, the "not pending" reading of an API failure, and
-# the two outcomes the caller draws from the answer.
-#
 # Usage: test-copilot-pending.sh
 
 set -euo pipefail
@@ -44,23 +37,17 @@ GH_CALLS_FILE="$TESTTMP/gh-calls"
 : > "$GH_CALLS_FILE"
 GH_RESPONSE=""
 GH_STATUS=0
-GH_ERROR_BODY='{"message":"Not Found","status":"404"}'
 
 gh() {
   printf '%s\n' "$*" >> "$GH_CALLS_FILE"
   if [[ "$GH_STATUS" -ne 0 ]]; then
-    printf '%s\n' "$GH_ERROR_BODY"
+    printf '%s\n' '{"message":"Not Found","status":"404"}'
     return "$GH_STATUS"
   fi
   local filter=""
   while [[ $# -gt 0 ]]; do
-    case "$1" in
-      --jq)
-        filter="$2"
-        shift 2
-        ;;
-      *) shift ;;
-    esac
+    [[ "$1" == "--jq" ]] && filter="$2"
+    shift
   done
   printf '%s' "$GH_RESPONSE" | jq -r "$filter"
 }
@@ -86,53 +73,42 @@ gh_passed_pr_coordinates() {
   [[ "$calls" == *"owner=acme"* && "$calls" == *"name=widgets"* && "$calls" == *"pr=123"* ]]
 }
 
-# ── Test: a requested Copilot Bot node reads as pending ───────────────────
-# The bug this fix closes: REST reported {"users":[],"teams":[]} here.
+# Assert what is_copilot_review_pending makes of a response holding $2's nodes.
+assert_pending() { response_with "$2"; assert "$1" is_copilot_review_pending; }
+assert_not_pending() { response_with "$2"; assert_not "$1" is_copilot_review_pending; }
 
-response_with "$(bot copilot-pull-request-reviewer)"
-assert "requested Copilot bot is pending" is_copilot_review_pending
+# ── Test: a requested Copilot Bot node reads as pending ───────────────────
+
+assert_pending "requested Copilot bot is pending" "$(bot copilot-pull-request-reviewer)"
 assert "asks GraphQL, not the REST requested_reviewers list" gh_asked_graphql
 assert "splits REPO into owner and name and passes the PR number" gh_passed_pr_coordinates
 
 # ── Test: the login aliases GitHub reports Copilot under ──────────────────
 
-response_with "$(bot Copilot)"
-assert "the Copilot alias is pending" is_copilot_review_pending
-
-response_with "$(bot 'copilot-pull-request-reviewer[bot]')"
-assert "the [bot]-suffixed login is pending" is_copilot_review_pending
+assert_pending "the Copilot alias is pending" "$(bot Copilot)"
+assert_pending "the [bot]-suffixed login is pending" "$(bot 'copilot-pull-request-reviewer[bot]')"
 
 # ── Test: nothing requested ───────────────────────────────────────────────
 
-response_with ""
-assert_not "no requested reviewers is not pending" is_copilot_review_pending
+assert_not_pending "no requested reviewers is not pending" ""
 
 # ── Test: reviewers that are not Copilot ──────────────────────────────────
 
-response_with "$(user octocat)"
-assert_not "a requested human is not pending" is_copilot_review_pending
-
-response_with "$(user copilot-fan)"
-assert_not "a human handle containing copilot is not pending" is_copilot_review_pending
-
-response_with "$(bot greptile-apps)"
-assert_not "a different review bot is not pending" is_copilot_review_pending
-
-response_with '{"requestedReviewer":{"__typename":"Team","name":"Reviewers","slug":"reviewers"}}'
-assert_not "a requested team is not pending" is_copilot_review_pending
-
-response_with '{"requestedReviewer":null}'
-assert_not "a null reviewer node is not pending" is_copilot_review_pending
+assert_not_pending "a requested human is not pending" "$(user octocat)"
+assert_not_pending "a human handle containing copilot is not pending" "$(user copilot-fan)"
+assert_not_pending "a different review bot is not pending" "$(bot greptile-apps)"
+assert_not_pending "a requested team is not pending" \
+  '{"requestedReviewer":{"__typename":"Team","name":"Reviewers","slug":"reviewers"}}'
+assert_not_pending "a null reviewer node is not pending" '{"requestedReviewer":null}'
 
 # ── Test: Copilot alongside other reviewers ───────────────────────────────
 
-response_with "$(user octocat),$(bot copilot-pull-request-reviewer)"
-assert "Copilot among other reviewers is pending" is_copilot_review_pending
+assert_pending "Copilot among other reviewers is pending" \
+  "$(user octocat),$(bot copilot-pull-request-reviewer)"
 
 # ── Test: an API failure reads as not pending, quietly ────────────────────
-# gh writes HTTP error bodies to stdout, so the "0" fallback has to replace the
-# captured body rather than be appended to it: the function's `-gt` test errors
-# out loudly on a captured body it cannot read as a number.
+# gh writes HTTP error bodies to stdout, so a failed fetch must not be read as
+# an answer: the count runs on the captured list only after the fetch succeeds.
 
 stderr_file="$TESTTMP/stderr"
 GH_STATUS=22
@@ -143,23 +119,21 @@ assert "an API failure stays quiet" test ! -s "$stderr_file"
 GH_STATUS=0
 
 # ── Caller: what get_copilot_review_for_head does with the answer ─────────
-# Reading "not pending" while Copilot was mid-review sent it down the request
-# branch, where a PR with no earlier Copilot review then failed the enabled
-# check and returned 2 — so copilot-review-loop.sh gave up on the very first
-# review of every PR. POLL_TIMEOUT=0 skips the polling loop, leaving only the
-# branch under test; a timeout there returns 1.
+# POLL_TIMEOUT=0 skips the polling loop, leaving only the branch under test; a
+# timeout there returns 1.
 
 POLL_TIMEOUT=0
 requested_count=0
-HEAD_SHA="abc1234"
-LATEST_REVIEW='{"id":null,"commit_id":null}'
 
-get_pr_head_sha() { echo "$HEAD_SHA"; }
-get_latest_copilot_review() { echo "$LATEST_REVIEW"; }
+get_pr_head_sha() { echo "abc1234"; }
+get_latest_copilot_review() { echo '{"id":null,"commit_id":null}'; }
 request_copilot_review() {
   requested_count=$((requested_count + 1))
   return 0
 }
+
+# These three stubs are never restored, so anything added below runs against
+# them. Keep this the last section in the file.
 
 # Copilot mid-review on a PR it has never reviewed before.
 response_with "$(bot copilot-pull-request-reviewer)"

--- a/bin/lib/test-copilot-pending.sh
+++ b/bin/lib/test-copilot-pending.sh
@@ -106,16 +106,21 @@ assert_not_pending "a null reviewer node is not pending" '{"requestedReviewer":n
 assert_pending "Copilot among other reviewers is pending" \
   "$(user octocat),$(bot copilot-pull-request-reviewer)"
 
-# ── Test: an API failure reads as not pending, quietly ────────────────────
+# ── Test: an API failure reads as not pending, and says so ────────────────
 # gh writes HTTP error bodies to stdout, so a failed fetch must not be read as
 # an answer: the count runs on the captured list only after the fetch succeeds.
+# The warning belongs on stderr, since get_copilot_review_for_head returns the
+# review ID on stdout.
 
+stdout_file="$TESTTMP/stdout"
 stderr_file="$TESTTMP/stderr"
 GH_STATUS=22
 rc=0
-is_copilot_review_pending 2>"$stderr_file" || rc=$?
+is_copilot_review_pending >"$stdout_file" 2>"$stderr_file" || rc=$?
 assert "an API failure is not pending" test "$rc" -ne 0
-assert "an API failure stays quiet" test ! -s "$stderr_file"
+assert "an API failure warns why" \
+  grep -q "Could not check for a pending Copilot review" "$stderr_file"
+assert "the warning stays off stdout" test ! -s "$stdout_file"
 GH_STATUS=0
 
 # ── Caller: what get_copilot_review_for_head does with the answer ─────────


### PR DESCRIPTION
`is_copilot_review_pending` read `repos/:owner/:repo/pulls/:n/requested_reviewers` and counted `.users[]`. Copilot is a GitHub App, so it comes back as a Bot node and never appears in `.users`. The function returned false the entire time a Copilot review was in flight.

Verified live on haacked/review-code#137: REST returned `{"users":[],"teams":[]}` at the same moment GraphQL `reviewRequests` returned `{__typename: "Bot", login: "copilot-pull-request-reviewer"}`.

The fix is the same GraphQL query and `__typename` projection already used in `ai/skills/wait-for-pr-reviews/scripts/check-pending-reviews.sh`, so the two spellings match.

## The callers were the reason this waited

`get_copilot_review_for_head` has two call sites. The first now skips a redundant re-request and polls instead, which is the change you would expect.

The second was actually broken. `if ! is_copilot_review_pending && [[ "$latest_id" == "0" ]]` collapsed to just the `latest_id` test while the function was stuck false, so on any PR where Copilot had never reviewed, the function returned 2 ("Copilot does not appear to be enabled") immediately after successfully requesting a review. `bin/copilot-review-loop.sh` treats any non-zero as "proceeding without a fresh Copilot review", so the loop has been skipping Copilot's first review on every new PR.

## Failure reads are no longer confused with empty ones

A failed fetch and an empty reviewer list both returned 1, and the caller reads 1 as "Copilot is not enabled for this repo". A transient 502 or rate limit sent you to change repository settings that were already correct. A failed read now returns 2, and only a definite 1 produces that message.

The reviewer list is captured before it is counted rather than piped into jq, since a piped jq exits 0 on the empty output of a failed fetch and would report "not pending" as though it were an answer.

## Test plan

- [x] `bin/lib/test-copilot-pending.sh`, 23 assertions, all passing
- [x] Red/green checked: against the pre-fix `copilot.sh` the suite fails 9 of its cases, including both caller assertions
- [x] Sibling suites that source `copilot.sh` still pass: `test-copilot-filter` 8/8, `test-unresolved-comments` 17/17, `test-dismissed-state` 53/53, `test-dismissed-replies` 28/28
- [x] `shellcheck -x` clean on the new test; `copilot.sh` unchanged at its 3 pre-existing SC2016 infos

`gh` is stubbed as a shell function defined after sourcing, following `test-dismissed-replies.sh`. Calls are recorded to a file rather than a variable, because the production call runs inside a command substitution whose subshell variables die with it. The stub extracts the `--jq` argument and applies it to the fixture with real jq, so the tests exercise the production projection instead of a canned count.

## One behavior change worth knowing

A lingering stuck Copilot request now polls to timeout (600s default) rather than re-POSTing. Low impact, since POSTing an already-requested reviewer is a no-op and the old path timed out too.

https://claude.ai/code/session_01SAv3sg4k4vZeupnhbvLaHi