### PR TITLE
Default code comments to none and add a cleanup pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,22 +46,32 @@ Skills live in [`ai/skills/`](ai/skills). The installer symlinks the same direct
 | ------- | ------------ |
 | [`address-pr-reviews`](ai/skills/address-pr-reviews) | Evaluate unresolved PR review comments from any reviewer, fix legitimate issues, reply to dismissed ones. |
 | [`analyze-permissions`](ai/skills/analyze-permissions) | Analyze accumulated Claude Code permissions and suggest smart wildcard patterns. |
+| [`babysit-prs`](ai/skills/babysit-prs) | One sweep over every open PR: CI and merge-queue state, new review comments, fix and push. |
 | [`ci-monitor`](ai/skills/ci-monitor) | Monitor CI checks after pushing, distinguish flaky from real failures, auto-fix. |
+| [`comment-cleanup`](ai/skills/comment-cleanup) | Delete and tighten code comments after they are written, cutting the survivors to one fact each. |
 | [`commit`](ai/skills/commit) | Commit staged/unstaged changes with a well-crafted commit message. |
 | [`create-pr`](ai/skills/create-pr) | Create or update a GitHub PR with automatic template detection and filling. |
 | [`explain-open`](ai/skills/explain-open) | Explain open or skipped code-review items in plain English with impact analysis and a recommendation. |
-| [`go`](ai/skills/go) | Plan, implement, and iteratively review a task end to end using Claude plus Copilot reviewers. |
+| [`followup`](ai/skills/followup) | Capture a follow-up item mid-session, list open items, close one, or run a review pass. |
+| [`github-pr-operations`](ai/skills/github-pr-operations) | Reference for GitHub PR review endpoints and resolving review threads via `gh`. |
+| [`go`](ai/skills/go) | Plan, implement, and review a task end to end: review-code and ReviewHog in parallel, CI watched to green, open items explained. |
+| [`handoff`](ai/skills/handoff) | Write or resume a handoff document so the next agent session can pick up the current work. |
 | [`metabase-prod-query`](ai/skills/metabase-prod-query) | Guarded workflow for querying PostHog production Metabase via `hogli metabase:*`. |
 | [`note`](ai/skills/note) | Capture complex technical discoveries into structured, reusable notes. |
 | [`ops-report`](ai/skills/ops-report) | Generate a 24-hour operational health report for a PostHog service via Grafana and Prometheus. |
+| [`plain-writing`](ai/skills/plain-writing) | Write, rewrite, or review prose for other people in clear, direct English. |
+| [`posthog-context`](ai/skills/posthog-context) | PostHog repo workflow, database access rules, production architecture notes, SDK repository locations. |
+| [`quarterly-planning`](ai/skills/quarterly-planning) | Draft quarterly goals for a PostHog team, walking the HOGS framework from issues and strategy docs. |
 | [`resolve-conflicts`](ai/skills/resolve-conflicts) | Resolve git conflicts with mergiraf structural merging, lock file handling, stacked PR dedup. |
-| [`review-fix-cycle`](ai/skills/review-fix-cycle) | One review, fix, simplify, commit iteration. |
+| [`review-fix-cycle`](ai/skills/review-fix-cycle) | One review, fix, simplify, clean comments, commit iteration. |
 | [`sprint-planning`](ai/skills/sprint-planning) | Bi-weekly sprint planning updates for the Feature Flags Platform team. |
+| [`squash`](ai/skills/squash) | Squash each contributor's run of contiguous commits on the branch into one, preserving authorship. |
 | [`standup`](ai/skills/standup) | Generate standup notes from your recent GitHub PR activity. |
 | [`support`](ai/skills/support) | Support hero workflow: start ticket investigations, find prior notes, generate weekly highlights. |
 | [`test-plan`](ai/skills/test-plan) | Generate a manual test plan checklist focused on scenarios uncovered by existing tests. |
 | [`triage-issues`](ai/skills/triage-issues) | Identify unlabeled GitHub issues that may belong to a specific team. |
 | [`vault`](ai/skills/vault) | Operate the notes vault knowledge loop: ingest raw sources into interlinked wiki pages, lint vault health, consolidate duplicate pages, show the backlog. |
+| [`wait-for-pr-reviews`](ai/skills/wait-for-pr-reviews) | Wait for in-flight PR reviews, chaining address-pr-reviews before and after the wait. |
 
 The `squash` command lives at [`ai/commands/squash.md`](ai/commands/squash.md): squash developer commits on the current branch into one while preserving CI snapshot commits.
 
@@ -160,4 +170,4 @@ You don't need to install the whole thing. A few common shapes:
 - **Just `tree-me`**: copy `bin/tree-me` onto your `PATH` and add `source <(tree-me shellenv)` to your shell rc.
 - **Just the PR review scripts**: they depend on `bin/lib/*.sh` helpers; copy `bin/lib/` alongside whichever scripts you want.
 
-A handful of skills and scripts are PostHog-specific (`metabase-prod-query`, `ops-report`, `sprint-planning`, `kube-region`, `triage-feature-flags`). The rest are general.
+A handful of skills and scripts are PostHog-specific (`metabase-prod-query`, `ops-report`, `posthog-context`, `quarterly-planning`, `sprint-planning`, `kube-region`, `triage-feature-flags`). The rest are general.

