### PR TITLE
Add agentskills.io spec validation for AI skills

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,18 @@
+name: Test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  ai-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run AI tooling tests
+        # test-canonical-skills.sh is excluded: it fails on a false positive in
+        # sprint-planning/scripts/test_board_scripts.py (a comment, not a path).
+        run: |
+          ai/tests/test-skill-spec.sh
+          ai/tests/test-ai-installers.sh

--- a/ai/README.md
+++ b/ai/README.md
@@ -45,4 +45,7 @@ ai/tests/test-ai-installers.sh
 ai/tests/test-canonical-skills.sh
 ai/tests/test-plain-writing-contract.sh
 python3 ai/skills/plain-writing/scripts/tests/test_plain_writing_lint.py
+ai/tests/test-skill-spec.sh
 ```
+
+`test-skill-spec.sh` validates every skill against the agentskills.io spec: directory name equals the frontmatter `name`, `description` is 1–1024 characters, and frontmatter only uses spec keys plus this repo's own extensions (`argument-hint`, `model`, `color`). Skills listed in `codex/excluded-skills.txt` also carry `compatibility: Designed for Claude Code (or similar products)` so spec-aware clients know they are Claude-only.

--- a/ai/skills/analyze-permissions/SKILL.md
+++ b/ai/skills/analyze-permissions/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: analyze-permissions
 description: Analyze accumulated permissions and suggest smart wildcard patterns. Only invoke when the user explicitly runs /analyze-permissions or asks to analyze their Claude Code permissions.
+compatibility: Designed for Claude Code (or similar products)
 argument-hint: [analyze|apply|cleanup]
 model: sonnet
 metadata:

--- a/ai/skills/ci-monitor/SKILL.md
+++ b/ai/skills/ci-monitor/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: ci-monitor
 description: Monitor CI checks after pushing, detect flaky vs legit failures, and auto-fix. Follows a PR into a Trunk merge queue, where the queue's CI runs on its own branch.
+compatibility: Designed for Claude Code (or similar products)
 argument-hint: "[<pr-number>|<pr-url>|--no-fix|--no-requeue|--timeout <min>|--auto-approve-base-sync]"
 allowed-tools: Bash(~/.dotfiles/ai/skills/ci-monitor/scripts/*:*, ~/.dotfiles/bin/detect-pr.sh:*, sleep:*, gh:*, git:*), Read(~/.dotfiles/ai/skills/ci-monitor/**), Write, Edit, Agent
 model: sonnet

--- a/ai/skills/explain-open/SKILL.md
+++ b/ai/skills/explain-open/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: explain-open
 description: Explain each open or skipped code-review item in plain English, weigh what happens on each side of the decision, and give a recommendation.
+compatibility: Designed for Claude Code (or similar products)
 argument-hint: "[<pr-url>|<pr-number>|<branch>|<file>]"
 model: sonnet
 metadata:

--- a/ai/skills/go/SKILL.md
+++ b/ai/skills/go/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: go
 description: Plan, implement, and review a task end-to-end — review-code + ReviewHog in parallel, every review addressed, CI watched to green, open items explained. Idempotent — re-running reports where the pipeline stands and resumes from the first incomplete step.
+compatibility: Designed for Claude Code (or similar products)
 argument-hint: "<task description> [--skip-planner] [--skip-reviewhog] [--plan-file <path>]"
 ---
 

--- a/ai/skills/review-fix-cycle/SKILL.md
+++ b/ai/skills/review-fix-cycle/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: review-fix-cycle
 description: Run one review-fix iteration — review code, fix findings, simplify, and commit.
+compatibility: Designed for Claude Code (or similar products)
 argument-hint: "[<review-target>] [--iteration N]"
 model: sonnet
 metadata:

--- a/ai/tests/test-canonical-skills.sh
+++ b/ai/tests/test-canonical-skills.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 # Skills shared with Codex must not depend on a provider-specific install path.
 # Claude-only skills listed in codex/excluded-skills.txt are exempt.
+#
+# TODO: the matcher below also flags prose comments that mention ~/.claude
+# (e.g. sprint-planning/scripts/test_board_scripts.py:36), so it currently
+# fails on main and is excluded from .github/workflows/test.yml until the
+# pattern learns to skip comment lines.
 set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/ai/tests/test-skill-spec.sh
+++ b/ai/tests/test-skill-spec.sh
@@ -8,9 +8,15 @@ set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SKILLS_DIR="$(cd "${SCRIPT_DIR}/../skills" && pwd)"
+EXCLUSIONS="${SCRIPT_DIR}/../codex/excluded-skills.txt"
 
 passes=0
 failures=0
+
+# Same parse as is_excluded_skill in ai/install-codex.sh.
+is_excluded_skill() {
+	grep -Ev '^[[:space:]]*(#|$)' "$EXCLUSIONS" | grep -Fxq "$1"
+}
 
 allowed_keys="name description license compatibility metadata allowed-tools argument-hint model color"
 
@@ -38,6 +44,15 @@ for skill_dir in "$SKILLS_DIR"/*; do
 			desc_len=${#fm_desc}
 			if (( desc_len < 1 || desc_len > 1024 )); then
 				problems+="  description length $desc_len outside 1-1024"$'\n'
+			fi
+			# `compatibility` marks a skill as Claude-only, which must track the
+			# codex/excluded-skills.txt membership that install-codex.sh reads; drift
+			# in either direction is silent, so enforce both.
+			if printf '%s\n' "$fm_keys" | grep -Fxq compatibility && ! is_excluded_skill "$skill_name"; then
+				problems+="  declares compatibility but is not in codex/excluded-skills.txt"$'\n'
+			fi
+			if ! printf '%s\n' "$fm_keys" | grep -Fxq compatibility && is_excluded_skill "$skill_name"; then
+				problems+="  excluded from Codex but missing compatibility frontmatter"$'\n'
 			fi
 			while IFS= read -r key; do
 				[[ -n "$key" ]] || continue

--- a/ai/tests/test-skill-spec.sh
+++ b/ai/tests/test-skill-spec.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Validate every skill in ai/skills/ against the agentskills.io specification:
+# directory name must equal the frontmatter `name`, description must be 1-1024
+# characters, and frontmatter may only use spec keys (name, description, license,
+# compatibility, metadata, allowed-tools) plus this repo's own Claude extensions
+# (argument-hint, model, color).
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILLS_DIR="$(cd "${SCRIPT_DIR}/../skills" && pwd)"
+
+passes=0
+failures=0
+
+allowed_keys="name description license compatibility metadata allowed-tools argument-hint model color"
+
+for skill_dir in "$SKILLS_DIR"/*; do
+	[[ -d "$skill_dir" ]] || continue
+	skill_name=$(basename "$skill_dir")
+	skill_file="$skill_dir/SKILL.md"
+	problems=""
+
+	if [[ ! -f "$skill_file" ]]; then
+		problems+="  missing SKILL.md"$'\n'
+	else
+		# Frontmatter must open the file and close before any body content.
+		frontmatter=$(awk '/^---$/{n++; if (n==2) exit; next} n==1' "$skill_file")
+		if [[ -z "$frontmatter" ]]; then
+			problems+="  no frontmatter block"$'\n'
+		else
+			fm_name=$(printf '%s\n' "$frontmatter" | sed -n 's/^name:[[:space:]]*//p' | head -1 | tr -d '[:space:]')
+			fm_desc=$(printf '%s\n' "$frontmatter" | sed -n 's/^description:[[:space:]]*//p' | head -1)
+			fm_keys=$(printf '%s\n' "$frontmatter" | sed -n 's/^\([A-Za-z0-9_-]*\):.*/\1/p')
+
+			if [[ "$fm_name" != "$skill_name" ]]; then
+				problems+="  name '$fm_name' does not match directory '$skill_name'"$'\n'
+			fi
+			desc_len=${#fm_desc}
+			if (( desc_len < 1 || desc_len > 1024 )); then
+				problems+="  description length $desc_len outside 1-1024"$'\n'
+			fi
+			while IFS= read -r key; do
+				[[ -n "$key" ]] || continue
+				if ! printf '%s\n' $allowed_keys | grep -Fxq "$key"; then
+					problems+="  unsupported frontmatter key '$key'"$'\n'
+				fi
+			done <<< "$fm_keys"
+		fi
+	fi
+
+	if [[ -n "$problems" ]]; then
+		failures=$((failures + 1))
+		printf 'FAIL %s\n%s' "$skill_name" "$problems"
+	else
+		passes=$((passes + 1))
+	fi
+done
+
+# An empty scan would otherwise read as a clean run.
+if (( passes == 0 && failures == 0 )); then
+	echo "FAIL no skills found under $SKILLS_DIR"
+	exit 1
+fi
+
+echo "Validated $((passes + failures)) skills: $passes passed, $failures failed"
+(( failures == 0 ))

--- a/ai/tests/test-skill-spec.sh
+++ b/ai/tests/test-skill-spec.sh
@@ -29,11 +29,15 @@ for skill_dir in "$SKILLS_DIR"/*; do
 	if [[ ! -f "$skill_file" ]]; then
 		problems+="  missing SKILL.md"$'\n'
 	else
-		# Frontmatter must open the file and close before any body content.
-		frontmatter=$(awk '/^---$/{n++; if (n==2) exit; next} n==1' "$skill_file")
-		if [[ -z "$frontmatter" ]]; then
+		# Frontmatter must open the file and close before any body content. Check
+		# structurally before extracting: a leading body, a missing opening line, or a
+		# missing closing line each mean "no frontmatter block", not "frontmatter to parse".
+		first_line=$(head -n 1 "$skill_file")
+		delimiter_count=$(grep -c '^---$' "$skill_file" || true)
+		if [[ "$first_line" != "---" ]] || (( delimiter_count < 2 )); then
 			problems+="  no frontmatter block"$'\n'
 		else
+			frontmatter=$(awk '/^---$/{n++; if (n==2) exit; next} n==1' "$skill_file")
 			fm_name=$(printf '%s\n' "$frontmatter" | sed -n 's/^name:[[:space:]]*//p' | head -1 | tr -d '[:space:]')
 			fm_desc=$(printf '%s\n' "$frontmatter" | sed -n 's/^description:[[:space:]]*//p' | head -1)
 			fm_keys=$(printf '%s\n' "$frontmatter" | sed -n 's/^\([A-Za-z0-9_-]*\):.*/\1/p')


### PR DESCRIPTION
## What

Wires the agentskills.io spec (the open SKILL.md standard adopted by Claude Code, Codex, VS Code, and others — see #190 for the Codex adoption that made this repo spec-shaped in the first place) into this repo as a tested invariant:

- **`ai/tests/test-skill-spec.sh`** — validates every skill against the spec:
  - directory name equals the frontmatter `name`
  - `description` is 1–1024 characters
  - frontmatter only uses spec keys (`name`, `description`, `license`, `compatibility`, `metadata`, `allowed-tools`) plus this repo's own extensions (`argument-hint`, `model`, `color`)
  - exits non-zero on any violation, and fails if the skills directory is somehow empty (so a glob that matches nothing can't read as a pass)
- **`.github/workflows/test.yml`** — first CI workflow in this repo; runs `test-skill-spec.sh` and `test-ai-installers.sh` on PRs and pushes to main.
- **`compatibility: Designed for Claude Code (or similar products)`** on the five Codex-excluded skills (`analyze-permissions`, `explain-open`, `go`, `review-fix-cycle`, `ci-monitor`). The spec defines `compatibility` as environment requirements — accurate here, since these are intentionally Claude-only per `codex/excluded-skills.txt`.

## Why not `skills-ref validate`

The spec repo's own `skills-ref` validator is a Python library its README flags as "not meant to be used in production." Rather than pin a moving git SHA in CI, `test-skill-spec.sh` enforces the three spec requirements that actually matter for this repo (name/dir match, description length, no unsupported top-level keys) in ~60 lines of bash with no dependencies. Verified against fixtures that it catches each violation class:

```
FAIL bad-key
  unsupported frontmatter key 'nonsense'
FAIL bad-name
  name 'other-name' does not match directory 'bad-name'
FAIL long-desc
  description length 1025 outside 1-1024
FAIL no-desc
  description length 0 outside 1-1024
```

## Not in CI (yet)

`test-canonical-skills.sh` fails on main on a false positive: a descriptive comment in `sprint-planning/scripts/test_board_scripts.py` ("deployed read-only into ~/.claude/skills/…") matches its hardcoded-path grep. That deserves its own fix — out of scope here.

## Test plan

- [x] `ai/tests/test-skill-spec.sh` — 26/26 pass on this branch
- [x] `ai/tests/test-ai-installers.sh` — 61/61 pass
- [x] Negative fixtures above confirm the validator catches each violation class

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*