### PR TITLE
Shrink the skill listing's context footprint

### DIFF
--- a/ai/skills/metabase-prod-query/SKILL.md
+++ b/ai/skills/metabase-prod-query/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: metabase-prod-query
-description: Query PostHog production Metabase for investigations. Use when the user wants to look at prod data (queries, counts, distributions, debugging customer reports, comparing regions). Wraps the `hogli metabase:*` commands (login, databases, query) into a guarded workflow that prompts for approval before running SQL against prod. Do NOT use for local dev investigations (use the `posthog-db` MCP for that).
+description: Query PostHog production Metabase. Use when the user wants prod data such as counts, distributions, customer-report debugging, or region comparisons. Not for local dev investigations; use the `posthog-db` MCP for those.
 argument-hint: "[--region us|eu|both] [<question or SQL>]"
 model: sonnet
 metadata:

--- a/ai/skills/posthog-context/SKILL.md
+++ b/ai/skills/posthog-context/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: posthog-context
-description: PostHog repo-specific workflow, database access rules, production architecture notes, SDK repository locations, and the `posthog-cli api` workflow for PostHog data queries. Use when working in posthog/posthog or any PostHog SDK repo, and before running any PostHog data query or API operation.
+description: PostHog repo workflow, database access rules, production architecture, SDK repo locations, and the `posthog-cli api` workflow. Use when working in posthog/posthog or any PostHog SDK repo, and before any PostHog data query or API operation.
 ---
 
 # PostHog Context

--- a/ai/skills/quarterly-planning/SKILL.md
+++ b/ai/skills/quarterly-planning/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: quarterly-planning
-description: Draft quarterly goals for a PostHog team (defaults to Feature Flags). Gathers supporting docs (RFCs, strategy docs, Slack threads), mines open issues by label, clusters them into themes, walks the HOGS framework, and produces goals in PostHog's format. Use when planning a new quarter's objectives.
+description: Draft quarterly goals for a PostHog team (defaults to Feature Flags), clustering open issues into themes and producing goals in PostHog's HOGS format. Use when planning a new quarter's objectives.
 color: purple
 argument-hint: [themes]
 model: opus

--- a/ai/skills/standup/SKILL.md
+++ b/ai/skills/standup/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: standup
 description: Generate standup notes from GitHub PR activity. Only invoke when the user explicitly runs /standup or asks for standup notes.
+disable-model-invocation: true
 model: haiku
 metadata:
   execution-tier: fast

--- a/ai/skills/support/SKILL.md
+++ b/ai/skills/support/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: support
 description: Support hero workflow — start a ticket investigation with auto-organized notes, find existing notes, or generate the weekly highlights log. Only invoke when the user explicitly runs /support or asks to start a support ticket investigation.
+disable-model-invocation: true
 argument-hint: "[find|log|posthog|zendesk|github] <number-or-url-or-date>"
 model: sonnet
 metadata:

--- a/ai/skills/triage-issues/SKILL.md
+++ b/ai/skills/triage-issues/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: triage-issues
 description: Identify unlabeled GitHub issues and external PRs that may belong to a specific team, and normalize conventional title scopes to the team's canonical short form. Only invoke when the user explicitly runs /triage-issues or asks to triage the team's GitHub issues.
+disable-model-invocation: true
 argument-hint: "[days] [limit] [team] [unattended]"
 model: sonnet
 metadata:

--- a/ai/skills/vault/SKILL.md
+++ b/ai/skills/vault/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: vault
-description: Operate the notes vault knowledge loop — ingest raw sources (standups, ops reports, meeting transcripts, URLs) into interlinked wiki pages, lint vault health, consolidate duplicate wiki pages, or show the ingest backlog. Use when the user runs /vault, asks to turn meeting notes or reports into knowledge, wants duplicate notes merged, or wants a vault health check.
+description: Ingest raw sources (standups, ops reports, transcripts, URLs) into interlinked wiki pages, lint vault health, consolidate duplicate pages, or show the ingest backlog. Use when the user wants notes turned into knowledge, duplicates merged, or a vault health check.
 argument-hint: "[ingest [path|url|--tranche N] | lint [area] | consolidate [area|pages] | status]"
 ---
 

--- a/ai/tests/test-skill-spec.sh
+++ b/ai/tests/test-skill-spec.sh
@@ -3,8 +3,8 @@
 # directory name must equal the frontmatter `name`, description must be 1-1024
 # characters, and frontmatter may only use spec keys (name, description, license,
 # compatibility, metadata, allowed-tools) plus this repo's own Claude extensions