--- a/ai/AGENTS.md
+++ b/ai/AGENTS.md
@@ -25,7 +25,7 @@ If arriving from an approved Plan Mode plan, invoke the `go` skill with `--plan-
 2. `unit-test-writer` writes tests first (red)
 3. Implement minimal code to pass (green)
 4. Refactor with tests passing
-5. Run `/simplify` to review changed code
+5. Run `/simplify` to review changed code, then `comment-cleanup` over the result
 6. `code-reviewer` before committing
 
 After 2 failed attempts, stop and use `bug-root-cause-analyzer`. Don't keep pushing a broken approach.
@@ -99,8 +99,8 @@ See the `posthog-context` skill for repo-specific workflow, full database access
 ## Style
 
 - Use actual ellipsis (…) instead of three dots (...) in user-facing messages.
-- Comments: default to none. The code already shows how it works, so comment only on what isn't obvious to a skilled reader: a constraint, a deliberate deviation, a gotcha, a workaround. Never narrate the code, restate a name or signature inline, or mark the end of a block. Concise prose with proper grammar.
-- Say what happens, not a phrase that stands for it. A phrase is a label when a reader who doesn't already know the mechanism can't say what changes state: "holds the batch" (holding does what to it?) against "the batch does not commit its offsets until the broker answers". Keep a term the codebase already uses in that sense; the test is whether you can find it there meaning the same thing. This rule sets the wording of a comment that "comment only on what isn't obvious" already justified; it never justifies one. A comment restating the line it sits on gets deleted, not expanded, and the ones that survive get one sentence and one fact.
+- Comments: default to none. The code already shows how it works, so comment only on what isn't obvious to a skilled reader: a constraint, a deliberate deviation, a gotcha, a workaround. Never narrate the code, restate a name or signature inline, or mark the end of a block. Hold each to one sentence carrying one fact, in concise prose with proper grammar; a doc comment may also carry the contract a caller cannot see. The `comment-cleanup` skill enforces this over comments that already exist.
+- Say what happens, not a phrase that stands for it. A phrase is a label when a reader who doesn't already know the mechanism can't say what changes state: "holds the batch" (holding does what to it?) against "the batch does not commit its offsets until the broker answers". Keep a term the codebase already uses in that sense; the test is whether you can find it there meaning the same thing. This sets the wording of a comment the rule above already justified; it never justifies one.
 - Describe final state, not the journey. Comments, commit messages, and PR descriptions say what the code does now, not what it replaced. Write "Uses a LEFT JOIN to fetch users with their orders", not "Combined two queries into one LEFT JOIN".
 
 ## Communication

--- a/ai/AGENTS.md
+++ b/ai/AGENTS.md
@@ -99,8 +99,8 @@ See the `posthog-context` skill for repo-specific workflow, full database access
 ## Style
 
 - Use actual ellipsis (…) instead of three dots (...) in user-facing messages.
-- Comments: concise prose with proper grammar. Comment only on what isn't obvious to a skilled reader.
-- Say what happens, not a phrase that stands for it. A phrase is a label when a reader who doesn't already know the mechanism can't say what changes state: "holds the batch" (holding does what to it?) against "the batch does not commit its offsets until the broker answers". Keep a term the codebase already uses in that sense; the test is whether you can find it there meaning the same thing.
+- Comments: default to none. The code already shows how it works, so comment only on what isn't obvious to a skilled reader: a constraint, a deliberate deviation, a gotcha, a workaround. Never narrate the code, restate a name or signature inline, or mark the end of a block. Concise prose with proper grammar.
+- Say what happens, not a phrase that stands for it. A phrase is a label when a reader who doesn't already know the mechanism can't say what changes state: "holds the batch" (holding does what to it?) against "the batch does not commit its offsets until the broker answers". Keep a term the codebase already uses in that sense; the test is whether you can find it there meaning the same thing. This rule sets the wording of a comment that "comment only on what isn't obvious" already justified; it never justifies one. A comment restating the line it sits on gets deleted, not expanded, and the ones that survive get one sentence and one fact.
 - Describe final state, not the journey. Comments, commit messages, and PR descriptions say what the code does now, not what it replaced. Write "Uses a LEFT JOIN to fetch users with their orders", not "Combined two queries into one LEFT JOIN".
 
 ## Communication

--- a/ai/skills/address-pr-reviews/SKILL.md
+++ b/ai/skills/address-pr-reviews/SKILL.md
@@ -119,7 +119,7 @@ With user confirmation:
 
 1. Show a summary: N comments fixed, M comments dismissed
 2. **Present drafted replies to human reviewers for the user to post.** For each not-legit comment from a human reviewer, show the file:line, the comment quote, and your drafted reply. Write each reply to a file so it survives quotes and newlines, then give the user the exact command to post it — the same replies endpoint as Step 4, with `-F body=@<reply-file>` in place of `-f body=`. The user reviews each reply and posts the ones they approve.
-3. If any files were changed, ask the user if they want to commit and push:
+3. If any files were changed, run `Skill("comment-cleanup")` over the uncommitted diff first, so the fixes don't ship the over-commenting they were written with, and report anything it hands back for the user's call with the summary. Then ask the user if they want to commit and push:
    - Commit message: "Address PR review feedback"
    - Push to the current branch
    - Under `--no-push`, commit but don't push — tell the user the invoker owns the push

--- a/ai/skills/address-pr-reviews/SKILL.md
+++ b/ai/skills/address-pr-reviews/SKILL.md
@@ -119,10 +119,11 @@ With user confirmation:
 
 1. Show a summary: N comments fixed, M comments dismissed
 2. **Present drafted replies to human reviewers for the user to post.** For each not-legit comment from a human reviewer, show the file:line, the comment quote, and your drafted reply. Write each reply to a file so it survives quotes and newlines, then give the user the exact command to post it — the same replies endpoint as Step 4, with `-F body=@<reply-file>` in place of `-f body=`. The user reviews each reply and posts the ones they approve.
-3. If any files were changed, run `Skill("comment-cleanup")` over the uncommitted diff first, so the fixes don't ship the over-commenting they were written with, and report anything it hands back for the user's call with the summary. Then ask the user if they want to commit and push:
+3. If any files were changed, invoke the `comment-cleanup` skill over those files, so the fixes don't ship the over-commenting they were written with, then `git add` each one again so its edits reach the commit. Naming the files keeps the pass off unrelated work the checkout was already carrying. Report anything it hands back for the user's call with the summary. Then ask the user if they want to commit and push:
    - Commit message: "Address PR review feedback"
    - Push to the current branch
    - Under `--no-push`, commit but don't push — tell the user the invoker owns the push
+   - After the commit lands, append one `### Held comment:` block per held item to `.notes/review-skipped.md`, in the format `review-fix-cycle` Step 7a uses. An unattended `babysit-prs` sweep has no one watching the summary, and `explain-open` reads that file.
 4. Record each dismissed comment in the shared state file so future runs filter it out. Extract the body from the Step 2 file with jq — never retype or paste it yourself; a single altered byte changes the hash and breaks the dedup — and pipe it into the record script:
 
 ```bash

--- a/ai/skills/comment-cleanup/SKILL.md
+++ b/ai/skills/comment-cleanup/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: comment-cleanup
 description: Delete and tighten code comments in source files after they are written. Drops narration, restatement, and change-log comments, then cuts the survivors to one fact each. Use when the user says the comments are too wordy, asks to clean up or trim comments, or right after generating code that came out over-commented. Not for PR descriptions, review comments, or other prose; use plain-writing for those.
-argument-hint: "[<path>…] [--staged|--branch] [--all] [--report]"
+argument-hint: "[<path>…] [--branch] [--parent <ref>] [--all] [--dry-run]"
 model: sonnet
 metadata:
   execution-tier: balanced
@@ -15,21 +15,28 @@ The standard is the Style section of `AGENTS.md`. The code shows how it works, s
 
 ## Reading the Arguments
 
-- `paths` = any non-flag arguments. Given, they replace the default scope, and every comment in them is in scope.
-- `--staged` scopes to the staged diff. `--branch` scopes to commits since the merge-base with the default branch.
-- With no path and no scope flag, the scope is the working-tree diff plus commits since the merge-base with the default branch.
-- `--all` widens a diff scope from comments the diff touched to every comment in the files the diff touched.
-- `--report` prints the decisions and changes nothing.
+- With no arguments, the scope is the uncommitted working-tree diff, staged and unstaged both (`git diff HEAD`). That is the work just done, which is what the pipelines that call this skill mean by "the changes just made".
+- `paths` = any non-flag arguments. Given, they replace that scope, and every comment in those files is in scope.
+- `--branch` widens to every commit on this branch. Resolve the base with the repo's stack-aware helper rather than assuming the default branch, so a stacked branch does not pull in the parent PR's commits:
 
-Never widen past the requested scope. A comment nobody touched is someone else's judgment call, and rewriting it buries the real change in noise.
+```bash
+eval "$(bash "$HOME/.dotfiles/bin/lib/git-pr-base.sh")"   # append --parent <ref> if the user passed one
+git diff "$REF"...HEAD
+```
+
+  If the helper is unavailable or leaves `REF` empty, say so and stop rather than falling back to a guess. Report `NOTES` to the user when it is non-empty.
+
+- `--parent <ref>` overrides the base the helper picks. Only meaningful with `--branch`.
+- `--all` widens a diff scope from the comments the diff touched to every comment in the files it touched. It changes nothing when explicit paths were given, since those are already whole files.
+- `--dry-run` prints the decisions and changes nothing.
+
+Never widen past the requested scope. Outside `--all` and explicit paths, a comment the diff did not touch is someone else's judgment call.
 
 ## Steps
 
 ### 1. Collect the comments
 
-Read the files in scope. For each comment, note its file, line, text, and whether it is a **doc comment** (the language's documented position and format on a declaration: godoc, JSDoc, rustdoc, XML doc, a Python docstring) or an **inline comment** (everything else, including a block comment sitting above a statement inside a function).
-
-The two kinds have different standards. Doc comments are API surface that tooling consumes and readers reach for without opening the file. Inline comments are the ones that accumulate.
+Read the diff hunks for the scope. Under a diff scope the hunk carries the comment and the code it sits next to, which is all the delete rules need; read the whole file only when a comment's fate turns on something further away, and always under `--all` or an explicit path.
 
 ### 2. Leave these alone
 
@@ -41,32 +48,41 @@ These are code wearing a comment's syntax, and deleting one changes behavior:
 - `TODO`/`FIXME`/`HACK` markers that name an issue, ticket, or owner. One with no reference is a normal comment; judge it on its content.
 - Commented-out code. Report it, do not delete it. Whether it is dead or parked is the author's call.
 
-### 3. Decide each remaining comment
+### 3. Hold doc comments to their own standard
 
-First match wins.
+A doc comment is the language's documented form on a declaration: godoc, JSDoc, rustdoc, XML doc, a Python docstring. It is API surface that tooling renders and callers read without opening the file, so restating the signature is its job, and the delete rules in Step 4 do not apply to it.
 
-1. **Restates its line.** The comment says what the code next to it already says, at the same level of detail (`// increment the counter` over `counter += 1`; `// loop over users`; `// parse the body`). Delete. This is the largest category by far.
-2. **Restates a name, type, or signature.** An inline comment repeating what the declaration on the next line spells out. Delete. A doc comment does this legitimately; leave it to rule 7.
-3. **Narrates the change.** `fixed X`, `updated to Y`, `now uses Z`, `as requested`, `changed from the old approach`. Delete, or if the comment carries a fact worth keeping, rewrite it as final state per the Style rule: what the code does now, never what it replaced.
-4. **Leaks reasoning.** The model's own working shown to the reader: `we need to be careful here`, `this is important because`, a recap of an alternative that was considered and dropped. Delete. A constraint that ruled the alternative out can survive as one sentence if a reader would otherwise reintroduce the bug.
-5. **Marks structure.** End-of-block markers, section banners, `// helpers below`, a header restating the function it opens. Delete.
-6. **Contradicts the code.** Stale, describing behavior that is no longer there. Fix it if the correct fact is clear from the code; delete it if not. A stale comment is worse than none.
-7. **Earns its place but sprawls.** Multi-sentence rationale, a paragraph where a clause does, or a mechanism spelled out that the line itself already shows. Cut to the single non-obvious fact a reader needs at that line, in one sentence. For a doc comment, cut to a one-line summary plus whatever contract the caller cannot see: raised errors, units, nullability, ordering, thread safety.
-8. **Reads as a label.** A compact phrase standing in for a mechanism, where a reader who does not already know it cannot say what changes state. Expand it to what happens, in one sentence, per the Style rule. This is the one case that gets longer, and only after the comment has survived rules 1 through 7.
-9. **Uncertain.** Keep it, unchanged.
+Cut it to a one-line summary plus the contract a caller cannot see: raised errors, units, nullability, ordering, thread safety. Delete nothing a linter or a doc build requires, and never trade a doc comment for silence just because the name reads clearly.
 
