### PR TITLE
Add shared plain-writing skill

### DIFF
--- a/ai/AGENTS.md
+++ b/ai/AGENTS.md
@@ -19,7 +19,7 @@ A skill's own scripts and references are written relative to the skill's directo
 
 ### Implementation Flow
 
-If arriving from an approved Plan Mode plan, invoke the `go` skill with `--plan-file <path>` instead of the manual steps below — it runs plan-reuse, implementation, simplify, commit, PR, and both review loops automatically.
+If arriving from an approved Plan Mode plan, invoke the `go` skill with `--plan-file <path>` instead of the manual steps below. It runs plan-reuse, implementation, simplify, commit, PR, and both review loops automatically.
 
 1. Study existing patterns in the codebase
 2. `unit-test-writer` writes tests first (red)
@@ -55,7 +55,7 @@ When a plan is implemented/merged, move it to `plans/archive/` within the same r
 
 ## GitHub Operations
 
-Write as the user in all public-facing content — don't refer to yourself as an AI, and don't volunteer AI/LLM attribution, co-authorship notes, or agent-context sections in PRs, commits, or other public-facing content. Two exceptions win over that default: when a repo's PR template asks about agent involvement (e.g. an "Agent context" section), follow the template and fill it honestly as the agent; and attribution the coding tool itself mandates (e.g. PostHog Code's commit trailers and PR footer) is fine to add and keep.
+Write as the user in all public-facing content. Don't refer to yourself as an AI, and don't volunteer AI/LLM attribution, co-authorship notes, or agent-context sections in PRs, commits, or other public-facing content. Two exceptions win over that default: when a repo's PR template asks about agent involvement (e.g. an "Agent context" section), follow the template and fill it honestly as the agent; and attribution the coding tool itself mandates (e.g. PostHog Code's commit trailers and PR footer) is fine to add and keep.
 
 **Always use `gh` CLI** for GitHub operations. Never use GitHub MCP server tools.
 
@@ -65,8 +65,8 @@ Write as the user in all public-facing content — don't refer to yourself as an
 
 ### posthog/posthog
 
-- **Never use `posthog-db` to investigate production issues.** It does not have prod data — for prod investigations, use the `metabase-prod-query` skill.
-- **Never use socket IP addresses in PostHog services.** They're the load balancer's IP — use `X-Forwarded-For` (primary), `X-Real-IP` (fallback), or `Forwarded` (RFC 7239).
+- **Never use `posthog-db` to investigate production issues.** It does not have prod data, so for prod investigations use the `metabase-prod-query` skill.
+- **Never use socket IP addresses in PostHog services.** They're the load balancer's IP, so use `X-Forwarded-For` (primary), `X-Real-IP` (fallback), or `Forwarded` (RFC 7239).
 
 See the `posthog-context` skill for repo-specific workflow, full database access rules, production architecture notes, and the SDK repository table.
 
@@ -100,7 +100,18 @@ See the `posthog-context` skill for repo-specific workflow, full database access
 
 - Use actual ellipsis (…) instead of three dots (...) in user-facing messages.
 - Comments: concise prose with proper grammar. Comment only on what isn't obvious to a skilled reader.
-- Describe final state, not the journey. Comments, commit messages, and PR descriptions say what the code does now — not what it replaced. Write "Uses a LEFT JOIN to fetch users with their orders", not "Combined two queries into one LEFT JOIN".
+- Describe final state, not the journey. Comments, commit messages, and PR descriptions say what the code does now, not what it replaced. Write "Uses a LEFT JOIN to fetch users with their orders", not "Combined two queries into one LEFT JOIN".
+
+## Communication
+
+These rules govern every response, chat replies included. The `plain-writing` skill owns the full rule set; what follows is only what must hold when no skill runs.
+
+- Lead with the answer, result, or decision.
+- Describe concrete behavior instead of inventing labels, metaphors, or jargon.
+- Never use an em dash or an en dash. Use a comma, colon, semicolon, parenthesis, or a second sentence.
+- Start concise. Add detail only when it affects a decision or prevents a mistake.
+
+Before writing a PR description, review comment, report, design doc, or a message sent on my behalf, apply `plain-writing`. Skip it for commit messages, code comments, and chat replies, and skip it when the active skill already applies `plain-writing` itself, as `create-pr` does.
 
 ## Test Instructions
 

