### PR TITLE
Explain the override when removing a locked worktree

### DIFF
--- a/bin/lib/test-tree-me-remove.sh
+++ b/bin/lib/test-tree-me-remove.sh
@@ -114,6 +114,43 @@ tree_me rm --force --force locked-three
 assert "--force --force removes a locked worktree" test "$rc" -eq 0
 assert "--force --force removed the worktree directory" test ! -d "$path"
 
+# A single -f on a locked worktree should say who holds the lock and how to
+# override it, not leave the user to parse git's advice.
+path=$(mkworktree locked-hint)
+git -C "$REPO_DIR" worktree lock "$path" --reason '{"owner":"supacode"}'
+tree_me rm -f locked-hint
+assert "a locked refusal still fails" test "$rc" -ne 0
+assert "the hint names the lock holder" test "${out#*supacode}" != "$out"
+assert "the hint suggests doubling the flags given" test "${out#*-f -f locked-hint}" != "$out"
+
+path=$(mkworktree locked-hint-plain)
+git -C "$REPO_DIR" worktree lock "$path" --reason "test"
+tree_me rm locked-hint-plain
+assert "a locked refusal without -f fails" test "$rc" -ne 0
+assert "the hint suggests one -f when none were given" test "${out#*tree-me remove -f locked-hint-plain}" != "$out"
+
+# Locked wins over dirty: a locked worktree with uncommitted changes still
+# needs the doubling, so the hint must not talk about the changes instead.
+path=$(mkworktree locked-dirty)
+echo changed > "$path/file"
+git -C "$REPO_DIR" worktree lock "$path"
+tree_me rm -f locked-dirty
+assert "a locked dirty refusal fails" test "$rc" -ne 0
+assert "a locked dirty worktree gets the lock hint" test "${out#*-f -f locked-dirty}" != "$out"
+git -C "$REPO_DIR" worktree unlock "$path"
+tree_me rm -ff locked-dirty
+assert "-ff removes the unlocked dirty worktree" test "$rc" -eq 0
+
+# The hint reflects a pattern's target the same way.
+path=$(mkworktree "locked-batch")
+git -C "$REPO_DIR" worktree lock "$path"
+tree_me rm -f "locked-b*"
+assert "a locked pattern match fails" test "$rc" -ne 0
+assert "a locked pattern match gets the -f -f hint" test "${out#*-f -f locked-batch}" != "$out"
+git -C "$REPO_DIR" worktree unlock "$path"
+tree_me rm -ff "locked-b*"
+assert "-ff removes the pattern match" test "$rc" -eq 0
+
 # ── Test: the confirmation a pattern prompts for ───────────────────────────
 
 path_a=$(mkworktree "review-a")

--- a/bin/tree-me
+++ b/bin/tree-me
@@ -483,12 +483,37 @@ EOF
         # One match git refuses (locked, or dirty without -f) shouldn't strand
         # the rest of the batch unattempted, so report it and carry on, with
         # the final status reflecting that something was left behind.
+        force_display=""
+        if [ "$force" -gt 0 ]; then
+            for ((i = 0; i < force; i++)); do
+                force_display+="-f "
+            done
+        fi
+
+        # When git reports a locked worktree, quote who holds the lock so the
+        # user knows which tool would unlock it (Supacode, in the JSON case)
+        # and how to override the lock instead.
+        print_lock_hint() {
+            local output="$1" branch="$2" reason
+            reason=$(echo "$output" | sed -n 's/^fatal: cannot remove a locked working tree, lock reason: //p' | head -1)
+            if [ -n "$reason" ]; then
+                echo "ℹ '$branch' is locked ($reason). Unlock it where it was locked, or override the lock with:" >&2
+            else
+                echo "ℹ '$branch' is locked. Unlock it with 'git worktree unlock', or override the lock with:" >&2
+            fi
+            echo "    tree-me remove ${force_display}-f $branch" >&2
+        }
+
         failed=0
         for b in "${matches[@]}"; do
             path="${branch_to_path[$b]}"
-            if git worktree remove "${force_args[@]}" "$path"; then
+            if output=$(git worktree remove "${force_args[@]}" "$path" 2>&1); then
                 echo "✓ Removed worktree: $path"
             else
+                echo "$output" >&2
+                if [ "$force" -lt 2 ] && echo "$output" | grep -q "locked working tree"; then
+                    print_lock_hint "$output" "$b"
+                fi
                 echo "✗ Skipped worktree: $path" >&2
                 failed=1
             fi


### PR DESCRIPTION
## Problem

Removing a locked worktree with a single `-f` failed with git's terse advice buried in the error:

```
fatal: cannot remove a locked working tree, lock reason: {"build":"...","owner":"supacode",...}
use 'remove -f -f' to override or unlock first
✗ Skipped worktree: /path/to/worktree
```

The lock reason (which tool holds it, e.g. Supacode) was easy to miss, and nothing said who would unlock it or restated the fix as a runnable `tree-me` command.

## Change

When git refuses because the worktree is locked and fewer than two force flags were given, `tree-me remove` now quotes the lock reason and prints the command to override:

```
ℹ 'demo-lock' is locked ({"build":...,"owner":"supacode",...}). Unlock it where it was locked, or override the lock with:
    tree-me remove -f -f demo-lock
```

- The hint reuses the `-f` flags already given and adds one: a single `-f` yields `-f -f`, none yields `-f`.
- It names the branch, so it stays correct in pattern batches (`review-*`).
- Locked wins over dirty in the message: a locked-and-dirty worktree still needs the doubling, so it won't imply one `-f` is enough.
- With no lock reason, it falls back to suggesting `git worktree unlock`.

## Tests

`bin/lib/test-tree-me-remove.sh`: 54 passed (7 new) covering the hint output for a single `-f`, no `-f`, locked-and-dirty, and the pattern case. All other suites in `bin/lib/` still pass.