-Rule 9 is deliberately asymmetric. A redundant comment left in place costs a reader two seconds. A deleted warning costs someone an outage. When you cannot tell whether a comment encodes a real constraint, it does.
+### 4. Decide each inline comment
 
-### 4. Apply and report
+Everything Step 2 and Step 3 did not claim. Take the first rule that **clearly** matches.
 
-Under `--report`, print the table and stop. Otherwise make the edits, then print it:
+Clearly is the operative word, and it governs every rule below rather than waiting at the end as a last resort. When you cannot tell whether a rule matches, none of them do, and the comment stays exactly as written. A redundant comment costs a reader seconds; a deleted warning costs an outage. Where a comment might encode a real constraint, assume it does.
+
+1. **Restates the code next to it.** The comment says what the adjacent line already says, at the same level of detail (`// increment the counter` over `counter += 1`; `// loop over users`), or repeats the name, type, or signature it sits above. Delete. This is the largest category by far.
+2. **Narrates the change.** `fixed X`, `updated to Y`, `now uses Z`, `as requested`, `changed from the old approach`. Delete, or if it carries a fact worth keeping, rewrite as final state per the Style rule: what the code does now, never what it replaced.
+3. **Leaks reasoning.** The model's own working shown to the reader: `we need to be careful here`, `this is important because`, a recap of an alternative that was considered and dropped. Delete. A constraint that ruled the alternative out can survive as one sentence if a reader would otherwise reintroduce the bug.
+4. **Marks structure.** End-of-block markers, section banners, `// helpers below`, a header restating the function it opens. Delete.
+5. **Contradicts the code.** Stale, describing behavior that is no longer there. Fix it if the correct fact is clear from the code; delete it if not. A stale comment is worse than none.
+6. **Earns its place but sprawls.** Multi-sentence rationale, a paragraph where a clause does, or a mechanism spelled out that the adjacent line already shows. Cut to the single non-obvious fact a reader needs at that line, in one sentence.
+7. **Reads as a label.** A compact phrase standing in for a mechanism, where a reader who does not already know it cannot say what changes state. Expand it to what happens, in one sentence, per the Style rule. This is the one rule that makes a comment longer, and it fires only when rules 1 through 6 have all missed.
+
+Rules 1 and 7 divide on one question: can a reader work the fact out from the code in front of them? `// holds the batch` over `self.pending.append(batch)` is rule 1, because the line says it. The same phrase over `flush_deadline = None` is rule 7, because nothing nearby says what holding does to the batch.
+
+### 5. Apply and report
+
+Under `--dry-run`, print the report and stop. Otherwise make the edits, then print it.
+
+List only what changed, so the report stays proportional to the edits rather than to the comments read:
 
 | File:line | Was | Action | Why |
 | --- | --- | --- | --- |
 | `sync.py:42` | `# increment the counter` | deleted | restates its line |
