### PR TITLE
Cover three AI writing tells in plain-writing

### DIFF
--- a/ai/skills/plain-writing/SKILL.md
+++ b/ai/skills/plain-writing/SKILL.md
@@ -41,6 +41,9 @@ When a mode's reference file conflicts with a rule below, follow the reference f
 - Prefer active voice when naming the actor helps. Keep passive voice when the actor is unknown or irrelevant.
 - Keep paragraphs focused and short. Use headings and lists only when they make the text easier to scan.
 - Remove signposting, filler, hype, vague attribution, repeated summaries, generic conclusions, and chatbot closers.
+- Do not deny a smaller claim to set up the real one. Write what is true instead of `it is not just a cache, it is a full index`.
+- Do not end a sentence with an `-ing` clause that restates it. Cut `highlighting the need for review` or replace it with the fact it stands for.
+- Do not pad a list to three items for rhythm. Use as many items as the content has.
 - Do not use an em dash or an en dash, in any mode including voice-match. Restructure the sentence with other punctuation or separate sentences.
 - Allow natural contractions in technical mode. Do not force all sentences to the same length or rhythm.
 - Explain uncommon jargon once. Do not explain terms the intended reader already knows.

--- a/ai/skills/plain-writing/scripts/plain-writing-lint.py
+++ b/ai/skills/plain-writing/scripts/plain-writing-lint.py
@@ -33,6 +33,33 @@ RAW_PATTERNS: dict[str, tuple[str, ...]] = {
         r"\b(?:facilitate|facilitates|facilitated|facilitating)\b",
         r"\b(?:navigate|navigates|navigated|navigating)\b",
     ),
+    # Each pattern needs the second clause, so "the flag is not set, so the skill
+    # loads" stays quiet and only the denial-then-assertion shape matches.
+    "negative_parallelism": (
+        r"\bnot (?:just|only|merely|simply) [^.!?;\n]{2,80}?, but\b",
+        r"\b(?:it|this|that)(?:'|\u2019)s not (?:just|only|merely|simply) "
+        r"[^.!?;\n]{2,80}?, (?:it|this|that)(?:'|\u2019)s\b",
+        r"\b(?:is|are|was|were) not (?:just|only|merely|simply) "
+        r"[^.!?;\n]{2,80}?, (?:it|this|that|they) (?:is|are|was|were)\b",
+        r"\b(?:is|are|was|were)n(?:'|\u2019)t (?:just |only |merely |simply )?about "
+        r"[^.!?;\n]{2,80}?, (?:it|this|that)(?:'|\u2019)s about\b",
+    ),
+    # A comma inside the clause means a mid-sentence aside ("the report, highlighting
+    # three defects, was filed"), which is ordinary prose rather than the tic.
+    "trailing_participle": (
+        r", (?:highlighting|underscoring|emphasizing|showcasing|reflecting"
+        r"|demonstrating|illustrating|signaling|signalling|cementing|solidifying"
+        r"|reinforcing)\b[^.!?;,\n]{0,120}[.!?]",
+    ),
+}
+
+MESSAGES: dict[str, str] = {
+    "negative_parallelism": (
+        "Denies a smaller claim to set up the real one; state what is true."
+    ),
+    "trailing_participle": (
+        "Trailing -ing clause restates the sentence; cut it or name the fact."
+    ),
 }
 
 # Compiled once at import so the per-line loop below only dispatches matches, the same
@@ -118,7 +145,10 @@ def lint(text: str, strict: bool = False) -> list[LintWarning]:
                     warning(
                         line_number,
                         category,
-                        f"Possible {category}; use concrete, direct wording.",
+                        MESSAGES.get(
+                            category,
+                            f"Possible {category}; use concrete, direct wording.",
+                        ),
                         original,
                     )
                 )

--- a/ai/skills/plain-writing/scripts/tests/test_plain_writing_lint.py
+++ b/ai/skills/plain-writing/scripts/tests/test_plain_writing_lint.py
@@ -109,6 +109,57 @@ This seamless process works.
 
         self.assertEqual(categories(result), {"em_dash"})
 
+    def test_flags_negative_parallelism(self) -> None:
+        for text in (
+            "It's not just a linter, it's a style guide.",
+            "This isn't about speed, it's about correctness.",
+            "The change is not merely a rename, it is a behavior change.",
+            "These are not just warnings, they are errors.",
+            "Not only a cache, but a full index.",
+            "It\u2019s not only slower, it\u2019s wrong.",
+        ):
+            with self.subTest(text=text):
+                self.assertIn("negative_parallelism", categories(lint(text)))
+
+    def test_plain_negation_is_not_negative_parallelism(self) -> None:
+        for text in (
+            "The flag is not set, so the skill loads normally.",
+            "Do not use this for local dev investigations.",
+            "This is not just wrong.",
+            "The value is not merely cached, so a refetch is cheap.",
+        ):
+            with self.subTest(text=text):
+                self.assertEqual(lint(text), [])
+
+    def test_flags_trailing_participle(self) -> None:
+        for text in (
+            "The rollout stalled, highlighting the need for better tests.",
+            "Latency doubled, underscoring how fragile the cache is.",
+            "Adoption grew, demonstrating the value of the approach.",
+        ):
+            with self.subTest(text=text):
+                self.assertIn("trailing_participle", categories(lint(text)))
+
+    def test_mid_sentence_aside_is_not_a_trailing_participle(self) -> None:
+        for text in (
+            "The report, highlighting three defects, was filed on Monday.",
+            "We are reflecting on the outcome.",
+        ):
+            with self.subTest(text=text):
+                self.assertEqual(lint(text), [])
+
+    def test_new_categories_carry_their_own_message(self) -> None:
+        generic = lint("This robust process works.")[0]["message"]
+        specific = lint("It's not just a linter, it's a style guide.")[0]["message"]
+
+        self.assertEqual(
+            generic, "Possible hype; use concrete, direct wording."
+        )
+        self.assertEqual(
+            specific,
+            "Denies a smaller claim to set up the real one; state what is true.",
+        )
+
     def test_cli_warns_without_failing_unless_requested(self) -> None:
         command = [sys.executable, str(SCRIPT), "--json"]
         warning_only = subprocess.run(


### PR DESCRIPTION
The `humanizer` skill I had installed was a third-party drop-in that overlapped `plain-writing` on em dashes, filler, hype, and vague attribution, plus a set of Wikipedia concerns (notability, legacy framing, promotional copy) this repo has no use for. Three of its checks had no home here, so `plain-writing` now carries them.

- Do not deny a smaller claim to set up the real one.
- Do not end a sentence with an `-ing` clause that restates it.
- Do not pad a list to three items for rhythm.

The linter gains a category for the first two. Each pattern needs the second clause to match, so `the flag is not set, so the skill loads normally` and a mid-sentence aside like `the report, highlighting three defects, was filed` stay quiet. Rule of three stays prose-only: a regex cannot tell a padded triad from a list that genuinely has three items, and a check that fires on every three-item list would train me to ignore the linter.

Categories can now carry their own message. Existing ones keep the generic `Possible {category}` text, so current output is unchanged.

This is a follow-up to #199, which cut the skill listing's context footprint. Retiring humanizer takes another 446 characters off that listing, since its description was the single largest entry.

## Test plan

- [x] `python3 ai/skills/plain-writing/scripts/tests/test_plain_writing_lint.py` passes, 15 tests
- [x] New tests cover six negative-parallelism phrasings and three trailing-participle ones, plus four plain negations and a mid-sentence aside that must stay quiet
- [x] All four suites under `ai/tests/` pass
- [x] The linter reports no warnings against its own SKILL.md