### PR TITLE
Fix git pr to resolve fork PRs on renamed branches

### DIFF
--- a/bin/git-pr
+++ b/bin/git-pr
@@ -6,56 +6,57 @@
 # `gh pr view` with no argument resolves the head ref from the local
 # branch name, not branch.<name>.merge, so it misses a fork PR checked out
 # under a different local name (e.g. via `gh pr checkout`).
-# A refs/pull/<N>/head merge ref means the fork disabled "allow edits by
-# maintainers"; it resolves straight through `gh pr view <N>`.
-# Otherwise the resolved branch name goes to `gh pr list --head`, which
-# matches bare names across every fork, so a same-named branch in an
-# unrelated fork (e.g. "main", "patch-1") can outrank the right one.
+# This resolves the real branch name instead, then looks it up with
+# `gh pr list --head`, which matches bare names across every fork, so a
+# same-named branch in an unrelated fork (e.g. "main", "patch-1") can
+# outrank the right one.
 # The push remote's owner narrows that match back down to the right fork.
 
 set -e
 
+pr_url() { env GH_PAGER= gh pr view "$@" --json url -q .url; }
+
 if [ -n "$1" ]; then
-    env GH_PAGER= gh pr view "$1" --json url -q .url
+    pr_url "$1"
     exit
 fi
 
 current_branch=$(git branch --show-current)
-merge_ref=""
+branch=""
 remote=""
 if [ -n "$current_branch" ]; then
-    merge_ref=$(git config "branch.$current_branch.merge" 2>/dev/null || true)
+    branch=$(git config "branch.$current_branch.merge" 2>/dev/null || true)
     # Mirrors gh's own push-remote resolution order.
     remote=$(git config "branch.$current_branch.pushRemote" 2>/dev/null || true)
     [ -n "$remote" ] || remote=$(git config remote.pushDefault 2>/dev/null || true)
     [ -n "$remote" ] || remote=$(git config "branch.$current_branch.remote" 2>/dev/null || true)
     # "." means the branch tracks a local branch, not a remote one.
-    [ "$remote" = "." ] && { remote=""; merge_ref=""; }
+    [ "$remote" = "." ] && { remote=""; branch=""; }
+    [ -n "$remote" ] || remote=origin
 fi
 