-| `queue.go:88` | `// holds the batch` | rewrote | label, expanded to what happens |
-| `api.ts:15` | `// retry twice, the gateway 502s on cold start` | kept | non-obvious constraint |
+| `queue.go:88` | `// holds the batch` | rewrote | label over unrelated state, expanded |
 
-Then a count: deleted, rewrote, kept. List commented-out code and anything rule 9 held separately, so the author can rule on it.
+Then one count line: deleted, rewrote, kept.
+
+Then, separately, the items the author has to rule on: comments a rule nearly matched but not clearly, and the commented-out code from Step 2. A caller that persists anything persists this list, so keep it short and name the file and line for each.
 
 Do not commit. Do not touch code that is not a comment. If a comment can only be fixed by changing the code it describes, say so in the report and leave both alone.

--- a/ai/skills/comment-cleanup/SKILL.md
+++ b/ai/skills/comment-cleanup/SKILL.md
@@ -15,9 +15,9 @@ The standard is the Style section of `AGENTS.md`. The code shows how it works, s
 
 ## Reading the Arguments
 
-- With no arguments, the scope is the uncommitted working-tree diff, staged and unstaged both (`git diff HEAD`). That is the work just done, which is what the pipelines that call this skill mean by "the changes just made".
+- With no arguments, the scope is the uncommitted work: the tracked-file diff (`git diff HEAD`, staged and unstaged both) plus every path `git ls-files --others --exclude-standard` reports. `git diff HEAD` never lists an untracked file, and a file created during this work has no hunk to scope to, so treat each one as an explicit path and put every comment in it in scope. That is the work just done, which is what the pipelines that call this skill mean by "the changes just made".
 - `paths` = any non-flag arguments. Given, they replace that scope, and every comment in those files is in scope.