--- a/ai/README.md
+++ b/ai/README.md
@@ -43,4 +43,6 @@ Run the installer and portability tests with:
 ```sh
 ai/tests/test-ai-installers.sh
 ai/tests/test-canonical-skills.sh
+ai/tests/test-plain-writing-contract.sh
+python3 ai/skills/plain-writing/scripts/tests/test_plain_writing_lint.py
 ```

--- a/ai/skills/address-pr-reviews/SKILL.md
+++ b/ai/skills/address-pr-reviews/SKILL.md
@@ -99,6 +99,8 @@ Present your assessment for each comment with:
 
 After evaluating all comments, present a summary table and ask the user for confirmation before proceeding.
 
+Before presenting the assessments and summary table, apply the `plain-writing` skill in technical mode to them. Keep every quoted comment and every verdict exactly as written. Apply the same rules to each reply you draft in Steps 4 and 5, before you show it.
+
 ### Step 4: Act on Comments
 
 With user confirmation:

--- a/ai/skills/create-pr/SKILL.md
+++ b/ai/skills/create-pr/SKILL.md
@@ -13,15 +13,18 @@ Create (or update) a GitHub pull request using `gh`, auto-detecting and filling 
 
 ## Writing voice
 
-Write the PR body the way a staff engineer writes a Slack message to a colleague who reviews the code. One direct sentence per idea. No ceremony.
+Apply the `plain-writing` skill in technical mode to the PR body, then apply these PR-specific rules on top. Write the way a staff engineer messages a colleague who reviews the code: one direct sentence per idea, no ceremony.
 
-Three things immediately signal AI authorship. Never produce any of them:
+Never produce any of these. Each one immediately signals AI authorship:
 
 - Em dashes (—) or en dashes (–). Use a comma, colon, semicolon, parenthesis, or split into two sentences. No exceptions.
 - Bold inside prose sentences. Bold is for labels at the start of a line only (e.g., `**Test plan:**`). Never bold error messages, key terms, or warnings mid-paragraph.
 - Bolded pseudo-labels like `**Root cause:**`, `**Caveat:**`, `**Note:**`. Make it a real heading or fold the content into a sentence without a label.
+- Hedging meta-commentary such as "I'm an agent" or "I have not verified this". State what you did and what you found.
+- Inflation words: critical, pivotal, robust, seamless, leverage, utilize, ensure, facilitate.
+- Title Case headings, emoji, or a closing summary paragraph. Use Sentence case and stop when the point is made.
 
-For everything else: plain verbs ("is" not "serves as"), Sentence case headings, short paragraphs. No inflation words (critical, pivotal, robust, seamless, leverage, utilize, ensure, facilitate). No hedging meta-commentary ("I'm an agent", "I have not verified"). No closers. No emoji. Two exceptions: a template-requested agent-context section speaks as the agent (see Step 5), and a footer or trailer the coding tool mandates stays as given.
+Two exceptions: a template-requested agent-context section speaks as the agent (see Step 5), and a footer or trailer the coding tool mandates stays as given.
 
 How it sounds (cause and effect in one sentence, caveats as plain declarative sentences with no label):
 
@@ -162,9 +165,9 @@ Notes:
 - Keep the blank lines around `<details>` and `</details>` so GitHub renders the collapsible block correctly
 - If the testing section already contains template guidance text (e.g., placeholders), replace that text with the `<details>` block rather than stacking them
 
-### 6. Verify voice before preview
+### 6. Edit the prose before preview
 
-Re-read the composed body against the Writing voice rules and rewrite any violating sentence. Then ask yourself: would a staff engineer write this sentence verbatim in a Slack message to a teammate? If not, simplify it. The agent-context section and any tool-mandated footer are exempt from the staff-engineer test.
+Apply the `plain-writing` skill in technical mode to the composed body. Keep the template structure, its checkboxes, and any tool-mandated footer exactly as given, and leave the agent-context section in the first-person agent voice Step 5 requires. Then enforce the PR-specific rules in the Writing voice section, and ask of each sentence: would a staff engineer send this verbatim in a Slack message to the reviewer? If not, simplify it. The agent-context section and the footer are exempt from that test. Show only the finished body in the preview.
 
 ### 7. Show Preview and Confirm
 