-case "$merge_ref" in
+case "$branch" in
     refs/pull/*/head)
-        pr_number=${merge_ref#refs/pull/}
-        pr_number=${pr_number%/head}
-        env GH_PAGER= gh pr view "$pr_number" --json url -q .url
+        # gh's own no-argument lookup already resolves this merge-ref form.
+        pr_url
         exit
         ;;
 esac
 
-branch=${merge_ref#refs/heads/}
+branch=${branch#refs/heads/}
 [ -n "$branch" ] || branch=$current_branch
 
 if [ -z "$branch" ]; then
-    env GH_PAGER= gh pr view --json url -q .url
+    pr_url
     exit
 fi
 
-[ -n "$remote" ] || remote=origin
 remote_url=$(git remote get-url "$remote" 2>/dev/null || echo "$remote")
 remote_url=${remote_url%.git}
 remote_url=${remote_url%/}
-path=${remote_url%/*}
-owner=$(printf '%s' "${path##*[:/]}" | tr '[:upper:]' '[:lower:]')
+owner=${remote_url%/*}
+owner=${owner##*[:/]}
+owner=${owner,,}
 
 url=$(env GIT_PR_OWNER="$owner" GH_PAGER= gh pr list --head "$branch" --state all --limit 100 \
     --json url,state,headRepositoryOwner \

--- a/bin/git-pr
+++ b/bin/git-pr
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Prints the URL of the PR for the current branch, or for an explicit
+# <number>/<url> argument (passed straight to `gh pr view` unchanged).
+# Usage: git pr [<number>|<url>]
+#
+# `gh pr view` with no argument resolves the head ref from the local
+# branch name, not branch.<name>.merge, so it misses a fork PR checked out
+# under a different local name (e.g. via `gh pr checkout`).
+# A refs/pull/<N>/head merge ref means the fork disabled "allow edits by
+# maintainers"; it resolves straight through `gh pr view <N>`.
+# Otherwise the resolved branch name goes to `gh pr list --head`, which
+# matches bare names across every fork, so a same-named branch in an
+# unrelated fork (e.g. "main", "patch-1") can outrank the right one.
+# The push remote's owner narrows that match back down to the right fork.
+
+set -e
+
+if [ -n "$1" ]; then
+    env GH_PAGER= gh pr view "$1" --json url -q .url
+    exit
+fi
+
+current_branch=$(git branch --show-current)
+merge_ref=""
+remote=""
+if [ -n "$current_branch" ]; then
+    merge_ref=$(git config "branch.$current_branch.merge" 2>/dev/null || true)
+    # Mirrors gh's own push-remote resolution order.
+    remote=$(git config "branch.$current_branch.pushRemote" 2>/dev/null || true)
+    [ -n "$remote" ] || remote=$(git config remote.pushDefault 2>/dev/null || true)
+    [ -n "$remote" ] || remote=$(git config "branch.$current_branch.remote" 2>/dev/null || true)
+    # "." means the branch tracks a local branch, not a remote one.
+    [ "$remote" = "." ] && { remote=""; merge_ref=""; }
+fi
+
+case "$merge_ref" in
+    refs/pull/*/head)
+        pr_number=${merge_ref#refs/pull/}
+        pr_number=${pr_number%/head}
+        env GH_PAGER= gh pr view "$pr_number" --json url -q .url
+        exit
+        ;;
+esac
+
+branch=${merge_ref#refs/heads/}
+[ -n "$branch" ] || branch=$current_branch
+
+if [ -z "$branch" ]; then
+    env GH_PAGER= gh pr view --json url -q .url
+    exit
+fi
+
+[ -n "$remote" ] || remote=origin
+remote_url=$(git remote get-url "$remote" 2>/dev/null || echo "$remote")
+remote_url=${remote_url%.git}
+remote_url=${remote_url%/}
+path=${remote_url%/*}
+owner=$(printf '%s' "${path##*[:/]}" | tr '[:upper:]' '[:lower:]')
+
+url=$(env GIT_PR_OWNER="$owner" GH_PAGER= gh pr list --head "$branch" --state all --limit 100 \
+    --json url,state,headRepositoryOwner \
+    -q '[.[] | select(((.headRepositoryOwner.login // "") | ascii_downcase) == $ENV.GIT_PR_OWNER)] | sort_by(.state != "OPEN") | .[0].url')
+
+if [ -z "$url" ] || [ "$url" = "null" ]; then
+    echo "no pull requests found for branch '$branch'" >&2
+    exit 1
+fi
+
+echo "$url"

--- a/bin/git-pr
+++ b/bin/git-pr
@@ -51,6 +51,8 @@ if [ -z "$branch" ]; then
     exit
 fi
 
+# gh pr checkout writes the fork's URL, not a remote name, into
+# branch.<name>.remote when the fork has no configured remote.
 remote_url=$(git remote get-url "$remote" 2>/dev/null || echo "$remote")
 remote_url=${remote_url%.git}
 remote_url=${remote_url%/}
@@ -58,12 +60,13 @@ owner=${remote_url%/*}
 owner=${owner##*[:/]}
 owner=${owner,,}
 
+# Prefers an OPEN PR over a merged one when both exist for the branch.
 url=$(env GIT_PR_OWNER="$owner" GH_PAGER= gh pr list --head "$branch" --state all --limit 100 \
     --json url,state,headRepositoryOwner \
     -q '[.[] | select(((.headRepositoryOwner.login // "") | ascii_downcase) == $ENV.GIT_PR_OWNER)] | sort_by(.state != "OPEN") | .[0].url')
 
 if [ -z "$url" ] || [ "$url" = "null" ]; then
-    echo "no pull requests found for branch '$branch'" >&2
+    echo "no pull requests found for branch '$branch' owned by '$owner'" >&2
     exit 1
 fi
 

--- a/bin/lib/github.sh
+++ b/bin/lib/github.sh
@@ -54,7 +54,7 @@ resolve_pr_target() {
   SKIP_REPO_VALIDATION=false
   if [[ -z "$pr_arg" ]]; then
     local pr_url
-    pr_url=$(gh pr view --json url -q '.url' 2>/dev/null) || {
+    pr_url=$("$(dirname "${BASH_SOURCE[0]}")/../git-pr" 2>/dev/null) || {
       log_error "No PR found for the current branch. Specify a PR number or URL."
       return 1
     }

--- a/git/gitconfig.aliases.symlink
+++ b/git/gitconfig.aliases.symlink
@@ -70,8 +70,10 @@
     migrate = "!f(){ DEFAULT=$(git default); CURRENT=$(git symbolic-ref --short HEAD); git checkout -b $1 && git branch --force $CURRENT ${3-$CURRENT@{u}} && git rebase --onto ${2-$DEFAULT} $CURRENT; }; f"
     new = !git init && git symbolic-ref HEAD refs/heads/main
     open = "!f(){ URL=$(git config remote.origin.url); open ${URL%.git}; }; f"
-    # See bin/git-pr.
-    pr = "!git-pr \"$@\""
+    # Git tries the external git-pr command on PATH before this alias, so
+    # this only runs when bin/git-pr isn't on PATH; point it at the
+    # hardcoded path so it can still find the script in that case.
+    pr = "!$HOME/.dotfiles/bin/git-pr"
     publish = "!f() { git push origin $1 && git push drafts :$1 && git browse; }; f"
     pushf = push --force-with-lease --force-if-includes
     rba = rebase --abort

--- a/git/gitconfig.aliases.symlink
+++ b/git/gitconfig.aliases.symlink
@@ -70,7 +70,8 @@
     migrate = "!f(){ DEFAULT=$(git default); CURRENT=$(git symbolic-ref --short HEAD); git checkout -b $1 && git branch --force $CURRENT ${3-$CURRENT@{u}} && git rebase --onto ${2-$DEFAULT} $CURRENT; }; f"
     new = !git init && git symbolic-ref HEAD refs/heads/main
     open = "!f(){ URL=$(git config remote.origin.url); open ${URL%.git}; }; f"
-    pr = "!GH_PAGER= gh pr view --json url -q .url 2>/dev/null"
+    # See bin/git-pr.
+    pr = "!git-pr \"$@\""
     publish = "!f() { git push origin $1 && git push drafts :$1 && git browse; }; f"
     pushf = push --force-with-lease --force-if-includes
     rba = rebase --abort


### PR DESCRIPTION
- Replaces the `pr` git alias with `bin/git-pr`, which reads `branch.<name>.merge` instead of the local branch name, so a fork PR checked out under a renamed local branch (via `gh pr checkout`) resolves correctly.
- Filters `gh pr list --head` results by the push remote's owner, so a same-named branch in an unrelated fork can't outrank the right PR, and lets `gh` errors propagate instead of silently swallowing them.
- Points `resolve_pr_target()` in `bin/lib/github.sh` at the new script too, so `detect-pr.sh`, `pr-review.sh`, `copilot-review-loop.sh`, and `gh-resolve-threads` pick up the same fix.

**Test plan**
- Check out a fork PR under a renamed local branch with `gh pr checkout <url>`, then run `git pr` and confirm it prints that PR's URL.
- Run `git pr` on a branch with no PR and confirm it prints an error instead of nothing.
- Run `bin/detect-pr.sh --json` on a branch with no PR and confirm the JSON error is a single clean message.

https://claude.ai/code/session_01TXeApJn9nTh2UMJm6NtRZV