-- `--branch` widens to every commit on this branch. Resolve the base with the repo's stack-aware helper rather than assuming the default branch, so a stacked branch does not pull in the parent PR's commits:
+- `--branch` covers every commit on this branch, and only committed work; run with no arguments for the working tree. Resolve the base with the repo's stack-aware helper rather than assuming the default branch, so a stacked branch does not pull in the parent PR's commits:
 
 ```bash
 eval "$(bash "$HOME/.dotfiles/bin/lib/git-pr-base.sh")"   # append --parent <ref> if the user passed one
@@ -38,15 +38,24 @@ Never widen past the requested scope. Outside `--all` and explicit paths, a comm
 
 Read the diff hunks for the scope. Under a diff scope the hunk carries the comment and the code it sits next to, which is all the delete rules need; read the whole file only when a comment's fate turns on something further away, and always under `--all` or an explicit path.
 
+Stat the diff first, so a regenerated lock file does not fill the context before Step 2 rules it out as generated:
+
+```bash
+git diff HEAD --stat -- . ':(exclude)*.lock' ':(exclude)*-lock.*' ':(exclude)package-lock.json'
+```
+
+Under about 200 changed lines, read the whole diff. Above it, read the changed files one at a time with `git diff HEAD -- <path>`, carrying the same pathspec.
+
 ### 2. Leave these alone
 
-These are code wearing a comment's syntax, and deleting one changes behavior:
+These are code wearing a comment's syntax, or a warning the next editor needs to keep the code correct:
 
 - Lint and compiler directives: `# noqa`, `# type: ignore`, `eslint-disable`, `// nolint`, `#pragma`, `@ts-expect-error`, `SPDX-License-Identifier`.
 - Shebangs, encoding declarations, build tags, and file-level license or copyright headers.
 - Anything inside a generated file, plus the header that marks it generated.
 - `TODO`/`FIXME`/`HACK` markers that name an issue, ticket, or owner. One with no reference is a normal comment; judge it on its content.
 - Commented-out code. Report it, do not delete it. Whether it is dead or parked is the author's call.
+- Safety and security invariants: a `// SAFETY:` block over an `unsafe` block, a "must stay constant-time" or "never log this value" warning. Keep every invariant it lists, and do not read one that repeats an identifier on its line as restatement; neither the Step 4 rules nor the one-sentence cap applies.
 
 ### 3. Hold doc comments to their own standard
 