-# (argument-hint, model, color). Also checks that each skill has a row in the
-# README table.
+# (argument-hint, model, color, disable-model-invocation). Also checks that each
+# skill has a row in the README table.
 set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -20,7 +20,7 @@ is_excluded_skill() {
 	grep -Ev '^[[:space:]]*(#|$)' "$EXCLUSIONS" | grep -Fxq "$1"
 }
 
-allowed_keys="name description license compatibility metadata allowed-tools argument-hint model color"
+allowed_keys="name description license compatibility metadata allowed-tools argument-hint model color disable-model-invocation"
 
 for skill_dir in "$SKILLS_DIR"/*; do
 	[[ -d "$skill_dir" ]] || continue
@@ -72,6 +72,18 @@ for skill_dir in "$SKILLS_DIR"/*; do
 					problems+="  unsupported frontmatter key '$key'"$'\n'
 				fi
 			done <<< "$fm_keys"
+
+			# An unquoted value containing a colon followed by a space parses as a nested
+			# mapping, so the YAML loader errors and the skill never loads. The key and
+			# length checks above use sed, which reads such a file without complaint.
+			while IFS= read -r line; do
+				[[ "$line" =~ ^[A-Za-z0-9_-]+:[[:space:]]+(.*)$ ]] || continue
+				value="${BASH_REMATCH[1]}"
+				[[ "$value" == \"* || "$value" == \'* ]] && continue
+				if [[ "$value" == *": "* ]]; then
+					problems+="  unquoted frontmatter value contains ': ' (breaks YAML parsing): $line"$'\n'
+				fi
+			done <<< "$frontmatter"
 		fi
 	fi
 

--- a/ai/tests/test-skill-spec.sh
+++ b/ai/tests/test-skill-spec.sh
@@ -77,7 +77,7 @@ for skill_dir in "$SKILLS_DIR"/*; do
 			# mapping, so the YAML loader errors and the skill never loads. The key and
 			# length checks above use sed, which reads such a file without complaint.
 			while IFS= read -r line; do
-				[[ "$line" =~ ^[A-Za-z0-9_-]+:[[:space:]]+(.*)$ ]] || continue
+				[[ "$line" =~ ^[[:space:]]*[A-Za-z0-9_-]+:[[:space:]]+(.*)$ ]] || continue
 				value="${BASH_REMATCH[1]}"
 				[[ "$value" == \"* || "$value" == \'* ]] && continue
 				if [[ "$value" == *": "* ]]; then


### PR DESCRIPTION
Claude Code reserves 1% of the context window for the skill listing it puts in the system prompt. On a 200k-context model that is 8,000 characters, about 2,000 tokens, shared by bundled, user, project, and plugin skills. Over budget, it keeps descriptions in descending order of a usage recency score and drops the rest to bare names, which the model can no longer choose from. A newly written skill has no usage, so it scores zero and is demoted first.

My listed skills took 6,416 characters, 80% of that budget. A 200k-context session, checked with Haiku, was already dropping 16 of them to bare names, including go, plain-writing, handoff, posthog-context, and vault.

- standup, support, and triage-issues declare `disable-model-invocation`, so they leave the model's listing and keep their slash commands. Their descriptions still carry the explicit-run sentence, which is what Codex reads.
- The four widest remaining descriptions drop mechanism detail their bodies already document and keep the wording that decides when to reach for them: metabase-prod-query 426 to 242 characters, vault 375 to 272, quarterly-planning 320 to 218, posthog-context 312 to 258.
- Together that takes the listed skills from 6,416 to 5,308 characters, 80% to 66% of the budget.

`test-skill-spec.sh` allows the new key and rejects an unquoted frontmatter value containing a colon followed by a space. That parses as a nested mapping, so the YAML loader errors and the skill never loads. The existing sed-based checks read such a file without complaint, and one of these trims hit that exactly.

## Test plan

- [x] All four suites under `ai/tests/` pass
- [x] The new colon check fails the suite when the broken description is reintroduced, and passes once it is restored
- [x] `disable-model-invocation` removes a skill from the model's listing, confirmed against a probe skill on both Opus and Haiku
- [x] A prompt that names the slash command still invokes a flagged skill, so `bin/standup-run` and `bin/triage-run` keep working. A prompt that does not name it is blocked
- [ ] After merge and install, re-check on a 200k-context session that fewer skills fall back to bare names