--- a/ai/skills/plain-writing/SKILL.md
+++ b/ai/skills/plain-writing/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: plain-writing
+description: Write, rewrite, or review prose for other people in clear, direct English. Use for PR descriptions, review comments, plans, reports, documentation, and messages. Do not use for code, structured data, or text that must remain verbatim.
+argument-hint: "[technical|strict|voice-match|review] [text or file]"
+---
+
+# Plain Writing
+
+Make the text easy for its intended reader to understand on the first pass.
+
+## Modes
+
+- `technical` is the default mode, used whenever no mode word is given. Use it for PRs, reviews, plans, reports, documentation, and work messages.
+- `strict` is for procedures, warnings, and error messages. Read [references/strict.md](references/strict.md) before writing.
+- `voice-match` is for personal writing when the user supplies a writing sample. Read [references/voice-match.md](references/voice-match.md) before writing.
+- `review` identifies unclear passages without rewriting them. For each one, quote the passage, say what makes it hard to read, and give the smallest useful change. That list of findings is the entire output for `review` mode.
+
+When a mode's reference file conflicts with a rule below, follow the reference file.
+
+## Reading the Arguments
+
+- If the first word of the argument is `technical`, `strict`, `voice-match`, or `review`, treat it as the mode and treat the rest as the source. Otherwise treat the whole argument as the source and use `technical`.
+- If the source names a file that exists, edit that file in place.
+- If the source is not a file path, treat it as literal text and return the edited text without writing to disk.
+- If nothing remains after the mode word, or the argument is empty, edit the most recent draft prose in this conversation. That means the text you or a calling skill just produced. Ask which text to edit only when no such draft exists.
+
+## Preserve the Source
+
+- Preserve every fact, number, condition, qualifier, citation, link, identifier, error string, and technical term that carries exact meaning.
+- Keep code blocks, inline code, commands, quotations, templates, checkboxes, headings, and required labels unchanged unless the user asks to edit them.
+- Do not add facts, examples, opinions, certainty, humor, personality, or conclusions that are not in the source.
+- Keep uncertainty when the source is uncertain. Clear writing must not become a stronger claim.
+- Keep the requested format and approximate level of detail. Cut repetition, not substance.
+
+## Write Clearly
+
+- Lead with the answer, result, decision, or concrete consequence.
+- Use common words and direct verbs. Keep established technical terms when they are more precise than a simpler substitute.
+- Put one idea in each sentence. Split sentences that make the reader hold the cause, mechanism, consequence, and exception at once.
+- Describe what happens instead of naming an abstract category. Do not invent labels, metaphors, or shorthand that the reader must decode.
+- Prefer active voice when naming the actor helps. Keep passive voice when the actor is unknown or irrelevant.
+- Keep paragraphs focused and short. Use headings and lists only when they make the text easier to scan.
+- Remove signposting, filler, hype, vague attribution, repeated summaries, generic conclusions, and chatbot closers.
+- Do not use an em dash or an en dash, in any mode including voice-match. Restructure the sentence with other punctuation or separate sentences.
+- Allow natural contractions in technical mode. Do not force all sentences to the same length or rhythm.
+- Explain uncommon jargon once. Do not explain terms the intended reader already knows.
+
+## Finish
+
+Before you return your answer, silently reread the result as its intended reader and fix whatever fails these checks. Never print the checklist, your answers to it, or any other self-assessment.
+
+1. Is the main point in the first sentence or first useful line?
+2. Is the requested action clear?
+3. Does each sentence make sense without a second pass?
+4. Did every fact and technical token survive?
+5. Can any sentence lose words without losing meaning or tone?
+
+Before you return the text, check it with `python3 scripts/plain-writing-lint.py`, resolving `scripts/` against this skill's own directory. Pipe the text on stdin, or pass a file path when you edited a file. In strict mode, add `--strict` first. Treat the output as warnings, not a quality score. Fix real problems and ignore false positives.
+
+In every mode except `review`, return only the final text, with no audit, intermediate draft, change summary, preamble, or closing offer, unless the user explicitly asks to see the changes. In `review` mode, return only the findings described above and no rewritten text.

