### PR TITLE
Quote the sprint-planning argument-hint value

### DIFF
--- a/ai/skills/sprint-planning/SKILL.md
+++ b/ai/skills/sprint-planning/SKILL.md
@@ -6,7 +6,7 @@ metadata:
   execution-tier: balanced
 color: pink
 allowed-tools: Bash, Read, Grep, Glob, Skill
-argument-hint: [archive|--status [--last] [slack]|--approved]
+argument-hint: "[archive|--status [--last] [slack]|--approved]"
 ---
 
 # Sprint Planning


### PR DESCRIPTION
`argument-hint` in `ai/skills/sprint-planning/SKILL.md` was unquoted, and a YAML value starting with `[` opens a flow sequence where the `|` separators are illegal tokens. Strict parsers reject the entire frontmatter block. A skill whose frontmatter fails to parse still loads, but every field is dropped: the name falls back to the directory name, the description to the first line of the body, and `model`, `allowed-tools`, and `metadata.execution-tier` stop applying. Nothing warns at normal verbosity.

Claude Code's own parser tolerates the unquoted form today, so the skill has been working. PyYAML and `claude plugin validate` both reject it, and `ai/skills/` is shared with Codex, so quoting the value keeps every consumer reading the same fields.

## Test plan

- [x] `ai/skills/sprint-planning/SKILL.md` frontmatter parses under PyYAML with all seven fields intact: `name`, `description`, `model`, `metadata`, `color`, `allowed-tools`, `argument-hint`
- [x] Re-scanned all 31 installed `SKILL.md` files, 0 with broken frontmatter
- [x] `ai/tests/test-skill-spec.sh`: 27 skills, 27 passed
- [x] `ai/tests/test-ai-installers.sh`: 61 passed, 0 failed
- [ ] Run `/sprint-planning --status` and confirm the argument hint renders