### PR TITLE
Fix --pending missing fresh draft reviews

### DIFF
--- a/bin/lib/test-review-search-queries.sh
+++ b/bin/lib/test-review-search-queries.sh
@@ -30,8 +30,9 @@ QUERY_LOG="$TESTTMP/queries.log"
 mkdir -p "$TESTTMP/bin"
 
 # review-all-prs.sh needs bash 4+ (associative arrays), which macOS's /bin/bash
-# is not. Find a modern one and put its directory ahead of the system paths so
-# both the interpreter below and any bash the script re-invokes resolve to it.
+# is not, so find a modern one to run it with. Its directory also goes on the
+# shim PATH ahead of the system paths, which covers Homebrew-installed tools the
+# script needs (jq) on hosts where /usr/bin carries no copy.
 BASH4=""
 for candidate in "$BASH" /opt/homebrew/bin/bash /usr/local/bin/bash "$(command -v bash)"; do
   [[ -x "$candidate" ]] || continue
@@ -53,12 +54,32 @@ SHIM_PATH="$TESTTMP/bin:$(dirname "$BASH4"):/usr/bin:/bin"
 cat > "$TESTTMP/bin/gh" <<'SHIM'
 #!/bin/bash
 if [[ "${1-}" == "api" && "${2-}" == "graphql" ]]; then