--- a/ai/skills/comment-cleanup/SKILL.md
+++ b/ai/skills/comment-cleanup/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: comment-cleanup
+description: Delete and tighten code comments in source files after they are written. Drops narration, restatement, and change-log comments, then cuts the survivors to one fact each. Use when the user says the comments are too wordy, asks to clean up or trim comments, or right after generating code that came out over-commented. Not for PR descriptions, review comments, or other prose; use plain-writing for those.
+argument-hint: "[<path>…] [--staged|--branch] [--all] [--report]"
+model: sonnet
+metadata:
+  execution-tier: balanced
+---
+
+# Comment Cleanup
+
+Authoring-time rules do not hold on their own; a model that just worked out a mechanism reliably over-explains it. This is the pass that runs afterward, over comments that already exist.
+
+The standard is the Style section of `AGENTS.md`. The code shows how it works, so a comment earns its place only by carrying what the code cannot: a constraint, a deliberate deviation, a gotcha, a workaround. This skill enforces that by deleting, not by rewriting everything it finds.
+
+## Reading the Arguments
+
+- `paths` = any non-flag arguments. Given, they replace the default scope, and every comment in them is in scope.
+- `--staged` scopes to the staged diff. `--branch` scopes to commits since the merge-base with the default branch.
+- With no path and no scope flag, the scope is the working-tree diff plus commits since the merge-base with the default branch.
+- `--all` widens a diff scope from comments the diff touched to every comment in the files the diff touched.
+- `--report` prints the decisions and changes nothing.
+
+Never widen past the requested scope. A comment nobody touched is someone else's judgment call, and rewriting it buries the real change in noise.
+
+## Steps
+
+### 1. Collect the comments
+
+Read the files in scope. For each comment, note its file, line, text, and whether it is a **doc comment** (the language's documented position and format on a declaration: godoc, JSDoc, rustdoc, XML doc, a Python docstring) or an **inline comment** (everything else, including a block comment sitting above a statement inside a function).
+
+The two kinds have different standards. Doc comments are API surface that tooling consumes and readers reach for without opening the file. Inline comments are the ones that accumulate.
+
+### 2. Leave these alone
+
+These are code wearing a comment's syntax, and deleting one changes behavior:
+
+- Lint and compiler directives: `# noqa`, `# type: ignore`, `eslint-disable`, `// nolint`, `#pragma`, `@ts-expect-error`, `SPDX-License-Identifier`.
+- Shebangs, encoding declarations, build tags, and file-level license or copyright headers.
+- Anything inside a generated file, plus the header that marks it generated.
+- `TODO`/`FIXME`/`HACK` markers that name an issue, ticket, or owner. One with no reference is a normal comment; judge it on its content.
+- Commented-out code. Report it, do not delete it. Whether it is dead or parked is the author's call.
+
+### 3. Decide each remaining comment
+
+First match wins.
+
+1. **Restates its line.** The comment says what the code next to it already says, at the same level of detail (`// increment the counter` over `counter += 1`; `// loop over users`; `// parse the body`). Delete. This is the largest category by far.
+2. **Restates a name, type, or signature.** An inline comment repeating what the declaration on the next line spells out. Delete. A doc comment does this legitimately; leave it to rule 7.
+3. **Narrates the change.** `fixed X`, `updated to Y`, `now uses Z`, `as requested`, `changed from the old approach`. Delete, or if the comment carries a fact worth keeping, rewrite it as final state per the Style rule: what the code does now, never what it replaced.
+4. **Leaks reasoning.** The model's own working shown to the reader: `we need to be careful here`, `this is important because`, a recap of an alternative that was considered and dropped. Delete. A constraint that ruled the alternative out can survive as one sentence if a reader would otherwise reintroduce the bug.
+5. **Marks structure.** End-of-block markers, section banners, `// helpers below`, a header restating the function it opens. Delete.
+6. **Contradicts the code.** Stale, describing behavior that is no longer there. Fix it if the correct fact is clear from the code; delete it if not. A stale comment is worse than none.
+7. **Earns its place but sprawls.** Multi-sentence rationale, a paragraph where a clause does, or a mechanism spelled out that the line itself already shows. Cut to the single non-obvious fact a reader needs at that line, in one sentence. For a doc comment, cut to a one-line summary plus whatever contract the caller cannot see: raised errors, units, nullability, ordering, thread safety.
+8. **Reads as a label.** A compact phrase standing in for a mechanism, where a reader who does not already know it cannot say what changes state. Expand it to what happens, in one sentence, per the Style rule. This is the one case that gets longer, and only after the comment has survived rules 1 through 7.
+9. **Uncertain.** Keep it, unchanged.
+
+Rule 9 is deliberately asymmetric. A redundant comment left in place costs a reader two seconds. A deleted warning costs someone an outage. When you cannot tell whether a comment encodes a real constraint, it does.
+
+### 4. Apply and report
+
+Under `--report`, print the table and stop. Otherwise make the edits, then print it:
+
+| File:line | Was | Action | Why |
+| --- | --- | --- | --- |
+| `sync.py:42` | `# increment the counter` | deleted | restates its line |
+| `queue.go:88` | `// holds the batch` | rewrote | label, expanded to what happens |
+| `api.ts:15` | `// retry twice, the gateway 502s on cold start` | kept | non-obvious constraint |
+
+Then a count: deleted, rewrote, kept. List commented-out code and anything rule 9 held separately, so the author can rule on it.
+
+Do not commit. Do not touch code that is not a comment. If a comment can only be fixed by changing the code it describes, say so in the report and leave both alone.

--- a/ai/skills/go/SKILL.md
+++ b/ai/skills/go/SKILL.md
@@ -201,7 +201,7 @@ Skill("comment-cleanup")
 
 It defaults to the uncommitted diff, which is exactly the work this step is about to commit. Append the items it hands back for the author's call, one line each with file and line, under a `## Held comments` section at the end of the state file, so Step 11 still has them after a compaction or a resume.
 
-Steps 8 through 10 commit without these two passes. That is deliberate: the quality passes attach to the implementation commit, and review-driven edits get their own reviewers.
+Step 8 runs `comment-cleanup` over its own fixes, and `address-pr-reviews` runs it over the fixes it makes in Step 9. Step 10 does not, deliberately: `ci-monitor`'s `allowed-tools` fence excludes `Skill` because it reads untrusted CI logs, and widening that fence to tidy comments on a CI hotfix is the wrong trade. `/simplify` still runs only here.
 
 Then commit. Use a message that matches the situation:
 
@@ -259,6 +259,14 @@ Skill("review-code", args: "<pr-url> --fix")
 Its Fix Summary lists what was fixed, what needs a judgment call, and what it declined to fix — keep that in reach: Step 9 compares it against ReviewHog's round and Step 11 explains the open items.
 
 Run the test suite before committing — reviewer-driven fixes break code like any other change. A failure the fixes introduced means fixing the fix, not skipping the test.
+
+Then clean the comments those fixes introduced, over the uncommitted diff:
+
+```text
+Skill("comment-cleanup")
+```
+
+Append anything it hands back for the author's call to the state file's `## Held comments` section, the same way Step 5 does.
 
 Then commit the fixes but **don't push** — `wait-for-pr-reviews` owns the single push at the end of Step 9 (ReviewHog never retriggers on pushes, but other reviewers watching the PR can):
 

--- a/ai/skills/go/SKILL.md
+++ b/ai/skills/go/SKILL.md
@@ -326,7 +326,7 @@ Gather every loose end the run accumulated: prompt-optimizer suggestions Step 4 
 Skill("explain-open", args: "<pr-url>")
 ```
 
-It translates each open or skipped item into plain English, weighs both sides, and recommends a call — this is the part of the report that needs the user's judgment, so lead with it. explain-open reads the saved review artifacts, not the state file, so present the declined prompt suggestions yourself in that same lead section, one line each with the recorded reason. Offer to capture any items the user wants to keep for later as `/followup` entries.
+It translates each open or skipped item into plain English, weighs both sides, and recommends a call — this is the part of the report that needs the user's judgment, so lead with it. explain-open reads the saved review artifacts, not the state file, so present the declined prompt suggestions and the `## Held comments` entries yourself in that same lead section, one line each with the recorded reason. Offer to capture any items the user wants to keep for later as `/followup` entries.
 
 Then report the rest:
 

--- a/ai/skills/go/SKILL.md
+++ b/ai/skills/go/SKILL.md
@@ -88,7 +88,7 @@ When the branch has no upstream, `@{u}` yields nothing — count branch commits 
 | --- | --- | --- |
 | plan | `plan:` recorded, or `implement` is done | never |
 | implement | entry present | never |
-| simplify-commit | sha recorded and the tree is clean | tree is dirty — new work needs simplify + commit |
+| simplify-commit | sha recorded and the tree is clean | tree is dirty — new work needs the quality passes + commit |
 | pr | number recorded, or an open PR exists on the branch | PR closed or merged → report it and stop; this branch is finished |
 | reviewhog-requested | sha recorded or `skipped`, or the `reviewhog` label is on the PR right now (a round is in flight) | HEAD has moved since the request and no round is in flight — label present wins over HEAD-moved; never re-request into a running round. One label add buys one round at one head, so new commits need a fresh add |
 | review-code | sha equals current HEAD | HEAD has moved since the last pass |
@@ -189,7 +189,7 @@ Then run the suite. A test that still fails points at an implementation gap: fix
 
 Append `- implement: done` to the state file.
 
-### Step 5: Simplify and commit
+### Step 5: Quality passes and commit
 
 Invoke `/simplify` (bundled Claude slash command — not a skill). It applies its own fixes. Note anything it flags but declines to change — those items feed the explain-open wrap-up in Step 11. If a Step 2 test-gap dispatch is outstanding, collect it now so the tests ride this commit.
 
@@ -199,7 +199,9 @@ Then clean the comments over the same changes:
 Skill("comment-cleanup")
 ```
 
-It runs after `/simplify` so it judges the code in its final shape, and before the commit so its deletions ride the same one. Anything it holds under its uncertain rule, or reports as commented-out code, is the author's call rather than a fix to apply; those feed the Step 11 wrap-up too.
+It defaults to the uncommitted diff, which is exactly the work this step is about to commit. Append the items it hands back for the author's call, one line each with file and line, under a `## Held comments` section at the end of the state file, so Step 11 still has them after a compaction or a resume.
+
+Steps 8 through 10 commit without these two passes. That is deliberate: the quality passes attach to the implementation commit, and review-driven edits get their own reviewers.
 
 Then commit. Use a message that matches the situation:
 
@@ -310,7 +312,7 @@ It watches the PR's checks, reruns flaky failures, and fixes legit ones — comm
 
 ### Step 11: Explain open items and report
 
-Gather every loose end the run accumulated: prompt-optimizer suggestions Step 4 declined (under `## Declined prompt suggestions` in the state file), items `/simplify` flagged but didn't change, `review-code` Fix Summary items needing judgment or declined, entries in `.notes/review-skipped.md` (written only by older `review-fix-cycle` runs — usually absent), code comments `comment-cleanup` held under its uncertain rule or reported as commented-out code, and comments `address-pr-reviews` held for the user rather than acting on. Then have them explained, passing the PR URL so it reads the saved review artifacts rather than relying on this conversation — a long run may have compacted the review out of context:
+Gather every loose end the run accumulated: prompt-optimizer suggestions Step 4 declined (under `## Declined prompt suggestions` in the state file), items `/simplify` flagged but didn't change, `review-code` Fix Summary items needing judgment or declined, entries in `.notes/review-skipped.md` (written only by older `review-fix-cycle` runs — usually absent), the `## Held comments` section of the state file, and comments `address-pr-reviews` held for the user rather than acting on. Then have them explained, passing the PR URL so it reads the saved review artifacts rather than relying on this conversation — a long run may have compacted the review out of context:
 
 ```text
 Skill("explain-open", args: "<pr-url>")

--- a/ai/skills/go/SKILL.md
+++ b/ai/skills/go/SKILL.md
@@ -193,6 +193,14 @@ Append `- implement: done` to the state file.
 
 Invoke `/simplify` (bundled Claude slash command — not a skill). It applies its own fixes. Note anything it flags but declines to change — those items feed the explain-open wrap-up in Step 11. If a Step 2 test-gap dispatch is outstanding, collect it now so the tests ride this commit.
 
+Then clean the comments over the same changes:
+
+```text
+Skill("comment-cleanup")
+```
+
+It runs after `/simplify` so it judges the code in its final shape, and before the commit so its deletions ride the same one. Anything it holds under its uncertain rule, or reports as commented-out code, is the author's call rather than a fix to apply; those feed the Step 11 wrap-up too.
+
 Then commit. Use a message that matches the situation:
 
 - If this run produced a fresh implementation in Step 4: `"Implement $SLUG"`
@@ -202,7 +210,7 @@ Then commit. Use a message that matches the situation:
 Skill("commit", args: "--force <message>")
 ```
 
-Append `- simplify-commit: <short HEAD sha>` to the state file — also when `/simplify` made no changes and there was nothing to commit, so the step doesn't rerun.
+Append `- simplify-commit: <short HEAD sha>` to the state file — also when `/simplify` and `comment-cleanup` made no changes and there was nothing to commit, so the step doesn't rerun.
 
 ### Step 6: Open a draft PR (if needed)
 
@@ -302,7 +310,7 @@ It watches the PR's checks, reruns flaky failures, and fixes legit ones — comm
 
 ### Step 11: Explain open items and report
 
-Gather every loose end the run accumulated: prompt-optimizer suggestions Step 4 declined (under `## Declined prompt suggestions` in the state file), items `/simplify` flagged but didn't change, `review-code` Fix Summary items needing judgment or declined, entries in `.notes/review-skipped.md` (written only by older `review-fix-cycle` runs — usually absent), and comments `address-pr-reviews` held for the user rather than acting on. Then have them explained, passing the PR URL so it reads the saved review artifacts rather than relying on this conversation — a long run may have compacted the review out of context:
+Gather every loose end the run accumulated: prompt-optimizer suggestions Step 4 declined (under `## Declined prompt suggestions` in the state file), items `/simplify` flagged but didn't change, `review-code` Fix Summary items needing judgment or declined, entries in `.notes/review-skipped.md` (written only by older `review-fix-cycle` runs — usually absent), code comments `comment-cleanup` held under its uncertain rule or reported as commented-out code, and comments `address-pr-reviews` held for the user rather than acting on. Then have them explained, passing the PR URL so it reads the saved review artifacts rather than relying on this conversation — a long run may have compacted the review out of context:
 
 ```text
 Skill("explain-open", args: "<pr-url>")

--- a/ai/skills/review-fix-cycle/SKILL.md
+++ b/ai/skills/review-fix-cycle/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: review-fix-cycle
-description: Run one review-fix iteration — review code, fix findings, simplify, and commit.
+description: Run one review-fix iteration — review code, fix findings, simplify, clean comments, and commit.
 compatibility: Designed for Claude Code (or similar products)
 argument-hint: "[<review-target>] [--iteration N]"
 model: sonnet

--- a/ai/skills/review-fix-cycle/SKILL.md
+++ b/ai/skills/review-fix-cycle/SKILL.md
@@ -127,7 +127,7 @@ Then clean the comments on the result:
 Skill("comment-cleanup")
 ```
 
-It runs second so it judges the code in its final shape, and before Step 7 so its deletions ride the same commit. Report anything it holds under its uncertain rule, or flags as commented-out code, in the cycle output. Those are the author's call, not a fix to apply.
+It defaults to the uncommitted diff, so a looped iteration cleans that iteration's fixes rather than re-deciding the whole branch every pass. Carry the items it hands back for the author's call into Step 7a; terminal output does not survive a fresh-context iteration.
 
 ### Step 7: Commit
 
@@ -141,7 +141,7 @@ Skill("commit", args: "--force Address review feedback (iteration $N)")
 
 After the commit, append any skipped findings to `.notes/review-skipped.md`. Writing after the commit ensures the log file is never accidentally staged alongside the code changes.
 
-For each skipped finding noted in Step 5, append:
+For each skipped finding noted in Step 5, and each comment Step 6 handed back for the author's call, append:
 
 ```markdown
 ## Iteration $N — $DATE
@@ -149,6 +149,10 @@ For each skipped finding noted in Step 5, append:
 ### Skipped: $FINDING_TITLE
 **Reason:** $WHY_SKIPPED
 **Source:** $AGENT_NAME, `$FILE:$LINE`
+
+### Held comment: `$FILE:$LINE`
+**Reason:** $WHY_HELD
+**Source:** comment-cleanup
 ```
 
 Use append mode (do not overwrite previous iterations).

--- a/ai/skills/review-fix-cycle/SKILL.md
+++ b/ai/skills/review-fix-cycle/SKILL.md
@@ -121,6 +121,14 @@ Skill("simplify")
 
 Apply any improvements it suggests.
 
+Then clean the comments on the result:
+
+```
+Skill("comment-cleanup")
+```
+
+It runs second so it judges the code in its final shape, and before Step 7 so its deletions ride the same commit. Report anything it holds under its uncertain rule, or flags as commented-out code, in the cycle output. Those are the author's call, not a fix to apply.
+
 ### Step 7: Commit
 
 Invoke the commit skill with force mode:

--- a/ai/tests/test-skill-spec.sh
+++ b/ai/tests/test-skill-spec.sh
@@ -3,12 +3,14 @@
 # directory name must equal the frontmatter `name`, description must be 1-1024
 # characters, and frontmatter may only use spec keys (name, description, license,
 # compatibility, metadata, allowed-tools) plus this repo's own Claude extensions
-# (argument-hint, model, color).
+# (argument-hint, model, color). Also checks that each skill has a row in the
+# README table.
 set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SKILLS_DIR="$(cd "${SCRIPT_DIR}/../skills" && pwd)"
 EXCLUSIONS="${SCRIPT_DIR}/../codex/excluded-skills.txt"
+README="$(cd "${SCRIPT_DIR}/../.." && pwd)/README.md"
 
 passes=0
 failures=0
@@ -25,6 +27,12 @@ for skill_dir in "$SKILLS_DIR"/*; do
 	skill_name=$(basename "$skill_dir")
 	skill_file="$skill_dir/SKILL.md"
 	problems=""
+
+	# The table is hand-maintained, so a new skill drops off it silently.
+	readme_link=$(printf '[`%s`](ai/skills/%s)' "$skill_name" "$skill_name")
+	if ! grep -Fq "$readme_link" "$README"; then
+		problems+="  no row in the README skill table"$'\n'
+	fi
 
 	if [[ ! -f "$skill_file" ]]; then
 		problems+="  missing SKILL.md"$'\n'


### PR DESCRIPTION
Opus 5 writes comments that restate the line they sit on. The Style rules in `AGENTS.md` had a gate ("comment only on what isn't obvious") but no baseline and no length bound, and the naming rule added in 54e5a33 read as license to expand every comment into a sentence naming the mechanism.

Three changes:

- The gate bullet starts from none, lists what earns a comment, and caps each at one sentence carrying one fact, with doc comments allowed the contract a caller cannot see. The naming rule now only sets the wording of a comment the gate already justified.
- A new `comment-cleanup` skill runs over comments that already exist. Doc comments are decided before the delete rules, since godoc and JSDoc legitimately restate the signature an inline comment must not. Seven rules then decide each inline comment, first match wins, and only the label rule makes one longer. Uncertainty is a precondition on every delete rather than a last resort: where a comment might encode a real constraint, it stays. A redundant line costs a reader seconds, a deleted warning costs an outage.
- `go` and `review-fix-cycle` invoke the skill after simplify and before the commit. It defaults to the uncommitted diff, so a looped review-fix iteration cleans that iteration's fixes instead of re-deciding the whole branch every pass. Comments it hands back for the author's call land in `go`'s state file and `review-fix-cycle`'s skipped log, since terminal output does not survive a fresh-context iteration.

The cleanup pass exists because authoring-time rules alone do not hold this behavior. anthropics/claude-code#65961 reports those instructions getting overridden across Opus 4, Opus 5, and Sonnet 5.

`--branch` widens the scope to the whole branch and resolves the base through `bin/lib/git-pr-base.sh`, matching `squash` and `test-plan`, so a stacked branch does not pull in the parent PR's commits. Directives that only look like comments (noqa, eslint-disable, pragma, shebangs, build tags, SPDX headers) are left alone, and commented-out code is reported rather than deleted.

## Test plan

- [ ] `ai/tests/test-skill-spec.sh` passes, 28 skills including the new one
- [ ] `ai/tests/test-canonical-skills.sh` passes
- [ ] `ai/tests/test-plain-writing-contract.sh` passes
- [ ] `ai/tests/test-ai-installers.sh` passes
- [ ] After merge and `ai/install.sh`, `/comment-cleanup` deletes a redundant comment in the working tree and leaves a godoc summary alone
- [ ] `/comment-cleanup --branch` on a stacked branch touches only this branch's commits