--- a/ai/skills/plain-writing/references/strict.md
+++ b/ai/skills/plain-writing/references/strict.md
@@ -1,0 +1,15 @@
+# Strict Technical Writing
+
+Use this mode for procedures, warnings, and error messages where speed and certainty matter more than voice. It borrows selected rules from ASD-STE100 Simplified Technical English without claiming certified compliance. The selection was informed by [Ege Çelebi's STE writing kit](https://github.com/woosal1337/blog/tree/main/videos/ep01-the-cure-for-ai-slop).
+
+- Use commands for instructions: "Restart the worker," not "The worker should be restarted."
+- Put a condition before its command: "If the test fails, read the log."
+- Give one instruction per sentence. Aim for at most 20 words in instructions and 25 words in descriptions, but never remove a fact to meet a limit. The linter cannot distinguish instructions from descriptions, so strict mode warns at 20 words for both.
+- Use simple present, simple past, simple future, infinitives, and imperatives. Avoid stacked auxiliary verbs.
+- Use active voice when the actor is known.
+- Do not use contractions or semicolons.
+- Define an abbreviation the first time it appears.
+- Use numbered steps for a sequence. Start each step with the action.
+- Use `WARNING` for risk of injury, `CAUTION` for risk of damage, and `NOTE` for information. A note must not contain an instruction.
+
+The official standard is copyrighted. See <https://asd-ste100.org/> for the current standard and its terms.

--- a/ai/skills/plain-writing/references/voice-match.md
+++ b/ai/skills/plain-writing/references/voice-match.md
@@ -1,0 +1,18 @@
+# Voice Matching
+
+Use a sample written by the user as the source of voice. Do not imitate a third party unless the user has permission and the request allows it.
+
+Notice the sample's ordinary choices:
+
+- Sentence length and rhythm
+- Common words and recurring phrases
+- Paragraph length
+- Punctuation
+- Use of first person, humor, and asides
+- How directly it opens and closes
+
+Match those choices without copying distinctive phrases. Preserve the source text's facts and degree of certainty. Do not manufacture opinions, stories, jokes, verbal tics, or intentional mistakes to make the result appear human.
+
+Do not restore em dashes or en dashes even when the sample uses them. Use the sample's other habits in their place: commas, semicolons, parentheses, or separate sentences.
+
+Clarity still wins. If a habit from the sample would make technical prose harder to understand, keep the user's tone but use the clearer construction.

--- a/ai/skills/plain-writing/scripts/plain-writing-lint.py
+++ b/ai/skills/plain-writing/scripts/plain-writing-lint.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+"""Report mechanical plain-writing warnings without scoring the prose."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Iterable, TypedDict
+
+RAW_PATTERNS: dict[str, tuple[str, ...]] = {
+    "filler": (
+        r"\blet(?:'|’)s (?:dive in|dive into|explore|break this down)\b",
+        r"\bhere(?:'|’)s what you need to know\b",
+        r"\bit is (?:important|worth) to note\b",
+        r"\bin order to\b",
+        r"\bdue to the fact that\b",
+        r"\bat this point in time\b",
+        r"\bin the event that\b",
+        r"\bi hope this helps\b",
+        r"\blet me know\b",
+    ),
+    "hype": (
+        r"\b(?:robust|seamless|powerful|pivotal|groundbreaking|revolutionary)\b",
+        r"\b(?:world-class|cutting-edge|effortless|game-changing|best-in-class)\b",
+        r"\bcomprehensive\b",
+    ),
+    "jargon": (
+        r"\b(?:leverage|leverages|leveraged|leveraging)\b",
+        r"\b(?:utilize|utilizes|utilized|utilizing|utilization)\b",
+        r"\b(?:facilitate|facilitates|facilitated|facilitating)\b",
+        r"\b(?:navigate|navigates|navigated|navigating)\b",
+    ),
+}
+
+# Compiled once at import so the per-line loop below only dispatches matches, the same
+# way every other regex in this module is handled.
+PATTERNS: dict[str, tuple[re.Pattern[str], ...]] = {
+    category: tuple(re.compile(pattern, re.I) for pattern in patterns)
+    for category, patterns in RAW_PATTERNS.items()
+}
+
+CONTRACTION = re.compile(
+    r"\b(?:[A-Za-z]+n['’]t|(?:i|you|we|they|he|she|it|that|there|what|who|let)['’](?:re|ve|ll|d|m|s))\b",
+    re.I,
+)
+INLINE_CODE = re.compile(r"`[^`]*`")
+URL = re.compile(r"https?://[^\s)>]+")
+WORD = re.compile(r"[A-Za-z0-9][A-Za-z0-9'’/-]*")
+FENCE = re.compile(r"^ {0,3}(`{3,}|~{3,})")
+SENTENCE_SPLIT = re.compile(r"(?<=[.!?])\s+")
+FRONTMATTER_DELIMITER = "---"
+
+
+class LintWarning(TypedDict):
+    line: int
+    category: str
+    message: str
+    text: str
+
+
+def prose_lines(text: str) -> Iterable[tuple[int, str, str]]:
+    """Yield Markdown prose with code masked and original line numbers intact."""
+    lines = text.splitlines()
+    start = 0
+    # YAML frontmatter is metadata, not prose; linting it flags a skill's own
+    # description field. Only a delimiter on the first line opens a frontmatter block,
+    # so a horizontal rule later in the document still lints normally.
+    if lines and lines[0].strip() == FRONTMATTER_DELIMITER:
+        for index, line in enumerate(lines[1:], start=1):
+            if line.strip() == FRONTMATTER_DELIMITER:
+                start = index + 1
+                break
+
+    fence = ""
+    for line_number, line in enumerate(lines[start:], start=start + 1):
+        marker = FENCE.match(line)
+        token = marker.group(1) if marker else ""
+        if fence:
+            # A closing fence repeats the opening character at least as many times and
+            # carries nothing after it.
+            if (
+                marker
+                and token.startswith(fence)
+                and not line[marker.end() :].strip()
+            ):
+                fence = ""
+            continue
+        if token:
+            fence = token
+            continue
+        yield line_number, line, URL.sub("", INLINE_CODE.sub("", line))
+
+
+def warning(line: int, category: str, message: str, text: str) -> LintWarning:
+    return {
+        "line": line,
+        "category": category,
+        "message": message,
+        "text": text.strip(),
+    }
+
+
+def lint(text: str, strict: bool = False) -> list[LintWarning]:
+    warnings: list[LintWarning] = []
+    sentence_limit = 20 if strict else 30
+
+    for line_number, original, prose in prose_lines(text):
+        stripped = prose.strip()
+        if not stripped:
+            continue
+
+        for category, patterns in PATTERNS.items():
+            if any(pattern.search(prose) for pattern in patterns):
+                warnings.append(
+                    warning(
+                        line_number,
+                        category,
+                        f"Possible {category}; use concrete, direct wording.",
+                        original,
+                    )
+                )
+
+        if "—" in prose or "–" in prose:
+            warnings.append(
+                warning(
+                    line_number,
+                    "em_dash",
+                    "Restructure the sentence without an em dash or en dash.",
+                    original,
+                )
+            )
+
+        for sentence in SENTENCE_SPLIT.split(stripped):
+            word_count = len(WORD.findall(sentence))
+            if word_count > sentence_limit:
+                warnings.append(
+                    warning(
+                        line_number,
+                        "long_sentence",
+                        (
+                            f"Sentence has {word_count} words; check whether it needs "
+                            "two sentences."
+                        ),
+                        sentence,
+                    )
+                )
+
+        if strict and ";" in prose:
+            warnings.append(
+                warning(
+                    line_number,
+                    "semicolon",
+                    "Strict mode uses separate sentences instead of semicolons.",
+                    original,
+                )
+            )
+        if strict and CONTRACTION.search(prose):
+            warnings.append(
+                warning(
+                    line_number,
+                    "contraction",
+                    "Strict mode does not use contractions.",
+                    original,
+                )
+            )
+
+    return warnings
+
+
+def render_text(path: str, warnings: list[LintWarning]) -> str:
+    if not warnings:
+        return f"{path}: no mechanical warnings"
+    return "\n".join(
+        f"{path}:{item['line']}: {item['category']}: {item['message']}"
+        for item in warnings
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "files", nargs="*", help="Markdown or text files; read stdin when omitted"
+    )
+    parser.add_argument(
+        "--strict", action="store_true", help="Apply procedure and error-message checks"
+    )
+    parser.add_argument("--json", action="store_true", help="Print JSON results")
+    parser.add_argument(
+        "--fail-on-warnings",
+        action="store_true",
+        help="Exit 1 when warnings exist; warnings do not fail by default",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    inputs = args.files or ["-"]
+    results: list[tuple[str, list[LintWarning]]] = []
+
+    for name in inputs:
+        text = (
+            sys.stdin.read() if name == "-" else Path(name).read_text(encoding="utf-8")
+        )
+        results.append((name, lint(text, strict=args.strict)))
+
+    if args.json:
+        payload = [
+            {"file": name, "strict": args.strict, "warnings": warnings}
+            for name, warnings in results
+        ]
+        print(json.dumps(payload[0] if len(payload) == 1 else payload, indent=2))
+    else:
+        for name, warnings in results:
+            print(render_text(name, warnings))
+
+    has_warnings = any(warnings for _, warnings in results)
+    return 1 if args.fail_on_warnings and has_warnings else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ai/skills/plain-writing/scripts/tests/test_plain_writing_lint.py
+++ b/ai/skills/plain-writing/scripts/tests/test_plain_writing_lint.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""Behavior tests for plain-writing-lint.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[1] / "plain-writing-lint.py"
+
+
+def load_linter():
+    spec = importlib.util.spec_from_file_location("plain_writing_lint", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+lint = load_linter().lint
+
+
+def categories(warnings: list[dict[str, object]]) -> set[str]:
+    return {warning["category"] for warning in warnings}
+
+
+class PlainWritingLintTests(unittest.TestCase):
+    def test_flags_filler_hype_and_dense_sentences(self) -> None:
+        text = (
+            "Let's dive into this robust and seamless workflow, which provides a "
+            "comprehensive foundation that enables teams to leverage the platform "
+            "while navigating a rapidly evolving technical landscape without any "
+            "additional setup or operational changes."
+        )
+
+        result = lint(text)
+
+        self.assertTrue(
+            {"filler", "hype", "jargon", "long_sentence"} <= categories(result)
+        )
+
+    def test_ignores_fenced_and_inline_code(self) -> None:
+        text = """Use `leverage()` when the API requires it.
+
+```python
+def leverage_robust_platform():
+    return "seamless"
+```
+"""
+
+        result = lint(text)
+
+        self.assertEqual(result, [])
+
+    def test_ignores_nested_and_tilde_fences(self) -> None:
+        text = """````markdown
+```text
+robust
+```
+````
+
+~~~python
+leverage = True
+~~~
+"""
+
+        self.assertEqual(lint(text), [])
+
+    def test_ignores_words_inside_urls(self) -> None:
+        result = lint("Read https://example.com/robust-leverage-guide.")
+
+        self.assertEqual(result, [])
+
+    def test_preserves_line_numbers_after_fenced_code(self) -> None:
+        text = """Clear opening.
+
+```text
+robust
+```
+
+This seamless process works.
+"""
+
+        warnings = lint(text)
+
+        self.assertEqual(len(warnings), 1)
+        self.assertEqual(warnings[0]["line"], 7)
+        self.assertEqual(warnings[0]["category"], "hype")
+
+    def test_strict_mode_adds_contractions_and_semicolons(self) -> None:
+        normal = lint("Don't stop; retry the request.")
+        strict = lint("Don't stop; retry the request.", strict=True)
+
+        self.assertEqual(normal, [])
+        self.assertEqual(categories(strict), {"contraction", "semicolon"})
+
+    def test_strict_mode_does_not_treat_possessives_as_contractions(self) -> None:
+        result = lint("Restart the server's worker.", strict=True)
+
+        self.assertEqual(result, [])
+
+    def test_em_dash_is_always_flagged(self) -> None:
+        result = lint("The request succeeds — the cache remains stale.")
+
+        self.assertEqual(categories(result), {"em_dash"})
+
+    def test_cli_warns_without_failing_unless_requested(self) -> None:
+        command = [sys.executable, str(SCRIPT), "--json"]
+        warning_only = subprocess.run(
+            command,
+            input="This robust process works.",
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        fail_on_warnings = subprocess.run(
+            [*command, "--fail-on-warnings"],
+            input="This robust process works.",
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+        self.assertEqual(warning_only.returncode, 0)
+        self.assertEqual(fail_on_warnings.returncode, 1)
+        self.assertEqual(json.loads(warning_only.stdout)["warnings"][0]["line"], 1)
+
+    def test_cli_reads_file_and_renders_default_output(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "draft.md"
+            path.write_text("This robust process works.", encoding="utf-8")
+            completed = subprocess.run(
+                [sys.executable, str(SCRIPT), str(path)],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+
+        self.assertEqual(completed.returncode, 0)
+        self.assertEqual(
+            completed.stdout,
+            f"{path}:1: hype: Possible hype; use concrete, direct wording.\n",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ai/skills/quarterly-planning/SKILL.md
+++ b/ai/skills/quarterly-planning/SKILL.md
@@ -167,6 +167,8 @@ Synthesize the supporting documents, themes, reflection, and HOGS into **2-4 obj
 
 **Account for the infrastructure theme explicitly.** Before finalizing, confirm the Step 2b / Step 4 infrastructure work is either inside an objective or consciously deferred — never silently dropped. Infra that underpins a feature objective (e.g. a read-store or cache migration enabling real-time evaluation) belongs in that objective's "What we'll ship" with its own owner, so it's resourced rather than assumed. If you defer infra, say so in the leftover-themes note.
 
+Before formatting the draft, apply the `plain-writing` skill in technical mode to the objective statements, rationale, deliverables, and success metrics. Keep the required goal format and every scope qualifier intact. Apply the same rules to the leftover-themes note when you write it.
+
 Output the draft as raw markdown inside a code block so the user can copy it into a posthog.com goals PR:
 
 ````markdown

--- a/ai/skills/sprint-planning/SKILL.md
+++ b/ai/skills/sprint-planning/SKILL.md
@@ -5,7 +5,7 @@ model: sonnet
 metadata:
   execution-tier: balanced
 color: pink
-allowed-tools: Bash, Read, Grep, Glob
+allowed-tools: Bash, Read, Grep, Glob, Skill
 argument-hint: [archive|--status [--last] [slack]|--approved]
 ---
 
@@ -215,6 +215,8 @@ Wait for the user's response.
 ### Step 10: Generate the Update
 
 Compose the final sprint update using all gathered and confirmed data. Write a short narrative summary paragraph for the retro that captures the team's key themes and accomplishments.
+
+Before formatting the update, apply the `plain-writing` skill in technical mode to the narrative summary and the work-item descriptions you wrote. Keep issue and PR titles exactly as fetched. Leave the quarter-goal lines as carried forward from Step 3; they are not part of this pass.
 
 **IMPORTANT**: Output the update as raw markdown inside a code block so the user can copy/paste it directly into GitHub.
 

--- a/ai/skills/sprint-planning/scripts/test_board_scripts.py
+++ b/ai/skills/sprint-planning/scripts/test_board_scripts.py
@@ -33,7 +33,7 @@ def gh(tmp_path):
     bin_dir.mkdir()
     stub = bin_dir / "gh"
     # Copied rather than symlinked, so the stub still resolves when this
-    # directory is deployed read-only into ~/.claude/skills/ or ~/.agents/skills/.
+    # directory is deployed read-only into the harness skills directory.
     stub.write_text(GH_STUB.read_text())
     stub.chmod(0o755)
     log = tmp_path / "gh-calls.log"

--- a/ai/skills/standup/SKILL.md
+++ b/ai/skills/standup/SKILL.md
@@ -168,6 +168,8 @@ Build standup content and produce two outputs: a plain text archive file and HTM
 
 #### Render Both Outputs
 
+Before rendering, apply the `plain-writing` skill in technical mode to the descriptions you wrote. Keep PR titles, section names, status labels, and attribution exactly as generated. Keep the Discussion line exactly as chosen.
+
 Read `templates/standup-output.md` and render the content into both skeletons: the plain text version written to `new_file_path` for archival, and the HTML version copied to the clipboard with the shared helper script:
 
 ```bash

--- a/ai/tests/test-plain-writing-contract.sh
+++ b/ai/tests/test-plain-writing-contract.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Every skill that delegates prose editing to plain-writing must be able to call it.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+AI_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+SKILLS_DIR="${AI_DIR}/skills"
+
+# The phrase each caller uses to hand its draft to plain-writing. Harness-neutral on
+# purpose: Codex has no Skill tool, and these callers all ship to Codex.
+INVOCATION="apply the \`plain-writing\` skill in technical mode"
+
+passes=0
+failures=0
+
+pass() { passes=$((passes + 1)); }
+
+fail() { # desc
+	echo "FAIL: $1"
+	failures=$((failures + 1))
+}
+
+if [[ -f "${SKILLS_DIR}/plain-writing/SKILL.md" ]]; then
+	pass
+else
+	fail "plain-writing skill is missing"
+fi
+
+# Derived rather than hardcoded, so a new caller is covered the moment it lands and a
+# caller that drops the invocation fails instead of vanishing from a stale list.
+callers=$(grep -Fil "$INVOCATION" "${SKILLS_DIR}"/*/SKILL.md || true)
+
+if [[ -z "$callers" ]]; then
+	fail "no skill delegates to plain-writing"
+fi
+
+while IFS= read -r path; do
+	[[ -n "$path" ]] || continue
+	skill_name=$(basename "$(dirname "$path")")
+	# An absent allowed-tools line means unrestricted, which already permits Skill. A
+	# present one must list Skill or the delegation fails silently at runtime.
+	if grep -Eq '^allowed-tools:' "$path" &&
+		! grep -Eq '^allowed-tools:.*[ ,]Skill([ ,]|$)' "$path"; then
+		fail "${skill_name} restricts allowed-tools without permitting Skill"
+	else
+		pass
+	fi
+done <<<"$callers"
+
+echo "Inspected $(printf '%s\n' "$callers" | grep -c .) plain-writing callers"
+echo "Results: ${passes} passed, ${failures} failed"
+[[ "${failures}" -eq 0 ]]


### PR DESCRIPTION
- Adds a shared `plain-writing` skill with technical, strict, voice-match, and review modes plus a warning-only linter.
- Adds plain-English rules to `ai/AGENTS.md`, keeps `/humanizer` as a temporary alias, and applies the editor to prose-heavy workflows.
- Adds linter and integration tests for Markdown fences, strict checks, CLI behavior, argument forwarding, and workflow permissions.

## Test plan

- `python3 ai/skills/plain-writing/scripts/tests/test_plain_writing_lint.py`
- `python3 -m unittest discover -s ai/skills/plain-writing/scripts/tests -p 'test_*.py'`
- `bash ai/skills/plain-writing/scripts/tests/test-skill-contract.sh`
- `ruff format --check --no-cache ai/skills/plain-writing/scripts/plain-writing-lint.py ai/skills/plain-writing/scripts/tests/test_plain_writing_lint.py`
- `ruff check --no-cache --select E,F,I,SIM,C90 ai/skills/plain-writing/scripts/plain-writing-lint.py ai/skills/plain-writing/scripts/tests/test_plain_writing_lint.py`
- `mypy ai/skills/plain-writing/scripts/plain-writing-lint.py`
- `shellcheck ai/skills/plain-writing/scripts/tests/test-skill-contract.sh`
- `markdownlint-cli2 ai/AGENTS.md ai/skills/plain-writing/SKILL.md ai/skills/plain-writing/references/strict.md ai/skills/sprint-planning/SKILL.md`