+  query=""
   for ((i = 1; i <= $#; i++)); do
     arg="${!i}"
     if [[ "$arg" == searchQuery=* ]]; then
-      printf '%s\n' "${arg#searchQuery=}" >> "$QUERY_LOG"
+      query="${arg#searchQuery=}"
+      printf '%s\n' "$query" >> "$QUERY_LOG"
     fi
   done
+  # PR_FIXTURE_QUERY names a substring; searches matching it return one PR
+  # carrying an unsubmitted draft review by "me", every other search an empty
+  # page. That reproduces a draft only some qualifiers can see.
+  if [[ -n "${PR_FIXTURE_QUERY-}" && "$query" == *"$PR_FIXTURE_QUERY"* ]]; then
+    cat <<'NODE'
+{"data":{"search":{"pageInfo":{"hasNextPage":false,"endCursor":null},"edges":[{"node":{
+"number":99001,
+"title":"feat(flags): fixture PR carrying a fresh draft review",
+"url":"https://github.com/PostHog/posthog/pull/99001",
+"repository":{"nameWithOwner":"PostHog/posthog"},
+"author":{"login":"dev-one"},
+"updatedAt":"2026-08-24T12:00:00Z",
+"reviews":{"nodes":[{"author":{"login":"me"},"state":"PENDING","submittedAt":null}]},
+"commits":{"nodes":[{"commit":{"committedDate":"2026-08-24T11:00:00Z"}}]}
+}}]}}}
+NODE
+    exit 0
+  fi
   echo '{"data":{"search":{"pageInfo":{"hasNextPage":false,"endCursor":null},"edges":[]}}}'
   exit 0
 fi
@@ -75,10 +96,20 @@ esac
 SHIM
 chmod +x "$TESTTMP/bin/gh"
 
-# Runs review-all-prs.sh with a fresh query log and echoes the log path.
+# Truncates the query log, then runs review-all-prs.sh with the given flags.
 run_queries() {
   : > "$QUERY_LOG"
   run_bounded 20 env PATH="$SHIM_PATH" QUERY_LOG="$QUERY_LOG" "$BASH4" "$BIN" "$@" >/dev/null 2>&1 || true
+}
+
+# Runs review-all-prs.sh with the fixture PR armed for searches whose query
+# contains $1, and echoes its stdout.
+run_with_fixture() {  # run_with_fixture <query-substring> [flags...]
+  local fixture="$1"
+  shift
+  : > "$QUERY_LOG"
+  run_bounded 20 env PATH="$SHIM_PATH" QUERY_LOG="$QUERY_LOG" \
+    PR_FIXTURE_QUERY="$fixture" "$BASH4" "$BIN" "$@" 2>/dev/null || true
 }
 
 # True when some recorded query contains the given substring.
@@ -98,8 +129,9 @@ run_queries --draft --team flags
 assert "--draft honors --team via team-review-requested" \
   ran_query "team-review-requested:PostHog/flags"
 
+# Guards the shared --pending|--draft case arm rather than the query set.
 run_queries --pending
-assert "--pending is the same mode as --draft: it searches review-requested:@me too" \
+assert "--pending is an alias for --draft and searches the same candidates" \
   ran_query "review-requested:@me"
 
 # ── Default and --all modes keep their existing queries ─────────────────────
@@ -107,8 +139,7 @@ assert "--pending is the same mode as --draft: it searches review-requested:@me 
 run_queries
 assert "default mode searches review-requested:@me" ran_query "review-requested:@me"
 assert "default mode sweeps involves:@me for pending drafts" ran_query "involves:@me"
-assert "default mode does not run an author query" \
-  test "$(grep -cF -- 'author:dev-one' "$QUERY_LOG")" -eq 0
+assert_not "default mode does not run an author query" ran_query "author:dev-one"
 
 run_queries --all --priority-team flags
 assert "--all searches every open non-draft PR authored by a team member" \
@@ -119,5 +150,20 @@ assert "--all sweeps involves:@me for pending drafts" ran_query "involves:@me"
 
 run_queries --org acme --draft
 assert "--draft scopes its queries to --org" ran_query "org:acme"
+
+# ── The bug end to end: a draft only review-requested: can see ──────────────
+# The fixture answers review-requested:@me and leaves involves:@me empty, which
+# is the index lag observed on a freshly started draft review. Searching
+# involves:@me alone, as --draft used to, reports nothing here.
+
+out=$(run_with_fixture "review-requested:@me" --draft --json)
+assert "--draft reports a draft found only through review-requested:@me" \
+  grep -q '"number": 99001' <<< "$out"
+assert "--draft reports that PR as an unsubmitted draft" \
+  grep -q '"user_review_state": "PENDING"' <<< "$out"
+
+out=$(run_with_fixture "involves:@me" --draft --json)
+assert "--draft still reports a draft found only through the involves sweep" \
+  grep -q '"number": 99001' <<< "$out"
 
 print_results

--- a/bin/lib/test-review-search-queries.sh
+++ b/bin/lib/test-review-search-queries.sh
@@ -62,9 +62,10 @@ if [[ "${1-}" == "api" && "${2-}" == "graphql" ]]; then
       printf '%s\n' "$query" >> "$QUERY_LOG"
     fi
   done
-  # PR_FIXTURE_QUERY names a substring; searches matching it return one PR
-  # carrying an unsubmitted draft review by "me", every other search an empty
-  # page. That reproduces a draft only some qualifiers can see.
+  # PR_FIXTURE_QUERY names a substring; searches matching it return a page of
+  # two PRs, every other search an empty page. That reproduces a draft only some
+  # qualifiers can see. 99001 carries an unsubmitted draft review by "me";
+  # 99002 carries no review at all, so it is what pending mode has to drop.
   if [[ -n "${PR_FIXTURE_QUERY-}" && "$query" == *"$PR_FIXTURE_QUERY"* ]]; then
     cat <<'NODE'
 {"data":{"search":{"pageInfo":{"hasNextPage":false,"endCursor":null},"edges":[{"node":{
@@ -75,6 +76,15 @@ if [[ "${1-}" == "api" && "${2-}" == "graphql" ]]; then
 "author":{"login":"dev-one"},
 "updatedAt":"2026-08-24T12:00:00Z",
 "reviews":{"nodes":[{"author":{"login":"me"},"state":"PENDING","submittedAt":null}]},
+"commits":{"nodes":[{"commit":{"committedDate":"2026-08-24T11:00:00Z"}}]}
+}},{"node":{
+"number":99002,
+"title":"feat(flags): fixture PR you have not reviewed",
+"url":"https://github.com/PostHog/posthog/pull/99002",
+"repository":{"nameWithOwner":"PostHog/posthog"},
+"author":{"login":"dev-two"},
+"updatedAt":"2026-08-24T12:00:00Z",
+"reviews":{"nodes":[]},
 "commits":{"nodes":[{"commit":{"committedDate":"2026-08-24T11:00:00Z"}}]}
 }}]}}}
 NODE
@@ -96,20 +106,36 @@ esac
 SHIM
 chmod +x "$TESTTMP/bin/gh"
 
-# Truncates the query log, then runs review-all-prs.sh with the given flags.
-run_queries() {
+RUN_DEADLINE=20
+
+# Truncates the query log, then runs review-all-prs.sh with the given flags and
+# echoes its stdout. $1 arms the fixture PR for searches whose query contains
+# it; pass "" for none. A non-zero exit means the script stopped before it
+# recorded any queries, and every assertion below would then blame the query set
+# rather than the environment, so say what actually happened. run_bounded
+# discards the command's stderr itself, so no redirect belongs on this call.
+run_script() {  # run_script <fixture-query|""> [flags...]
+  local fixture="$1" rc=0
+  shift
   : > "$QUERY_LOG"
-  run_bounded 20 env PATH="$SHIM_PATH" QUERY_LOG="$QUERY_LOG" "$BASH4" "$BIN" "$@" >/dev/null 2>&1 || true
+  run_bounded "$RUN_DEADLINE" env PATH="$SHIM_PATH" QUERY_LOG="$QUERY_LOG" \
+    PR_FIXTURE_QUERY="$fixture" "$BASH4" "$BIN" "$@" || rc=$?
+  if [[ "$rc" -ne 0 ]]; then
+    local why=""
+    [[ "$rc" -eq 124 ]] && why=" (killed after ${RUN_DEADLINE}s)"
+    echo "SETUP: review-all-prs.sh $* exited ${rc}${why}" >&2
+  fi
+}
+
+# Runs review-all-prs.sh for its queries alone, discarding its output.
+run_queries() {
+  run_script "" "$@" >/dev/null
 }
 
 # Runs review-all-prs.sh with the fixture PR armed for searches whose query
 # contains $1, and echoes its stdout.
 run_with_fixture() {  # run_with_fixture <query-substring> [flags...]
-  local fixture="$1"
-  shift
-  : > "$QUERY_LOG"
-  run_bounded 20 env PATH="$SHIM_PATH" QUERY_LOG="$QUERY_LOG" \
-    PR_FIXTURE_QUERY="$fixture" "$BASH4" "$BIN" "$@" 2>/dev/null || true
+  run_script "$@"
 }
 
 # True when some recorded query contains the given substring.
@@ -124,6 +150,8 @@ assert "--draft searches review-requested:@me, so a fresh draft on a requested P
   ran_query "review-requested:@me"
 assert "--draft still sweeps involves:@me for drafts on PRs you weren't asked to review" \
   ran_query "involves:@me"
+assert_not "--draft's sweep keeps your own PRs, where a draft is still unfinished work" \
+  ran_query "involves:@me -author:@me"
 
 run_queries --draft --team flags
 assert "--draft honors --team via team-review-requested" \
@@ -139,6 +167,7 @@ assert "--pending is an alias for --draft and searches the same candidates" \
 run_queries
 assert "default mode searches review-requested:@me" ran_query "review-requested:@me"
 assert "default mode sweeps involves:@me for pending drafts" ran_query "involves:@me"
+assert "default mode's sweep excludes your own PRs" ran_query "involves:@me -author:@me"
 assert_not "default mode does not run an author query" ran_query "author:dev-one"
 
 run_queries --all --priority-team flags
@@ -161,9 +190,17 @@ assert "--draft reports a draft found only through review-requested:@me" \
   grep -q '"number": 99001' <<< "$out"
 assert "--draft reports that PR as an unsubmitted draft" \
   grep -q '"user_review_state": "PENDING"' <<< "$out"
+assert_not "--draft leaves out a review-requested PR you have no draft on" \
+  grep -q '"number": 99002' <<< "$out"
 
 out=$(run_with_fixture "involves:@me" --draft --json)
 assert "--draft still reports a draft found only through the involves sweep" \
   grep -q '"number": 99001' <<< "$out"
+
+# The hidden count measures the new-commits gate, which pending mode's extra
+# PENDING filter makes meaningless, so pending mode must not report one.
+out=$(run_with_fixture "review-requested:@me" --draft)
+assert_not "--draft does not count non-draft PRs as hidden by the new-commits gate" \
+  grep -q "no new commits since" <<< "$out"
 
 print_results

--- a/bin/lib/test-review-search-queries.sh
+++ b/bin/lib/test-review-search-queries.sh
@@ -1,0 +1,123 @@
+#!/bin/bash
+# Tests for the GitHub search queries review-all-prs.sh issues in each mode.
+#
+# Usage: test-review-search-queries.sh
+#
+# The bug these cover: --pending/--draft used to search involves:@me alone, so
+# it missed a fresh draft review on a PR whose only other tie was a review
+# request. GitHub does not clear the review request when you start a draft, and
+# its search index picks pending reviews up with a lag, so involves: is not a
+# superset of review-requested:.
+#
+# A PATH shim stands in for gh: it answers the member lookups from env vars and
+# records every GraphQL searchQuery into a log the assertions read. Every search
+# returns an empty page, so the tests assert on which queries ran, not on
+# results. Fully offline.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# shellcheck source=bin/lib/test-helpers.sh
+source "$SCRIPT_DIR/test-helpers.sh"
+
+BIN="$(cd "$SCRIPT_DIR/.." && pwd)/review-all-prs.sh"
+
+TESTTMP="$(cd "$(mktemp -d)" && pwd -P)"
+trap 'rm -rf "$TESTTMP"' EXIT
+
+QUERY_LOG="$TESTTMP/queries.log"
+mkdir -p "$TESTTMP/bin"
+
+# review-all-prs.sh needs bash 4+ (associative arrays), which macOS's /bin/bash
+# is not. Find a modern one and put its directory ahead of the system paths so
+# both the interpreter below and any bash the script re-invokes resolve to it.
+BASH4=""
+for candidate in "$BASH" /opt/homebrew/bin/bash /usr/local/bin/bash "$(command -v bash)"; do
+  [[ -x "$candidate" ]] || continue
+  # shellcheck disable=SC2016 # BASH_VERSINFO must expand in the candidate, not here
+  if [[ "$("$candidate" -c 'echo ${BASH_VERSINFO[0]}')" -ge 4 ]]; then
+    BASH4="$candidate"
+    break
+  fi
+done
+if [[ -z "$BASH4" ]]; then
+  echo "No bash 4+ found; review-all-prs.sh cannot run. Install bash via Homebrew." >&2
+  exit 1
+fi
+SHIM_PATH="$TESTTMP/bin:$(dirname "$BASH4"):/usr/bin:/bin"
+
+# gh shim. Member lookups answer with a fixed two-person team so the --all
+# author query has something to build from; graphql calls append their
+# searchQuery to $QUERY_LOG and return an empty single page.
+cat > "$TESTTMP/bin/gh" <<'SHIM'
+#!/bin/bash
+if [[ "${1-}" == "api" && "${2-}" == "graphql" ]]; then
+  for ((i = 1; i <= $#; i++)); do
+    arg="${!i}"
+    if [[ "$arg" == searchQuery=* ]]; then
+      printf '%s\n' "${arg#searchQuery=}" >> "$QUERY_LOG"
+    fi
+  done
+  echo '{"data":{"search":{"pageInfo":{"hasNextPage":false,"endCursor":null},"edges":[]}}}'
+  exit 0
+fi
+case "${2-}" in
+  user) echo "me" ;;
+  orgs/*/teams/*/members*)
+    # '[.[].login]' asks for a JSON array, '.[].login' for bare lines.
+    if [[ "$*" == *"[.[].login]"* ]]; then echo '["dev-one","dev-two"]'
+    else printf 'dev-one\ndev-two\n'; fi
+    ;;
+  orgs/*/members*) echo '["dev-one","dev-two"]' ;;
+  *) echo '[]' ;;
+esac
+SHIM
+chmod +x "$TESTTMP/bin/gh"
+
+# Runs review-all-prs.sh with a fresh query log and echoes the log path.
+run_queries() {
+  : > "$QUERY_LOG"
+  run_bounded 20 env PATH="$SHIM_PATH" QUERY_LOG="$QUERY_LOG" "$BASH4" "$BIN" "$@" >/dev/null 2>&1 || true
+}
+
+# True when some recorded query contains the given substring.
+ran_query() {
+  grep -qF -- "$1" "$QUERY_LOG"
+}
+
+# ── --draft searches the same candidates as the default mode ────────────────
+
+run_queries --draft
+assert "--draft searches review-requested:@me, so a fresh draft on a requested PR is found" \
+  ran_query "review-requested:@me"
+assert "--draft still sweeps involves:@me for drafts on PRs you weren't asked to review" \
+  ran_query "involves:@me"
+
+run_queries --draft --team flags
+assert "--draft honors --team via team-review-requested" \
+  ran_query "team-review-requested:PostHog/flags"
+
+run_queries --pending
+assert "--pending is the same mode as --draft: it searches review-requested:@me too" \
+  ran_query "review-requested:@me"
+
+# ── Default and --all modes keep their existing queries ─────────────────────
+
+run_queries
+assert "default mode searches review-requested:@me" ran_query "review-requested:@me"
+assert "default mode sweeps involves:@me for pending drafts" ran_query "involves:@me"
+assert "default mode does not run an author query" \
+  test "$(grep -cF -- 'author:dev-one' "$QUERY_LOG")" -eq 0
+
+run_queries --all --priority-team flags
+assert "--all searches every open non-draft PR authored by a team member" \
+  ran_query "author:dev-one author:dev-two"
+assert "--all folds the priority team into team-review-requested" \
+  ran_query "team-review-requested:PostHog/flags"
+assert "--all sweeps involves:@me for pending drafts" ran_query "involves:@me"
+
+run_queries --org acme --draft
+assert "--draft scopes its queries to --org" ran_query "org:acme"
+
+print_results

--- a/bin/review-all-prs.sh
+++ b/bin/review-all-prs.sh
@@ -238,10 +238,6 @@ while [[ $# -gt 0 ]]; do
       ;;
     --pending|--draft)
       PENDING_ONLY=true
-      # Pending drafts always pass the review gate, so this doesn't change
-      # which PRs survive; it disables the hidden-PR count, which would
-      # otherwise count every non-pending search result as hidden.
-      INCLUDE_REVIEWED=true
       shift
       ;;
     -h|--help)
@@ -254,8 +250,9 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-# --all needs a team to define whose work to widen to, and is meaningless in
-# the pending-draft path (which has its own involves:@me query).
+# --all needs a team to define whose work to widen to. It is meaningless with
+# --pending: --all widens to a team's whole queue, a different question from
+# which of your own reviews are unfinished.
 if [[ "$ALL" == "true" ]]; then
   if [[ "$PENDING_ONLY" == "true" ]]; then
     echo "--all and --pending/--draft cannot be combined" >&2
@@ -278,14 +275,29 @@ if [[ -n "$PRIORITY_TEAM" ]]; then
   }
 fi
 
-# --all also lists every open non-draft PR authored by the team(s). Collect the
-# union of member logins across the priority team and any --team(s); these drive
-# the author-based search query below.
+# Teams whose review requests count as yours, deduplicated because --team and
+# --priority-team can name the same team. --all folds in the priority team,
+# since it widens to that team's whole queue rather than just --team. This one
+# set drives both the team-review-requested queries and, under --all, the member
+# lookup behind the author-based query.
+request_team_candidates=("${TEAMS[@]}")
+if [[ "$ALL" == "true" && -n "$PRIORITY_TEAM" ]]; then
+  request_team_candidates+=("$PRIORITY_TEAM")
+fi
+REQUEST_TEAMS=()
+declare -A seen_request_team=()
+for team in "${request_team_candidates[@]}"; do
+  [[ -n "${seen_request_team[$team]:-}" ]] && continue
+  seen_request_team[$team]=1
+  REQUEST_TEAMS+=("$team")
+done
+
+# --all also lists every open non-draft PR authored by those teams. Collect the
+# union of their member logins; these drive the author-based search query below.
 AUTHOR_MEMBERS=()
 if [[ "$ALL" == "true" ]]; then
   declare -A seen_member=()
-  for team in "$PRIORITY_TEAM" "${TEAMS[@]}"; do
-    [[ -z "$team" ]] && continue
+  for team in "${REQUEST_TEAMS[@]}"; do
     members=$(gh api "orgs/${ORG}/teams/${team}/members?per_page=100" --paginate --jq '.[].login') || {
       echo "Could not list members of ${ORG}/${team}" >&2
       exit 1
@@ -412,26 +424,9 @@ run_search() {
 # --limit cap would otherwise give to reviewable PRs.
 SEARCH_QUERIES=("is:pr is:open review-requested:@me -author:@me org:${ORG}")
 
-# Teams to fold in via team-review-requested. --all also pulls in the priority
-# team, since it widens to that team's whole queue rather than just --team.
-REQUEST_TEAMS=("${TEAMS[@]}")
-if [[ "$ALL" == "true" && -n "$PRIORITY_TEAM" ]]; then
-  REQUEST_TEAMS+=("$PRIORITY_TEAM")
-fi
-declare -A seen_request_team=()
 for team in "${REQUEST_TEAMS[@]}"; do
-  [[ -n "${seen_request_team[$team]:-}" ]] && continue
-  seen_request_team[$team]=1
   SEARCH_QUERIES+=("is:pr is:open team-review-requested:${ORG}/${team} -author:@me org:${ORG}")
 done
-
-# Pending mode adds every PR you've engaged with, so it also finds drafts on
-# PRs you were never asked to review. Self-authored PRs stay in: a draft on your
-# own PR is still unfinished work. The non-pending path runs the equivalent
-# sweep further down, pre-filtered to drafts.
-if [[ "$PENDING_ONLY" == "true" ]]; then
-  SEARCH_QUERIES+=("is:pr is:open involves:@me org:${ORG}")
-fi
 
 # --all widens further to every open non-draft PR authored by a team member.
 # Multiple author: qualifiers are OR'd by GitHub search, so one query covers
@@ -451,20 +446,22 @@ for search_query in "${SEARCH_QUERIES[@]}"; do
   ALL_RESULTS=$(merge_results "$ALL_RESULTS" "$NODES")
 done
 
-# Sweep for pending (unsubmitted) draft reviews. GitHub removes your
-# review-requested state the moment you start a draft review, so the queries
-# above can miss those PRs entirely. involves:@me finds them; the pre-filter
-# keeps only PRs whose last review by you is an unsubmitted draft. Always
-# paginated: drafts can sit past the first page of involves results.
-# --pending mode already searches involves:@me as its only query.
-if [[ "$PENDING_ONLY" != "true" ]]; then
-  PENDING_NODES=$(run_search "is:pr is:open involves:@me -author:@me org:${ORG}" true) || exit 1
-  PENDING_NODES=$(echo "$PENDING_NODES" | jq --arg user "$GITHUB_USER" -f "${SCRIPT_DIR}/lib/pending-filter.jq")
-  # Merge the sweep first: unique_by keeps the first copy per URL, and the
-  # sweep copy is the one that captured the pending review if the same PR was
-  # fetched by an earlier query moments before the draft existed.
-  ALL_RESULTS=$(merge_results "$PENDING_NODES" "$ALL_RESULTS")
+# Sweep for pending (unsubmitted) draft reviews. The review-request queries
+# above cannot see a draft on a PR nobody asked you to review; involves:@me
+# finds those, and the pre-filter keeps only PRs whose last review by you is an
+# unsubmitted draft. Always paginated: drafts can sit past the first page.
+# Pending mode keeps self-authored PRs, where a draft is still your own
+# unfinished work; the other modes list other people's PRs.
+SWEEP_QUERY="is:pr is:open involves:@me -author:@me org:${ORG}"
+if [[ "$PENDING_ONLY" == "true" ]]; then
+  SWEEP_QUERY="is:pr is:open involves:@me org:${ORG}"
 fi
+PENDING_NODES=$(run_search "$SWEEP_QUERY" true) || exit 1
+PENDING_NODES=$(echo "$PENDING_NODES" | jq --arg user "$GITHUB_USER" -f "${SCRIPT_DIR}/lib/pending-filter.jq")
+# Merge the sweep first: unique_by keeps the first copy per URL, and the sweep
+# copy is the one that captured the pending review if the same PR was fetched by
+# an earlier query moments before the draft existed.
+ALL_RESULTS=$(merge_results "$PENDING_NODES" "$ALL_RESULTS")
 
 # Deduplicate by PR URL
 ALL_RESULTS=$(echo "$ALL_RESULTS" | jq 'unique_by(.url)')
@@ -483,9 +480,11 @@ fi
 
 # Count results. HIDDEN counts PRs dropped by the new-commits gate: you have
 # a submitted review and nothing changed since. Pending drafts are never hidden.
+# Pending mode skips the count: its extra PENDING filter drops PRs the gate
+# kept, so the subtraction would no longer measure the gate.
 COUNT=$(echo "$PROCESSED" | jq 'length')
 HIDDEN=0
-if [[ "$INCLUDE_REVIEWED" != "true" ]]; then
+if [[ "$INCLUDE_REVIEWED" != "true" && "$PENDING_ONLY" != "true" ]]; then
   TOTAL=$(echo "$ALL_RESULTS" | jq 'length')
   HIDDEN=$((TOTAL - COUNT))
 fi

--- a/bin/review-all-prs.sh
+++ b/bin/review-all-prs.sh
@@ -34,9 +34,12 @@
 # show already-settled PRs as well.
 #
 # PRs where you have a pending (unsubmitted draft) review are always included,
-# in every mode: GitHub drops your review-requested state the moment you start
-# a draft review, so these PRs are swept in via involves:@me and are never
-# hidden by the new-commits gate — a pending review is unfinished work.
+# in every mode, and are never hidden by the new-commits gate: a pending review
+# is unfinished work. Finding them all takes both the review-requested queries
+# and an involves:@me sweep. Starting a draft review does not clear your review
+# request, and GitHub's search index picks a pending review up only after a lag,
+# so a fresh draft can be missing from involves:@me while the PR still answers
+# review-requested:. Neither query alone finds every draft.
 #
 # By default, results are grouped by priority tier, then most recently updated
 # within each tier. An explicit --sort KEY orders the whole list by that key,
@@ -124,8 +127,10 @@ Options:
                       --limit. A triage superset, not a mirror of any project
                       board.
   --pending           List every PR where you have a pending (draft) review.
-                      Uses involves:@me and paginates, so it finds drafts even
-                      on PRs you weren't requested to review. Ignores --team.
+                      Searches the same review requests as the default listing
+                      (yours, plus any --team) and adds an involves:@me sweep,
+                      so it finds drafts on PRs you weren't requested to review
+                      as well. Paginates.
   --draft             Alias for --pending.
   -h, --help          Show this help message
 
@@ -235,7 +240,7 @@ while [[ $# -gt 0 ]]; do
       PENDING_ONLY=true
       # Pending drafts always pass the review gate, so this doesn't change
       # which PRs survive; it disables the hidden-PR count, which would
-      # otherwise count every non-pending involves:@me result as hidden.
+      # otherwise count every non-pending search result as hidden.
       INCLUDE_REVIEWED=true
       shift
       ;;
@@ -400,41 +405,43 @@ run_search() {
   echo "$merged"
 }
 
-# Pending mode wants every PR you've engaged with so we can find drafts on
-# PRs where you weren't a requested reviewer; involves:@me covers that.
-# --team is irrelevant in this mode and is silently ignored.
+# Every mode starts from the review requests addressed to you. GitHub search
+# combines multiple qualifiers with AND, so we need separate queries for
+# personal and team review requests and then merge the results. Self-authored
+# PRs are excluded at the source so they don't consume result slots that the
+# --limit cap would otherwise give to reviewable PRs.
+SEARCH_QUERIES=("is:pr is:open review-requested:@me -author:@me org:${ORG}")
+
+# Teams to fold in via team-review-requested. --all also pulls in the priority
+# team, since it widens to that team's whole queue rather than just --team.
+REQUEST_TEAMS=("${TEAMS[@]}")
+if [[ "$ALL" == "true" && -n "$PRIORITY_TEAM" ]]; then
+  REQUEST_TEAMS+=("$PRIORITY_TEAM")
+fi
+declare -A seen_request_team=()
+for team in "${REQUEST_TEAMS[@]}"; do
+  [[ -n "${seen_request_team[$team]:-}" ]] && continue
+  seen_request_team[$team]=1
+  SEARCH_QUERIES+=("is:pr is:open team-review-requested:${ORG}/${team} -author:@me org:${ORG}")
+done
+
+# Pending mode adds every PR you've engaged with, so it also finds drafts on
+# PRs you were never asked to review. Self-authored PRs stay in: a draft on your
+# own PR is still unfinished work. The non-pending path runs the equivalent
+# sweep further down, pre-filtered to drafts.
 if [[ "$PENDING_ONLY" == "true" ]]; then
-  SEARCH_QUERIES=("is:pr is:open involves:@me org:${ORG}")
-else
-  # GitHub search combines multiple qualifiers with AND, so we need separate
-  # queries for personal and team review requests and then merge the results.
-  # Self-authored PRs are excluded at the source so they don't consume result
-  # slots that the --limit cap would otherwise give to reviewable PRs.
-  SEARCH_QUERIES=("is:pr is:open review-requested:@me -author:@me org:${ORG}")
+  SEARCH_QUERIES+=("is:pr is:open involves:@me org:${ORG}")
+fi
 
-  # Teams to fold in via team-review-requested. --all also pulls in the priority
-  # team, since it widens to that team's whole queue rather than just --team.
-  REQUEST_TEAMS=("${TEAMS[@]}")
-  if [[ "$ALL" == "true" && -n "$PRIORITY_TEAM" ]]; then
-    REQUEST_TEAMS+=("$PRIORITY_TEAM")
-  fi
-  declare -A seen_request_team=()
-  for team in "${REQUEST_TEAMS[@]}"; do
-    [[ -n "${seen_request_team[$team]:-}" ]] && continue
-    seen_request_team[$team]=1
-    SEARCH_QUERIES+=("is:pr is:open team-review-requested:${ORG}/${team} -author:@me org:${ORG}")
+# --all widens further to every open non-draft PR authored by a team member.
+# Multiple author: qualifiers are OR'd by GitHub search, so one query covers
+# the whole team. Drafts aren't ready for review, so exclude them.
+if [[ "$ALL" == "true" && ${#AUTHOR_MEMBERS[@]} -gt 0 ]]; then
+  author_filter=""
+  for login in "${AUTHOR_MEMBERS[@]}"; do
+    author_filter+=" author:${login}"
   done
-
-  # --all widens further to every open non-draft PR authored by a team member.
-  # Multiple author: qualifiers are OR'd by GitHub search, so one query covers
-  # the whole team. Drafts aren't ready for review, so exclude them.
-  if [[ "$ALL" == "true" && ${#AUTHOR_MEMBERS[@]} -gt 0 ]]; then
-    author_filter=""
-    for login in "${AUTHOR_MEMBERS[@]}"; do
-      author_filter+=" author:${login}"
-    done
-    SEARCH_QUERIES+=("is:pr is:open -is:draft -author:@me org:${ORG}${author_filter}")
-  fi
+  SEARCH_QUERIES+=("is:pr is:open -is:draft -author:@me org:${ORG}${author_filter}")
 fi
 
 # Execute all queries and merge results

--- a/bin/review-all-prs.sh
+++ b/bin/review-all-prs.sh
@@ -298,10 +298,15 @@ AUTHOR_MEMBERS=()
 if [[ "$ALL" == "true" ]]; then
   declare -A seen_member=()
   for team in "${REQUEST_TEAMS[@]}"; do
-    members=$(gh api "orgs/${ORG}/teams/${team}/members?per_page=100" --paginate --jq '.[].login') || {
-      echo "Could not list members of ${ORG}/${team}" >&2
-      exit 1
-    }
+    # The priority team's roster is already in TEAM_MEMBERS as a JSON array.
+    if [[ -n "$PRIORITY_TEAM" && "$team" == "$PRIORITY_TEAM" ]]; then
+      members=$(jq -r '.[]' <<< "$TEAM_MEMBERS")
+    else
+      members=$(gh api "orgs/${ORG}/teams/${team}/members?per_page=100" --paginate --jq '.[].login') || {
+        echo "Could not list members of ${ORG}/${team}" >&2
+        exit 1
+      }
+    fi
     while IFS= read -r login; do
       [[ -z "$login" || -n "${seen_member[$login]:-}" ]] && continue
       seen_member[$login]=1


### PR DESCRIPTION
`--pending` searched `involves:@me` alone. Starting a draft review does not clear your review request, and GitHub's search index picks pending reviews up with a lag, so a fresh draft on a review-requested PR was invisible to that query.

Every mode now runs the same set: your review requests, any `--team` review requests, and an `involves:@me` sweep. `--pending` post-filters that down to reviews still in the PENDING state. Neither query alone finds every draft, so both run.

- `--pending` honors `--team` instead of ignoring it, and the help text says so.
- The team set is built once and feeds both the `team-review-requested:` queries and the `--all` member lookup, which drops one paginated roster call per `--all` run.
- The hidden-PR count is gated on pending mode directly. It used to be suppressed by forcing `INCLUDE_REVIEWED=true`, a flag that claimed to change filtering and did not.

Default and `--all` behavior is unchanged. Their query sets match main across every flag combination, which matters because the hourly launchd job runs `--all`.

## Test plan

`bin/lib/test-review-search-queries.sh` is new and covers this offline. A `gh` shim on `PATH` logs every GraphQL search and can answer one chosen query with a fixture PR, which reproduces the index lag in both directions.

- [ ] `bash bin/lib/test-review-search-queries.sh` passes 18 of 18
- [ ] `bin/review-all-prs.sh --pending` lists a PR where you have started but not submitted a review
- [ ] The same PR shows up when your only tie to it is the review request, which is the case that used to come back empty
- [ ] `bin/review-all-prs.sh --pending --team <team>` includes drafts on that team's review requests
- [ ] `bin/review-all-prs.sh` with no flags lists what it listed before